### PR TITLE
Change error messages when getting overviews metadata fails

### DIFF
--- a/lib/cartodb/api/overviews_metadata_api.js
+++ b/lib/cartodb/api/overviews_metadata_api.js
@@ -25,8 +25,7 @@ OverviewsMetadataApi.prototype.getOverviewsMetadata = function (username, sql, c
     var query = 'SELECT * FROM CDB_Overviews(CDB_QueryTablesText($windshaft$' + prepareSql(sql) + '$windshaft$))';
     this.pgQueryRunner.run(username, query, function handleOverviewsRows(err, rows) {
         if (err){
-            var msg = err.message ? err.message : err;
-            callback(new Error(msg));
+            callback(err);
             return;
         }
         var metadata = {};

--- a/lib/cartodb/api/overviews_metadata_api.js
+++ b/lib/cartodb/api/overviews_metadata_api.js
@@ -26,7 +26,7 @@ OverviewsMetadataApi.prototype.getOverviewsMetadata = function (username, sql, c
     this.pgQueryRunner.run(username, query, function handleOverviewsRows(err, rows) {
         if (err){
             var msg = err.message ? err.message : err;
-            callback(new Error('could not get overviews metadata: ' + msg));
+            callback(new Error(msg));
             return;
         }
         var metadata = {};

--- a/test/acceptance/multilayer_server.js
+++ b/test/acceptance/multilayer_server.js
@@ -334,7 +334,7 @@ describe('tests from old api translated to multilayer', function() {
 
                 var parsed = JSON.parse(res.body);
                 assert.deepEqual(parsed, {
-                    errors: ["could not get overviews metadata: fake error message"]
+                    errors: ["fake error message"]
                 });
 
                 done();


### PR DESCRIPTION
Remove the detail that the error occurred trying to get overviews
metadata from the error message. This should be less confusing
to the user.

Fixes #384 
