### PR TITLE
Support unneeded schema names in overviews queries

### DIFF
--- a/lib/cartodb/api/overviews_metadata_api.js
+++ b/lib/cartodb/api/overviews_metadata_api.js
@@ -1,5 +1,5 @@
 function OverviewsMetadataApi(pgQueryRunner) {
-   this.pgQueryRunner = pgQueryRunner;
+    this.pgQueryRunner = pgQueryRunner;
 }
 
 module.exports = OverviewsMetadataApi;

--- a/lib/cartodb/api/overviews_metadata_api.js
+++ b/lib/cartodb/api/overviews_metadata_api.js
@@ -22,7 +22,7 @@ function prepareSql(sql) {
 }
 
 OverviewsMetadataApi.prototype.getOverviewsMetadata = function (username, sql, callback) {
-    // FIXME: Currently using internal function parsed_table
+    // FIXME: Currently using internal function _cdb_schema_name
     //        CDB_Overviews should provide the schema information directly.
     var query = 'SELECT *, _cdb_schema_name(base_table)' +
                 '  FROM CDB_Overviews(CDB_QueryTablesText($windshaft$' + prepareSql(sql) + '$windshaft$))';

--- a/lib/cartodb/api/overviews_metadata_api.js
+++ b/lib/cartodb/api/overviews_metadata_api.js
@@ -31,18 +31,17 @@ OverviewsMetadataApi.prototype.getOverviewsMetadata = function (username, sql, c
             callback(err);
             return;
         }
-        var metadata = {};
-        rows.forEach(function(row) {
+        var metadata = rows.reduce(function(metadata, row){
             var table = row.base_table;
             var schema = row._cdb_schema_name;
             var table_metadata = metadata[table];
             if ( !table_metadata ) {
-              table_metadata = metadata[table] = {};
+                table_metadata = metadata[table] = {};
             }
             table_metadata[row.z] = { table: row.overview_table };
             table_metadata.schema = schema;
-        });
+            return metadata;
+        }, {});
         return callback(null, metadata);
     });
-
 };

--- a/lib/cartodb/api/overviews_metadata_api.js
+++ b/lib/cartodb/api/overviews_metadata_api.js
@@ -22,7 +22,10 @@ function prepareSql(sql) {
 }
 
 OverviewsMetadataApi.prototype.getOverviewsMetadata = function (username, sql, callback) {
-    var query = 'SELECT * FROM CDB_Overviews(CDB_QueryTablesText($windshaft$' + prepareSql(sql) + '$windshaft$))';
+    // FIXME: Currently using internal function parsed_table
+    //        CDB_Overviews should provide the schema information directly.
+    var query = 'SELECT *, _cdb_schema_name(base_table)' +
+                '  FROM CDB_Overviews(CDB_QueryTablesText($windshaft$' + prepareSql(sql) + '$windshaft$))';
     this.pgQueryRunner.run(username, query, function handleOverviewsRows(err, rows) {
         if (err){
             callback(err);
@@ -31,11 +34,13 @@ OverviewsMetadataApi.prototype.getOverviewsMetadata = function (username, sql, c
         var metadata = {};
         rows.forEach(function(row) {
             var table = row.base_table;
+            var schema = row._cdb_schema_name;
             var table_metadata = metadata[table];
             if ( !table_metadata ) {
               table_metadata = metadata[table] = {};
             }
             table_metadata[row.z] = { table: row.overview_table };
+            table_metadata.schema = schema;
         });
         return callback(null, metadata);
     });

--- a/lib/cartodb/api/overviews_metadata_api.js
+++ b/lib/cartodb/api/overviews_metadata_api.js
@@ -34,12 +34,11 @@ OverviewsMetadataApi.prototype.getOverviewsMetadata = function (username, sql, c
         var metadata = rows.reduce(function(metadata, row){
             var table = row.base_table;
             var schema = row._cdb_schema_name;
-            var table_metadata = metadata[table];
-            if ( !table_metadata ) {
-                table_metadata = metadata[table] = {};
+            if ( !metadata[table] ) {
+                metadata[table] = {};
             }
-            table_metadata[row.z] = { table: row.overview_table };
-            table_metadata.schema = schema;
+            metadata[table][row.z] = { table: row.overview_table };
+            metadata[table].schema = schema;
             return metadata;
         }, {});
         return callback(null, metadata);

--- a/lib/cartodb/utils/overviews_query_rewriter.js
+++ b/lib/cartodb/utils/overviews_query_rewriter.js
@@ -22,7 +22,7 @@ function overviews_view_for_table(table, overviews_metadata, indent) {
 
     indent = indent || '    ';
     for (var z in overviews_metadata) {
-        if (overviews_metadata.hasOwnProperty(z)) {
+        if (overviews_metadata.hasOwnProperty(z) && z !== 'schema') {
             sorted_overviews.push([z, overviews_metadata[z].table]);
         }
     }
@@ -127,8 +127,16 @@ function overviews_query(query, overviews, zoom_level_expression) {
         if (overviews.hasOwnProperty(table)) {
             var table_overviews = overviews[table];
             var table_view = overviews_view_name(table);
+            var schema = table_overviews.schema;
             replacement = "(\n" + overviews_view_for_table(table, table_overviews) + "\n  ) AS " + table_view;
             replaced_query = replace_table_in_query(replaced_query, table, replacement);
+            var parsed_table = TableNameParser.parse(table);
+            if (!parsed_table.schema && schema) {
+              // replace also the qualified table name, if the table wasn't qualified
+              parsed_table.schema = schema;
+              table = TableNameParser.table_identifier(parsed_table);
+              replaced_query = replace_table_in_query(replaced_query, table, replacement);
+            }
         }
     }
     if ( replaced_query !== query ) {

--- a/lib/cartodb/utils/overviews_query_rewriter.js
+++ b/lib/cartodb/utils/overviews_query_rewriter.js
@@ -39,11 +39,11 @@ function overviews_view_for_table(table, overviews_metadata, indent) {
     overview_layers.push(["_vovw_z > " + z_lo, table]);
 
     selects = overview_layers.map(function(condition_table) {
-      condition = condition_table[0];
-      ov_table = TableNameParser.parse(condition_table[1]);
-      ov_table.schema = ov_table.schema || parsed_table.schema;
-      var ov_identifier = TableNameParser.table_identifier(ov_table);
-      return indent + "SELECT * FROM " + ov_identifier + ", _vovw_scale WHERE " + condition;
+        condition = condition_table[0];
+        ov_table = TableNameParser.parse(condition_table[1]);
+        ov_table.schema = ov_table.schema || parsed_table.schema;
+        var ov_identifier = TableNameParser.table_identifier(ov_table);
+        return indent + "SELECT * FROM " + ov_identifier + ", _vovw_scale WHERE " + condition;
     });
 
     return selects.join("\n"+indent+"UNION ALL\n");
@@ -90,13 +90,13 @@ function replace_table_in_query(sql, old_table_name, replacement) {
                 return '';
             }
         } else {
-           // to match a table name without schema
-           // name should not begin right after a dot (i.e. have a explicit schema)
-           // nor be part of another name
-           // since the pattern matches the first character of the table
-           // it must be put back in the replacement text
-           replacement = '$01'+replacement;
-           return '([^\.a-z0-9_]|^)';
+            // to match a table name without schema
+            // name should not begin right after a dot (i.e. have a explicit schema)
+            // nor be part of another name
+            // since the pattern matches the first character of the table
+            // it must be put back in the replacement text
+            replacement = '$01'+replacement;
+            return '([^\.a-z0-9_]|^)';
         }
     }
 
@@ -132,10 +132,10 @@ function overviews_query(query, overviews, zoom_level_expression) {
             replaced_query = replace_table_in_query(replaced_query, table, replacement);
             var parsed_table = TableNameParser.parse(table);
             if (!parsed_table.schema && schema) {
-              // replace also the qualified table name, if the table wasn't qualified
-              parsed_table.schema = schema;
-              table = TableNameParser.table_identifier(parsed_table);
-              replaced_query = replace_table_in_query(replaced_query, table, replacement);
+                // replace also the qualified table name, if the table wasn't qualified
+                parsed_table.schema = schema;
+                table = TableNameParser.table_identifier(parsed_table);
+                replaced_query = replace_table_in_query(replaced_query, table, replacement);
             }
         }
     }
@@ -176,18 +176,19 @@ OverviewsQueryRewriter.prototype.query = function(query, data) {
 };
 
 OverviewsQueryRewriter.prototype.is_supported_query = function(sql) {
-  var basic_query = /\s*SELECT\s+[\*a-z0-9_,\s]+?\s+FROM\s+((\"[^"]+\"|[a-z0-9_]+)\.)?(\"[^"]+\"|[a-z0-9_]+)\s*;?\s*/i;
-  var unwrapped_query = new RegExp("^"+basic_query.source+"$", 'i');
-  // queries for named maps are wrapped like this:
-  var wrapped_query = new RegExp(
-    "^\\s*SELECT\\s+\\*\\s+FROM\\s+\\(" +
-    basic_query.source +
-    "\\)\\s+AS\\s+wrapped_query\\s+WHERE\\s+\\d+=1\\s*$",
-    'i'
-  );
-  return !!(sql.match(unwrapped_query) || sql.match(wrapped_query));
+    var basic_query =
+        /\s*SELECT\s+[\*a-z0-9_,\s]+?\s+FROM\s+((\"[^"]+\"|[a-z0-9_]+)\.)?(\"[^"]+\"|[a-z0-9_]+)\s*;?\s*/i;
+    var unwrapped_query = new RegExp("^"+basic_query.source+"$", 'i');
+    // queries for named maps are wrapped like this:
+    var wrapped_query = new RegExp(
+        "^\\s*SELECT\\s+\\*\\s+FROM\\s+\\(" +
+        basic_query.source +
+        "\\)\\s+AS\\s+wrapped_query\\s+WHERE\\s+\\d+=1\\s*$",
+        'i'
+    );
+    return !!(sql.match(unwrapped_query) || sql.match(wrapped_query));
 };
 
 OverviewsQueryRewriter.prototype.overviews_metadata = function(data) {
-  return data && data.overviews;
+    return data && data.overviews;
 };

--- a/test/acceptance/overviews_metadata.js
+++ b/test/acceptance/overviews_metadata.js
@@ -90,6 +90,7 @@ describe('overviews metadata', function() {
               var expected_data = {
                 overviews: {
                   test_table_overviews: {
+                    schema: 'public',
                     1: { table: '_vovw_1_test_table_overviews' },
                     2: { table: '_vovw_2_test_table_overviews' }
                   }

--- a/test/acceptance/overviews_metadata_named_maps.js
+++ b/test/acceptance/overviews_metadata_named_maps.js
@@ -59,117 +59,117 @@ describe('overviews metadata for named maps', function() {
     };
 
     it("should add overviews data to layers", function(done) {
-      step(
-        function postTemplate()
-        {
-          var next = this;
+        step(
+            function postTemplate()
+            {
+              var next = this;
 
-          assert.response(server, {
-              url: '/api/v1/map/named?api_key=1234',
-              method: 'POST',
-              headers: {host: 'localhost', 'Content-Type': 'application/json' },
-              data: JSON.stringify(template)
-          }, {}, function(res, err) {
-                     next(err, res);
-          });
-        },
-        function checkTemplate(err, res) {
-            assert.ifError(err);
+              assert.response(server, {
+                  url: '/api/v1/map/named?api_key=1234',
+                  method: 'POST',
+                  headers: {host: 'localhost', 'Content-Type': 'application/json' },
+                  data: JSON.stringify(template)
+              }, {}, function(res, err) {
+                         next(err, res);
+              });
+            },
+            function checkTemplate(err, res) {
+                assert.ifError(err);
 
-            var next = this;
-            assert.equal(res.statusCode, 200);
-            assert.deepEqual(JSON.parse(res.body), {
-                template_id: templateId
-            });
-            next(null);
-        },
-        function instantiateTemplate(err) {
-            assert.ifError(err);
+                var next = this;
+                assert.equal(res.statusCode, 200);
+                assert.deepEqual(JSON.parse(res.body), {
+                    template_id: templateId
+                });
+                next(null);
+            },
+            function instantiateTemplate(err) {
+                assert.ifError(err);
 
-            var next = this;
-            assert.response(server, {
-                url: '/api/v1/map/named/' + templateId,
-                method: 'POST',
-                headers: {
-                    host: 'localhost',
-                    'Content-Type': 'application/json'
-                }
-            }, {},
-            function(res, err) {
-                return next(err, res);
-            });
+                var next = this;
+                assert.response(server, {
+                    url: '/api/v1/map/named/' + templateId,
+                    method: 'POST',
+                    headers: {
+                        host: 'localhost',
+                        'Content-Type': 'application/json'
+                    }
+                }, {},
+                function(res, err) {
+                    return next(err, res);
+                });
 
-        },
-        function checkInstanciation(err, res) {
-            assert.ifError(err);
+            },
+            function checkInstanciation(err, res) {
+                assert.ifError(err);
 
-            var next = this;
+                var next = this;
 
-            assert.equal(res.statusCode, 200);
+                assert.equal(res.statusCode, 200);
 
-            var parsedBody = JSON.parse(res.body);
+                var parsedBody = JSON.parse(res.body);
 
-            keysToDelete['map_cfg|' + LayergroupToken.parse(parsedBody.layergroupid).token] = 0;
-            keysToDelete['user:localhost:mapviews:global'] = 5;
+                keysToDelete['map_cfg|' + LayergroupToken.parse(parsedBody.layergroupid).token] = 0;
+                keysToDelete['user:localhost:mapviews:global'] = 5;
 
-            assert.ok(parsedBody.layergroupid);
-            assert.ok(parsedBody.last_updated);
+                assert.ok(parsedBody.layergroupid);
+                assert.ok(parsedBody.last_updated);
 
-            next(null, parsedBody.layergroupid);
-        },
+                next(null, parsedBody.layergroupid);
+            },
 
-        function checkMapconfig(err, layergroupId)
-        {
-            assert.ifError(err);
+            function checkMapconfig(err, layergroupId)
+            {
+                assert.ifError(err);
 
-            var next = this;
+                var next = this;
 
-            var mapStore  = new windshaft.storage.MapStore({
-                pool: redisPool,
-                expire_time: 500000
-            });
-            mapStore.load(LayergroupToken.parse(layergroupId).token, function(err, mapConfig) {
-              assert.ifError(err);
-              assert.deepEqual(non_overviews_layer, mapConfig._cfg.layers[1]);
-              assert.equal(mapConfig._cfg.layers[0].type, 'cartodb');
-              assert.ok(mapConfig._cfg.layers[0].options.query_rewrite_data);
-              var expected_data = {
-                overviews: {
-                  test_table_overviews: {
-                    schema: 'public',
-                    1: { table: '_vovw_1_test_table_overviews' },
-                    2: { table: '_vovw_2_test_table_overviews' }
-                  }
-                }
-              };
-              assert.deepEqual(mapConfig._cfg.layers[0].options.query_rewrite_data, expected_data);
-            });
+                var mapStore  = new windshaft.storage.MapStore({
+                    pool: redisPool,
+                    expire_time: 500000
+                });
+                mapStore.load(LayergroupToken.parse(layergroupId).token, function(err, mapConfig) {
+                    assert.ifError(err);
+                    assert.deepEqual(non_overviews_layer, mapConfig._cfg.layers[1]);
+                    assert.equal(mapConfig._cfg.layers[0].type, 'cartodb');
+                    assert.ok(mapConfig._cfg.layers[0].options.query_rewrite_data);
+                    var expected_data = {
+                        overviews: {
+                            test_table_overviews: {
+                                  schema: 'public',
+                                  1: { table: '_vovw_1_test_table_overviews' },
+                                  2: { table: '_vovw_2_test_table_overviews' }
+                              }
+                          }
+                      };
+                    assert.deepEqual(mapConfig._cfg.layers[0].options.query_rewrite_data, expected_data);
+                });
 
-            next(err);
-        },
-        function deleteTemplate(err) {
-            assert.ifError(err);
+                next(err);
+            },
+            function deleteTemplate(err) {
+                assert.ifError(err);
 
-            var next = this;
+                var next = this;
 
-            assert.response(server, {
-                url: '/api/v1/map/named/' + templateId + '?api_key=1234',
-                method: 'DELETE',
-                headers: { host: 'localhost' }
-            }, {}, function (res, err) {
-                next(err, res);
-            });
-        },
-        function checkDeleteTemplate(err, res) {
-            assert.ifError(err);
-            assert.equal(res.statusCode, 204);
-            assert.ok(!res.body);
+                assert.response(server, {
+                    url: '/api/v1/map/named/' + templateId + '?api_key=1234',
+                    method: 'DELETE',
+                    headers: { host: 'localhost' }
+                }, {}, function (res, err) {
+                    next(err, res);
+                });
+            },
+            function checkDeleteTemplate(err, res) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 204);
+                assert.ok(!res.body);
 
-            return null;
-        },
-        function finish(err) {
-            done(err);
-        }
-      );
+                return null;
+            },
+            function finish(err) {
+                done(err);
+            }
+        );
     });
 });

--- a/test/acceptance/overviews_metadata_named_maps.js
+++ b/test/acceptance/overviews_metadata_named_maps.js
@@ -136,6 +136,7 @@ describe('overviews metadata for named maps', function() {
               var expected_data = {
                 overviews: {
                   test_table_overviews: {
+                    schema: 'public',
                     1: { table: '_vovw_1_test_table_overviews' },
                     2: { table: '_vovw_2_test_table_overviews' }
                   }

--- a/test/integration/mapconfig_overviews_adapter.js
+++ b/test/integration/mapconfig_overviews_adapter.js
@@ -73,13 +73,13 @@ describe('MapConfigOverviewsAdapter', function() {
             assert.equal(layers[0].options.cartocss_version, cartocss_version);
             assert.ok(layers[0].options.query_rewrite_data);
             var expected_data = {
-              overviews: {
-                test_table_overviews: {
-                  schema: 'public',
-                  1: { table: '_vovw_1_test_table_overviews' },
-                  2: { table: '_vovw_2_test_table_overviews' }
+                overviews: {
+                    test_table_overviews: {
+                        schema: 'public',
+                        1: { table: '_vovw_1_test_table_overviews' },
+                        2: { table: '_vovw_2_test_table_overviews' }
+                    }
                 }
-              }
             };
             assert.deepEqual(layers[0].options.query_rewrite_data, expected_data);
             done();

--- a/test/integration/mapconfig_overviews_adapter.js
+++ b/test/integration/mapconfig_overviews_adapter.js
@@ -75,6 +75,7 @@ describe('MapConfigOverviewsAdapter', function() {
             var expected_data = {
               overviews: {
                 test_table_overviews: {
+                  schema: 'public',
                   1: { table: '_vovw_1_test_table_overviews' },
                   2: { table: '_vovw_2_test_table_overviews' }
                 }

--- a/test/integration/overviews-metadata-api.js
+++ b/test/integration/overviews-metadata-api.js
@@ -40,6 +40,7 @@ describe('OverviewsMetadataApi', function() {
 
             assert.deepEqual(result, {
                 'test_table_overviews': {
+                  schema: 'public',
                   1: { table: '_vovw_1_test_table_overviews' },
                   2: { table: '_vovw_2_test_table_overviews' }
                 }

--- a/test/integration/overviews-metadata-api.js
+++ b/test/integration/overviews-metadata-api.js
@@ -40,9 +40,9 @@ describe('OverviewsMetadataApi', function() {
 
             assert.deepEqual(result, {
                 'test_table_overviews': {
-                  schema: 'public',
-                  1: { table: '_vovw_1_test_table_overviews' },
-                  2: { table: '_vovw_2_test_table_overviews' }
+                    schema: 'public',
+                    1: { table: '_vovw_1_test_table_overviews' },
+                    2: { table: '_vovw_2_test_table_overviews' }
                 }
             });
 

--- a/test/unit/cartodb/overviews_query_rewriter.js
+++ b/test/unit/cartodb/overviews_query_rewriter.js
@@ -17,7 +17,7 @@ function assertSameSql(sql1, sql2) {
 
 describe('Overviews query rewriter', function() {
 
-  it('does not alter queries if no overviews data is present', function(done){
+  it('does not alter queries if no overviews data is present', function(){
     var sql = "SELECT * FROM table1";
     var overviews_sql = overviewsQueryRewriter.query(sql);
     assert.equal(overviews_sql, sql);
@@ -25,11 +25,10 @@ describe('Overviews query rewriter', function() {
     assert.equal(overviews_sql, sql);
     overviews_sql = overviewsQueryRewriter.query(sql, { overviews: {} });
     assert.equal(overviews_sql, sql);
-    done();
   });
 
 
-  it('does not alter queries which don\'t use overviews', function(done){
+  it('does not alter queries which don\'t use overviews', function(){
     var sql = "SELECT * FROM table1";
     var data = {
         overviews: {
@@ -42,12 +41,11 @@ describe('Overviews query rewriter', function() {
     };
     var overviews_sql = overviewsQueryRewriter.query(sql, data);
     assert.equal(overviews_sql, sql);
-    done();
   });
 
   // jshint multistr:true
 
-  it('generates query with single overview layer for level 0', function(done){
+  it('generates query with single overview layer for level 0', function(){
     var sql = "SELECT * FROM table1";
     var data = {
         overviews: {
@@ -68,10 +66,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('generates query with single overview layer for level >0', function(done){
+  it('generates query with single overview layer for level >0', function(){
     var sql = "SELECT * FROM table1";
     var data = {
         overviews: {
@@ -91,10 +88,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('generates query with multiple overview layers for all levels up to N', function(done){
+  it('generates query with multiple overview layers for all levels up to N', function(){
     var sql = "SELECT * FROM table1";
     var data = {
         overviews: {
@@ -123,10 +119,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('generates query with multiple overview layers for random levels', function(done){
+  it('generates query with multiple overview layers for random levels', function(){
     var sql = "SELECT * FROM table1";
     var data = {
         overviews: {
@@ -152,10 +147,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('generates query for a table with explicit schema', function(done){
+  it('generates query for a table with explicit schema', function(){
     var sql = "SELECT * FROM public.table1";
     var data = {
         overviews: {
@@ -175,10 +169,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('generates query for a table with explicit schema in the overviews info', function(done){
+  it('generates query for a table with explicit schema in the overviews info', function(){
     var sql = "SELECT * FROM public.table1";
     var data = {
         overviews: {
@@ -199,10 +192,9 @@ describe('Overviews query rewriter', function() {
     ";
 
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('uses schema name from overviews', function(done){
+  it('uses schema name from overviews', function(){
     var sql = "SELECT * FROM public.table1";
     var data = {
         overviews: {
@@ -223,10 +215,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('ignores schema name from overviews if not necessary', function(done){
+  it('ignores schema name from overviews if not necessary', function(){
     var sql = "SELECT * FROM table1";
     var data = {
         overviews: {
@@ -247,10 +238,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('uses redundant schema information', function(done){
+  it('uses redundant schema information', function(){
     var sql = "SELECT * FROM public.table1";
     var data = {
         overviews: {
@@ -271,10 +261,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('generates query for a table that needs quoting with explicit schema', function(done){
+  it('generates query for a table that needs quoting with explicit schema', function(){
     var sql = "SELECT * FROM public.\"table 1\"";
     var data = {
         overviews: {
@@ -294,10 +283,9 @@ describe('Overviews query rewriter', function() {
           ) AS \"_vovw_table 1\"\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('generates query for a table with explicit schema that needs quoting', function(done){
+  it('generates query for a table with explicit schema that needs quoting', function(){
     var sql = "SELECT * FROM \"user-1\".table1";
     var data = {
         overviews: {
@@ -317,11 +305,10 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
 
-  it('generates query for a table with explicit schema both needing quoting', function(done){
+  it('generates query for a table with explicit schema both needing quoting', function(){
     var sql = "SELECT * FROM \"user-1\".\"table 1\"";
     var data = {
         overviews: {
@@ -342,11 +329,10 @@ describe('Overviews query rewriter', function() {
           ) AS \"_vovw_table 1\"\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
 
-  it('generates query using overviews for queries with selected columns', function(done){
+  it('generates query using overviews for queries with selected columns', function(){
     var sql = "SELECT column1, column2, column3 FROM table1";
     var data = {
         overviews: {
@@ -366,10 +352,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('generates query using overviews for queries with a semicolon', function(done){
+  it('generates query using overviews for queries with a semicolon', function(){
     var sql = "SELECT column1, column2, column3 FROM table1;";
     var data = {
         overviews: {
@@ -390,10 +375,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1;\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('generates query using overviews for queries with extra whitespace', function(done){
+  it('generates query using overviews for queries with extra whitespace', function(){
     var sql = "  SELECT  column1,column2,  column3 FROM  table1  ";
     var data = {
         overviews: {
@@ -413,10 +397,9 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 
-  it('does not alter queries which have not the simple supported form', function(done){
+  it('does not alter queries which have not the simple supported form', function(){
     var sql = "SELECT * FROM table1 WHERE column1='x'";
     var data = {
         overviews: {
@@ -463,11 +446,9 @@ describe('Overviews query rewriter', function() {
     sql = "SELECT table1.*, column1, column2, column3 FROM table1";
     overviews_sql = overviewsQueryRewriter.query(sql, data);
     assert.equal(overviews_sql, sql);
-
-    done();
   });
 
-  it('generates overviews for wrapped query', function(done){
+  it('generates overviews for wrapped query', function(){
     var sql = "SELECT * FROM (SELECT * FROM table1) AS wrapped_query WHERE 1=1";
     var data = {
         overviews: {
@@ -493,6 +474,5 @@ describe('Overviews query rewriter', function() {
           ) AS _vovw_table1) AS wrapped_query WHERE 1=1\
     ";
     assertSameSql(overviews_sql, expected_sql);
-    done();
   });
 });

--- a/test/unit/cartodb/overviews_query_rewriter.js
+++ b/test/unit/cartodb/overviews_query_rewriter.js
@@ -3,11 +3,11 @@ require('../../support/test_helper');
 var assert           = require('assert');
 var OverviewsQueryRewriter = require('../../../lib/cartodb/utils/overviews_query_rewriter');
 var overviewsQueryRewriter = new OverviewsQueryRewriter({
-  zoom_level: 'ZoomLevel()'
+    zoom_level: 'ZoomLevel()'
 });
 
 function normalize_whitespace(txt) {
-  return txt.replace(/\s+/g, " ").trim();
+    return txt.replace(/\s+/g, " ").trim();
 }
 
 // compare SQL statements ignoring whitespace
@@ -17,462 +17,462 @@ function assertSameSql(sql1, sql2) {
 
 describe('Overviews query rewriter', function() {
 
-  it('does not alter queries if no overviews data is present', function(){
-    var sql = "SELECT * FROM table1";
-    var overviews_sql = overviewsQueryRewriter.query(sql);
-    assert.equal(overviews_sql, sql);
-    overviews_sql = overviewsQueryRewriter.query(sql, {});
-    assert.equal(overviews_sql, sql);
-    overviews_sql = overviewsQueryRewriter.query(sql, { overviews: {} });
-    assert.equal(overviews_sql, sql);
-  });
+    it('does not alter queries if no overviews data is present', function(){
+        var sql = "SELECT * FROM table1";
+        var overviews_sql = overviewsQueryRewriter.query(sql);
+        assert.equal(overviews_sql, sql);
+        overviews_sql = overviewsQueryRewriter.query(sql, {});
+        assert.equal(overviews_sql, sql);
+        overviews_sql = overviewsQueryRewriter.query(sql, { overviews: {} });
+        assert.equal(overviews_sql, sql);
+    });
 
 
-  it('does not alter queries which don\'t use overviews', function(){
-    var sql = "SELECT * FROM table1";
-    var data = {
-        overviews: {
-            table2: {
-              0: { table: 'table2_ov0' },
-              1: { table: 'table2_ov1' },
-              4: { table: 'table2_ov4' }
+    it('does not alter queries which don\'t use overviews', function(){
+        var sql = "SELECT * FROM table1";
+        var data = {
+            overviews: {
+                table2: {
+                    0: { table: 'table2_ov0' },
+                    1: { table: 'table2_ov1' },
+                    4: { table: 'table2_ov4' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
+    });
 
-  // jshint multistr:true
+    // jshint multistr:true
 
-  it('generates query with single overview layer for level 0', function(){
-    var sql = "SELECT * FROM table1";
-    var data = {
-        overviews: {
-            table1: {
-              0: { table: 'table1_ov0' }
+    it('generates query with single overview layer for level 0', function(){
+        var sql = "SELECT * FROM table1";
+        var data = {
+            overviews: {
+                table1: {
+                    0: { table: 'table1_ov0' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
 
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM table1_ov0, _vovw_scale WHERE _vovw_z = 0\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 0\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM table1_ov0, _vovw_scale WHERE _vovw_z = 0\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 0\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('generates query with single overview layer for level >0', function(){
-    var sql = "SELECT * FROM table1";
-    var data = {
-        overviews: {
-            table1: {
-              2: { table: 'table1_ov2' }
+    it('generates query with single overview layer for level >0', function(){
+        var sql = "SELECT * FROM table1";
+        var data = {
+            overviews: {
+                table1: {
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('generates query with multiple overview layers for all levels up to N', function(){
-    var sql = "SELECT * FROM table1";
-    var data = {
-        overviews: {
-            table1: {
-              0: { table: 'table1_ov0' },
-              1: { table: 'table1_ov1' },
-              2: { table: 'table1_ov2' },
-              3: { table: 'table1_ov3' }
+    it('generates query with multiple overview layers for all levels up to N', function(){
+        var sql = "SELECT * FROM table1";
+        var data = {
+            overviews: {
+                table1: {
+                    0: { table: 'table1_ov0' },
+                    1: { table: 'table1_ov1' },
+                    2: { table: 'table1_ov2' },
+                    3: { table: 'table1_ov3' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM  (\
-            SELECT * FROM table1_ov0, _vovw_scale WHERE _vovw_z = 0\
-            UNION ALL\
-            SELECT * FROM table1_ov1, _vovw_scale WHERE _vovw_z = 1\
-            UNION ALL\
-            SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z = 2\
-            UNION ALL\
-            SELECT * FROM table1_ov3, _vovw_scale WHERE _vovw_z = 3\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 3\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM  (\
+                SELECT * FROM table1_ov0, _vovw_scale WHERE _vovw_z = 0\
+                UNION ALL\
+                SELECT * FROM table1_ov1, _vovw_scale WHERE _vovw_z = 1\
+                UNION ALL\
+                SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z = 2\
+                UNION ALL\
+                SELECT * FROM table1_ov3, _vovw_scale WHERE _vovw_z = 3\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 3\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('generates query with multiple overview layers for random levels', function(){
-    var sql = "SELECT * FROM table1";
-    var data = {
-        overviews: {
-            table1: {
-              0: { table: 'table1_ov0' },
-              1: { table: 'table1_ov1' },
-              6: { table: 'table1_ov6' }
+    it('generates query with multiple overview layers for random levels', function(){
+        var sql = "SELECT * FROM table1";
+        var data = {
+            overviews: {
+                table1: {
+                    0: { table: 'table1_ov0' },
+                    1: { table: 'table1_ov1' },
+                    6: { table: 'table1_ov6' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM table1_ov0, _vovw_scale WHERE _vovw_z = 0\
-            UNION ALL\
-            SELECT * FROM table1_ov1, _vovw_scale WHERE _vovw_z = 1\
-            UNION ALL\
-            SELECT * FROM table1_ov6, _vovw_scale WHERE _vovw_z > 1 AND _vovw_z <= 6\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 6\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM table1_ov0, _vovw_scale WHERE _vovw_z = 0\
+                UNION ALL\
+                SELECT * FROM table1_ov1, _vovw_scale WHERE _vovw_z = 1\
+                UNION ALL\
+                SELECT * FROM table1_ov6, _vovw_scale WHERE _vovw_z > 1 AND _vovw_z <= 6\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 6\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('generates query for a table with explicit schema', function(){
-    var sql = "SELECT * FROM public.table1";
-    var data = {
-        overviews: {
-            'public.table1': {
-              2: { table: 'table1_ov2' }
+    it('generates query for a table with explicit schema', function(){
+        var sql = "SELECT * FROM public.table1";
+        var data = {
+            overviews: {
+                'public.table1': {
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM public.table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM public.table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM public.table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM public.table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('generates query for a table with explicit schema in the overviews info', function(){
-    var sql = "SELECT * FROM public.table1";
-    var data = {
-        overviews: {
-            'public.table1': {
-              2: { table: 'table1_ov2' }
+    it('generates query for a table with explicit schema in the overviews info', function(){
+        var sql = "SELECT * FROM public.table1";
+        var data = {
+            overviews: {
+                'public.table1': {
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM public.table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM public.table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1\
-    ";
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM public.table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM public.table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1\
+        ";
 
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('uses schema name from overviews', function(){
-    var sql = "SELECT * FROM public.table1";
-    var data = {
-        overviews: {
-            'table1': {
-              schema: 'public',
-              2: { table: 'table1_ov2' }
+    it('uses schema name from overviews', function(){
+        var sql = "SELECT * FROM public.table1";
+        var data = {
+            overviews: {
+                'table1': {
+                    schema: 'public',
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('ignores schema name from overviews if not necessary', function(){
-    var sql = "SELECT * FROM table1";
-    var data = {
-        overviews: {
-            'table1': {
-              schema: 'public',
-              2: { table: 'table1_ov2' }
+    it('ignores schema name from overviews if not necessary', function(){
+        var sql = "SELECT * FROM table1";
+        var data = {
+            overviews: {
+                'table1': {
+                    schema: 'public',
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('uses redundant schema information', function(){
-    var sql = "SELECT * FROM public.table1";
-    var data = {
-        overviews: {
-            'public.table1': {
-              schema: 'public',
-              2: { table: 'table1_ov2' }
+    it('uses redundant schema information', function(){
+        var sql = "SELECT * FROM public.table1";
+        var data = {
+            overviews: {
+                'public.table1': {
+                    schema: 'public',
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM public.table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM public.table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM public.table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM public.table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('generates query for a table that needs quoting with explicit schema', function(){
-    var sql = "SELECT * FROM public.\"table 1\"";
-    var data = {
-        overviews: {
-            'public."table 1"': {
-              2: { table: '"table 1_ov2"' }
+    it('generates query for a table that needs quoting with explicit schema', function(){
+        var sql = "SELECT * FROM public.\"table 1\"";
+        var data = {
+            overviews: {
+                'public."table 1"': {
+                    2: { table: '"table 1_ov2"' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM public.\"table 1_ov2\", _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM public.\"table 1\", _vovw_scale WHERE _vovw_z > 2\
-          ) AS \"_vovw_table 1\"\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM public.\"table 1_ov2\", _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM public.\"table 1\", _vovw_scale WHERE _vovw_z > 2\
+              ) AS \"_vovw_table 1\"\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('generates query for a table with explicit schema that needs quoting', function(){
-    var sql = "SELECT * FROM \"user-1\".table1";
-    var data = {
-        overviews: {
-            '"user-1".table1': {
-              2: { table: 'table1_ov2' }
+    it('generates query for a table with explicit schema that needs quoting', function(){
+        var sql = "SELECT * FROM \"user-1\".table1";
+        var data = {
+            overviews: {
+                '"user-1".table1': {
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM \"user-1\".table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM \"user-1\".table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM \"user-1\".table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM \"user-1\".table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
 
-  it('generates query for a table with explicit schema both needing quoting', function(){
-    var sql = "SELECT * FROM \"user-1\".\"table 1\"";
-    var data = {
-        overviews: {
-            '"user-1"."table 1"': {
-              2: { table: '"table 1_ov2"' }
+    it('generates query for a table with explicit schema both needing quoting', function(){
+        var sql = "SELECT * FROM \"user-1\".\"table 1\"";
+        var data = {
+            overviews: {
+                '"user-1"."table 1"': {
+                    2: { table: '"table 1_ov2"' }
 
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (\
-            SELECT * FROM \"user-1\".\"table 1_ov2\", _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM \"user-1\".\"table 1\", _vovw_scale WHERE _vovw_z > 2\
-          ) AS \"_vovw_table 1\"\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (\
+                SELECT * FROM \"user-1\".\"table 1_ov2\", _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM \"user-1\".\"table 1\", _vovw_scale WHERE _vovw_z > 2\
+              ) AS \"_vovw_table 1\"\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
 
-  it('generates query using overviews for queries with selected columns', function(){
-    var sql = "SELECT column1, column2, column3 FROM table1";
-    var data = {
-        overviews: {
-            table1: {
-              2: { table: 'table1_ov2' }
+    it('generates query using overviews for queries with selected columns', function(){
+        var sql = "SELECT column1, column2, column3 FROM table1";
+        var data = {
+            overviews: {
+                table1: {
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT column1, column2, column3 FROM (\
-            SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT column1, column2, column3 FROM (\
+                SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('generates query using overviews for queries with a semicolon', function(){
-    var sql = "SELECT column1, column2, column3 FROM table1;";
-    var data = {
-        overviews: {
-            table1: {
-              2: { table: 'table1_ov2' }
+    it('generates query using overviews for queries with a semicolon', function(){
+        var sql = "SELECT column1, column2, column3 FROM table1;";
+        var data = {
+            overviews: {
+                table1: {
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
 
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT column1, column2, column3 FROM (\
-            SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1;\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT column1, column2, column3 FROM (\
+                SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1;\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('generates query using overviews for queries with extra whitespace', function(){
-    var sql = "  SELECT  column1,column2,  column3 FROM  table1  ";
-    var data = {
-        overviews: {
-            table1: {
-              2: { table: 'table1_ov2' }
+    it('generates query using overviews for queries with extra whitespace', function(){
+        var sql = "  SELECT  column1,column2,  column3 FROM  table1  ";
+        var data = {
+            overviews: {
+                table1: {
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT column1,column2, column3 FROM (\
-            SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT column1,column2, column3 FROM (\
+                SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z <= 2\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 
-  it('does not alter queries which have not the simple supported form', function(){
-    var sql = "SELECT * FROM table1 WHERE column1='x'";
-    var data = {
-        overviews: {
-            table1: {
-              2: { table: 'table1_ov2' }
+    it('does not alter queries which have not the simple supported form', function(){
+        var sql = "SELECT * FROM table1 WHERE column1='x'";
+        var data = {
+            overviews: {
+                table1: {
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
 
-    sql = "SELECT * FROM table1 JOIN table2 ON (table1.col1=table2.col1)";
-    overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
+        sql = "SELECT * FROM table1 JOIN table2 ON (table1.col1=table2.col1)";
+        overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
 
-    sql = "SELECT a+b AS c FROM table1";
-    overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
+        sql = "SELECT a+b AS c FROM table1";
+        overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
 
-    sql = "SELECT f(a) AS b FROM table1";
-    overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
+        sql = "SELECT f(a) AS b FROM table1";
+        overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
 
-    sql = "SELECT * FROM table1 AS x";
-    overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
+        sql = "SELECT * FROM table1 AS x";
+        overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
 
-    sql = "WITH a AS (1) SELECT * FROM table1";
-    overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
+        sql = "WITH a AS (1) SELECT * FROM table1";
+        overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
 
-    sql = "SELECT * FROM table1 WHERE a=1";
-    overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
+        sql = "SELECT * FROM table1 WHERE a=1";
+        overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
 
-    sql = "\
-        SELECT table1.* FROM table1 \
-               JOIN areas ON ST_Intersects(table1.the_geom, areas.the_geom) \
-               WHERE areas.name='A' \
-          ";
-    overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
+        sql = "\
+            SELECT table1.* FROM table1 \
+                   JOIN areas ON ST_Intersects(table1.the_geom, areas.the_geom) \
+                   WHERE areas.name='A' \
+              ";
+        overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
 
-    sql = "SELECT table1.*, column1, column2, column3 FROM table1";
-    overviews_sql = overviewsQueryRewriter.query(sql, data);
-    assert.equal(overviews_sql, sql);
-  });
+        sql = "SELECT table1.*, column1, column2, column3 FROM table1";
+        overviews_sql = overviewsQueryRewriter.query(sql, data);
+        assert.equal(overviews_sql, sql);
+    });
 
-  it('generates overviews for wrapped query', function(){
-    var sql = "SELECT * FROM (SELECT * FROM table1) AS wrapped_query WHERE 1=1";
-    var data = {
-        overviews: {
-            table1: {
-              0: { table: 'table1_ov0' },
-              1: { table: 'table1_ov1' },
-              2: { table: 'table1_ov2' }
+    it('generates overviews for wrapped query', function(){
+        var sql = "SELECT * FROM (SELECT * FROM table1) AS wrapped_query WHERE 1=1";
+        var data = {
+            overviews: {
+                table1: {
+                    0: { table: 'table1_ov0' },
+                    1: { table: 'table1_ov1' },
+                    2: { table: 'table1_ov2' }
+                }
             }
-        }
-    };
-    var overviews_sql = overviewsQueryRewriter.query(sql, data);
-    var expected_sql = "\
-        WITH\
-          _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
-          SELECT * FROM (SELECT * FROM  (\
-            SELECT * FROM table1_ov0, _vovw_scale WHERE _vovw_z = 0\
-            UNION ALL\
-            SELECT * FROM table1_ov1, _vovw_scale WHERE _vovw_z = 1\
-            UNION ALL\
-            SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z = 2\
-            UNION ALL\
-            SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
-          ) AS _vovw_table1) AS wrapped_query WHERE 1=1\
-    ";
-    assertSameSql(overviews_sql, expected_sql);
-  });
+        };
+        var overviews_sql = overviewsQueryRewriter.query(sql, data);
+        var expected_sql = "\
+            WITH\
+              _vovw_scale AS ( SELECT ZoomLevel() AS _vovw_z )\
+              SELECT * FROM (SELECT * FROM  (\
+                SELECT * FROM table1_ov0, _vovw_scale WHERE _vovw_z = 0\
+                UNION ALL\
+                SELECT * FROM table1_ov1, _vovw_scale WHERE _vovw_z = 1\
+                UNION ALL\
+                SELECT * FROM table1_ov2, _vovw_scale WHERE _vovw_z = 2\
+                UNION ALL\
+                SELECT * FROM table1, _vovw_scale WHERE _vovw_z > 2\
+              ) AS _vovw_table1) AS wrapped_query WHERE 1=1\
+        ";
+        assertSameSql(overviews_sql, expected_sql);
+    });
 });


### PR DESCRIPTION
Fixes #420

Keep table schema of overviews base tables and use it
to support queries that use the schema name when not
strictly needed.