### PR TITLE
Safe user extraction

### DIFF
--- a/lib/cartodb/controllers/layergroup.js
+++ b/lib/cartodb/controllers/layergroup.js
@@ -5,6 +5,7 @@ var util = require('util');
 var BaseController = require('./base');
 
 var cors = require('../middleware/cors');
+var userMiddleware = require('../middleware/user');
 
 var MapStoreMapConfigProvider = require('../models/mapconfig/map_store_provider');
 var TablesCacheEntry = require('../cache/model/database_tables_entry');
@@ -44,13 +45,28 @@ module.exports = LayergroupController;
 
 
 LayergroupController.prototype.register = function(app) {
-    app.get(app.base_url_mapconfig + '/:token/:z/:x/:y@:scale_factor?x.:format', cors(), this.tile.bind(this));
-    app.get(app.base_url_mapconfig + '/:token/:z/:x/:y.:format', cors(), this.tile.bind(this));
-    app.get(app.base_url_mapconfig + '/:token/:layer/:z/:x/:y.(:format)', cors(), this.layer.bind(this));
-    app.get(app.base_url_mapconfig + '/:token/:layer/attributes/:fid', cors(), this.attributes.bind(this));
-    app.get(app.base_url_mapconfig + '/static/center/:token/:z/:lat/:lng/:width/:height.:format', cors(),
+    app.get(app.base_url_mapconfig +
+        '/:token/:z/:x/:y@:scale_factor?x.:format', cors(), userMiddleware,
+        this.tile.bind(this));
+
+    app.get(app.base_url_mapconfig +
+        '/:token/:z/:x/:y.:format', cors(), userMiddleware,
+        this.tile.bind(this));
+
+    app.get(app.base_url_mapconfig +
+        '/:token/:layer/:z/:x/:y.(:format)', cors(), userMiddleware,
+        this.layer.bind(this));
+
+    app.get(app.base_url_mapconfig +
+        '/:token/:layer/attributes/:fid', cors(), userMiddleware,
+        this.attributes.bind(this));
+
+    app.get(app.base_url_mapconfig +
+        '/static/center/:token/:z/:lat/:lng/:width/:height.:format', cors(), userMiddleware,
         this.center.bind(this));
-    app.get(app.base_url_mapconfig + '/static/bbox/:token/:west,:south,:east,:north/:width/:height.:format', cors(),
+
+    app.get(app.base_url_mapconfig +
+        '/static/bbox/:token/:west,:south,:east,:north/:width/:height.:format', cors(), userMiddleware,
         this.bbox.bind(this));
 };
 

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -7,6 +7,7 @@ var util = require('util');
 var BaseController = require('./base');
 
 var cors = require('../middleware/cors');
+var userMiddleware = require('../middleware/user');
 
 var MapConfig = windshaft.model.MapConfig;
 var Datasource = windshaft.model.Datasource;
@@ -55,10 +56,10 @@ module.exports = MapController;
 
 
 MapController.prototype.register = function(app) {
-    app.get(app.base_url_mapconfig, cors(), this.createGet.bind(this));
-    app.post(app.base_url_mapconfig, cors(), this.createPost.bind(this));
-    app.get(app.base_url_templated + '/:template_id/jsonp', cors(), this.jsonp.bind(this));
-    app.post(app.base_url_templated + '/:template_id', cors(), this.instantiate.bind(this));
+    app.get(app.base_url_mapconfig, cors(), userMiddleware, this.createGet.bind(this));
+    app.post(app.base_url_mapconfig, cors(), userMiddleware, this.createPost.bind(this));
+    app.get(app.base_url_templated + '/:template_id/jsonp', cors(), userMiddleware, this.jsonp.bind(this));
+    app.post(app.base_url_templated + '/:template_id', cors(), userMiddleware, this.instantiate.bind(this));
     app.options(app.base_url_mapconfig, cors('Content-Type'));
 };
 

--- a/lib/cartodb/controllers/named_maps.js
+++ b/lib/cartodb/controllers/named_maps.js
@@ -7,6 +7,7 @@ var util = require('util');
 var BaseController = require('./base');
 
 var cors = require('../middleware/cors');
+var userMiddleware = require('../middleware/user');
 
 var TablesCacheEntry = require('../cache/model/database_tables_entry');
 
@@ -28,10 +29,13 @@ util.inherits(NamedMapsController, BaseController);
 module.exports = NamedMapsController;
 
 NamedMapsController.prototype.register = function(app) {
-    app.get(app.base_url_templated + '/:template_id/:layer/:z/:x/:y.(:format)', cors(), this.tile.bind(this));
-    app.get(
-        app.base_url_mapconfig + '/static/named/:template_id/:width/:height.:format', cors(), this.staticMap.bind(this)
-    );
+    app.get(app.base_url_templated +
+        '/:template_id/:layer/:z/:x/:y.(:format)', cors(), userMiddleware,
+        this.tile.bind(this));
+
+    app.get(app.base_url_mapconfig +
+        '/static/named/:template_id/:width/:height.:format', cors(), userMiddleware,
+        this.staticMap.bind(this));
 };
 
 NamedMapsController.prototype.sendResponse = function(req, res, resource, headers, namedMapProvider) {

--- a/lib/cartodb/controllers/named_maps_admin.js
+++ b/lib/cartodb/controllers/named_maps_admin.js
@@ -6,6 +6,7 @@ var util = require('util');
 var BaseController = require('./base');
 
 var cors = require('../middleware/cors');
+var userMiddleware = require('../middleware/user');
 
 
 /**
@@ -26,11 +27,11 @@ util.inherits(NamedMapsAdminController, BaseController);
 module.exports = NamedMapsAdminController;
 
 NamedMapsAdminController.prototype.register = function(app) {
-    app.post(app.base_url_templated, cors(), this.create.bind(this));
-    app.put(app.base_url_templated + '/:template_id', cors(), this.update.bind(this));
-    app.get(app.base_url_templated + '/:template_id', cors(), this.retrieve.bind(this));
-    app.delete(app.base_url_templated + '/:template_id', cors(), this.destroy.bind(this));
-    app.get(app.base_url_templated, cors(), this.list.bind(this));
+    app.post(app.base_url_templated, cors(), userMiddleware, this.create.bind(this));
+    app.put(app.base_url_templated + '/:template_id', cors(), userMiddleware, this.update.bind(this));
+    app.get(app.base_url_templated + '/:template_id', cors(), userMiddleware, this.retrieve.bind(this));
+    app.delete(app.base_url_templated + '/:template_id', cors(), userMiddleware, this.destroy.bind(this));
+    app.get(app.base_url_templated, cors(), userMiddleware, this.list.bind(this));
     app.options(app.base_url_templated + '/:template_id', cors('Content-Type'));
 };
 

--- a/lib/cartodb/middleware/user.js
+++ b/lib/cartodb/middleware/user.js
@@ -1,0 +1,7 @@
+var CdbRequest = require('../models/cdb_request');
+var cdbRequest = new CdbRequest();
+
+module.exports = function userMiddleware(req, res, next) {
+    req.context.user = cdbRequest.userByReq(req);
+    next();
+};

--- a/lib/cartodb/models/cdb_request.js
+++ b/lib/cartodb/models/cdb_request.js
@@ -8,7 +8,7 @@ module.exports = CdbRequest;
 
 
 CdbRequest.prototype.userByReq = function(req) {
-    var host = req.headers.host;
+    var host = req.headers.host || '';
     if (req.params.user) {
         return req.params.user;
     }

--- a/lib/cartodb/server.js
+++ b/lib/cartodb/server.js
@@ -27,9 +27,6 @@ var NamedMapProviderCache = require('./cache/named_map_provider_cache');
 var PgQueryRunner = require('./backends/pg_query_runner');
 var PgConnection = require('./backends/pg_connection');
 
-var CdbRequest = require('./models/cdb_request');
-var cdbRequest = new CdbRequest();
-
 var timeoutErrorTilePath = __dirname + '/../../assets/render-timeout-fallback.png';
 var timeoutErrorTile = require('fs').readFileSync(timeoutErrorTilePath, {encoding: null});
 
@@ -156,11 +153,6 @@ module.exports = function(serverOptions) {
     /*******************************************************************************************************************
      * Routing
      ******************************************************************************************************************/
-
-    app.all('*', function(req, res, next) {
-        req.context.user = cdbRequest.userByReq(req);
-        next();
-    });
 
     new controller.Layergroup(
         app,

--- a/test/unit/cartodb/cdb_request.test.js
+++ b/test/unit/cartodb/cdb_request.test.js
@@ -57,4 +57,28 @@ describe('req2params', function() {
 
         assert.equal(user, undefined);
     });
+
+    it('should not fail for undefined host header', function() {
+        var userFromHostConfig = global.environment.user_from_host;
+        global.environment.user_from_host = null;
+
+        var cdbRequest = new CdbRequest();
+        var user = cdbRequest.userByReq(createRequest(undefined));
+
+        global.environment.user_from_host = userFromHostConfig;
+
+        assert.equal(user, undefined);
+    });
+
+    it('should not fail for null host header', function() {
+        var userFromHostConfig = global.environment.user_from_host;
+        global.environment.user_from_host = null;
+
+        var cdbRequest = new CdbRequest();
+        var user = cdbRequest.userByReq(createRequest(null));
+
+        global.environment.user_from_host = userFromHostConfig;
+
+        assert.equal(user, undefined);
+    });
 });


### PR DESCRIPTION
Using a new middleware just for requests that needs a user in context.

It also defaults host header to string as fallback for falsy host headers, so at least there is a match method in the object.