### PR TITLE
Use a windshaft-specific name for the test user

### DIFF
--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -49,7 +49,7 @@ var config = {
     ,postgres: {
         // Parameters to pass to datasource plugin of mapnik
         // See http://github.com/mapnik/mapnik/wiki/PostGIS
-        user: "testpublicuser",
+        user: "test_windshaft_publicuser",
         password: "public",
         host: '127.0.0.1',
         port: 5432,


### PR DESCRIPTION
Avoids problems with running cartodb-sql-api tests after
windshaft-cartodb tests (as the test database is not cleaned up)