### PR TITLE
Use CDB_QueryTablesText instead of CDB_QueryTables

### DIFF
--- a/lib/cartodb/api/query_tables_api.js
+++ b/lib/cartodb/api/query_tables_api.js
@@ -14,7 +14,7 @@ module.exports = QueryTablesApi;
 
 QueryTablesApi.prototype.getAffectedTablesInQuery = function (username, sql, callback) {
 
-    var query = 'SELECT CDB_QueryTables($windshaft$' + prepareSql(sql) + '$windshaft$)';
+    var query = 'SELECT CDB_QueryTablesText($windshaft$' + prepareSql(sql) + '$windshaft$)';
 
     this.pgQueryRunner.run(username, query, handleAffectedTablesInQueryRows, callback);
 };
@@ -25,9 +25,9 @@ function handleAffectedTablesInQueryRows(err, rows, callback) {
         callback(new Error('could not fetch source tables: ' + msg));
         return;
     }
-    var qtables = rows[0].cdb_querytables;
-    var tableNames = qtables.split(/^\{(.*)\}$/)[1];
-    tableNames = tableNames ? tableNames.split(',') : [];
+
+    // This is an Array, so no need to split into parts
+    var tableNames = rows[0].cdb_querytablestext;
     callback(null, tableNames);
 }
 
@@ -35,7 +35,7 @@ QueryTablesApi.prototype.getAffectedTablesAndLastUpdatedTime = function (usernam
 
     var query = [
         'WITH querytables AS (',
-            'SELECT * FROM CDB_QueryTables($windshaft$' + prepareSql(sql) + '$windshaft$) as tablenames',
+            'SELECT * FROM CDB_QueryTablesText($windshaft$' + prepareSql(sql) + '$windshaft$) as tablenames',
         ')',
         'SELECT (SELECT tablenames FROM querytables), EXTRACT(EPOCH FROM max(updated_at)) as max',
         'FROM CDB_TableMetadata m',
@@ -54,8 +54,8 @@ function handleAffectedTablesAndLastUpdatedTimeRows(err, rows, callback) {
 
     var result = rows[0];
 
-    var tableNames = result.tablenames.split(/^\{(.*)\}$/)[1];
-    tableNames = tableNames ? tableNames.split(',') : [];
+    // This is an Array, so no need to split into parts
+    var tableNames = result.tablenames;
 
     var lastUpdatedTime = result.max || 0;
 

--- a/test/support/prepare_db.sh
+++ b/test/support/prepare_db.sh
@@ -80,7 +80,7 @@ if test x"$PREPARE_PGSQL" = xyes; then
 
   psql -c "CREATE EXTENSION plpythonu;" ${TEST_DB}
   curl -L -s https://github.com/CartoDB/cartodb-postgresql/raw/cdb/scripts-available/CDB_QueryStatements.sql -o sql/CDB_QueryStatements.sql
-  curl -L -s https://github.com/CartoDB/cartodb-postgresql/raw/86-CDB_QueryTables-fix-long-names/scripts-available/CDB_QueryTables.sql -o sql/CDB_QueryTables.sql
+  curl -L -s https://github.com/CartoDB/cartodb-postgresql/raw/cdb/scripts-available/CDB_QueryTables.sql -o sql/CDB_QueryTables.sql
   cat sql/CDB_QueryStatements.sql sql/CDB_QueryTables.sql |
     psql -v ON_ERROR_STOP=1 ${TEST_DB} || exit 1
 

--- a/test/support/prepare_db.sh
+++ b/test/support/prepare_db.sh
@@ -80,7 +80,7 @@ if test x"$PREPARE_PGSQL" = xyes; then
 
   psql -c "CREATE EXTENSION plpythonu;" ${TEST_DB}
   curl -L -s https://github.com/CartoDB/cartodb-postgresql/raw/cdb/scripts-available/CDB_QueryStatements.sql -o sql/CDB_QueryStatements.sql
-  curl -L -s https://github.com/CartoDB/cartodb-postgresql/raw/cdb/scripts-available/CDB_QueryTables.sql -o sql/CDB_QueryTables.sql
+  curl -L -s https://github.com/CartoDB/cartodb-postgresql/raw/86-CDB_QueryTables-fix-long-names/scripts-available/CDB_QueryTables.sql -o sql/CDB_QueryTables.sql
   cat sql/CDB_QueryStatements.sql sql/CDB_QueryTables.sql |
     psql -v ON_ERROR_STOP=1 ${TEST_DB} || exit 1
 


### PR DESCRIPTION
This avoids trouble with len(schema.table_name) > 63
See https://github.com/CartoDB/cartodb-postgresql/issues/86

This should be released after rolling out a new version of the cartodb-postgresql extension, with this PR merged: https://github.com/CartoDB/cartodb-postgresql/pull/88

@rochoa please review