### PR TITLE
Back to pg 9.3 and postgresql-plpython-9.3 using sudo=true build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
-sudo: false
+sudo: true
 
 addons:
-  postgresql: "9.4"
-  apt:
-    packages:
-    - postgresql-plpython-9.4
-    - pkg-config
-    - libcairo2-dev
-    - libjpeg8-dev
-    - libgif-dev
+  postgresql: "9.3"
 
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y postgresql-plpython-9.3 pkg-config libcairo2-dev libjpeg8-dev libgif-dev
   - npm install -g npm@2
   - createdb template_postgis
   - psql -c "CREATE EXTENSION postgis" template_postgis


### PR DESCRIPTION
This will make build way slower in terms of feedback because it's relying on `sudo: true`, aka non-container based builds, from travis.