### PR TITLE
[no merge] proposal to not cache tiles using non cartodbfied tables

### DIFF
--- a/lib/cartodb/server_options.js
+++ b/lib/cartodb/server_options.js
@@ -365,9 +365,13 @@ module.exports = function(redisPool) {
                 if (req.res && req.method == 'GET') {
                     var res = req.res;
                     var ttl = global.environment.varnish.layergroupTtl || 86400;
-                    res.header('Cache-Control', 'public,max-age='+ttl+',must-revalidate');
+                    if (result.affectedTables.length > 0) {
+                      res.header('Cache-Control', 'public,max-age='+ttl+',must-revalidate');
+                      res.header('X-Cache-Channel', cacheChannel);
+                    } else {
+                      res.header('Cache-Control', 'public,max-age=1,must-revalidate');
+                    }
                     res.header('Last-Modified', (new Date()).toUTCString());
-                    res.header('X-Cache-Channel', cacheChannel);
                 }
 
                 // last update for layergroup cache buster


### PR DESCRIPTION
I was playing with FDW and I realized that we don't have a way to tell maps api to not cache tiles for some map. In a local table we can always attach a trigger so we update cdb_tablemedata but with a FDW is not possible.

The right way would be:
- using cdb_touchtablemedata ('fdw_table')
- not cache when a FDW is involved (not sure how to know this but there should be a catalog table with that information for sure)

anyways, I though wrapping the query in a function would work so I could use select * fn_that_query_my_fdw() but when I use that cache headers are set (and a wrong x-cache-channel)

This PR is a proposal to fix that. I think it's not right since a ``select 'POINT(1 1)'::geometry as the_geom_webmercator`` would not be cached (and it definitely can be) but it's better than caching something you don't know if cacheable

cc @rochoa 



