### PR TITLE
removed dup text from static api section

### DIFF
--- a/docs/static_maps_api.md
+++ b/docs/static_maps_api.md
@@ -49,8 +49,6 @@ bbox | the bounding box in WGS 84 (EPSG:4326), comma separated values for:
 width | the width in pixels for the output image
 height | the height in pixels for the output image
 format | the format for the image, supported types: `png`, `jpg`
-
-format | the bounding box in WGS 84 (EPSG:4326), comma separated values for:
 --- | ---
 &#124;_ jpg | will have a default quality of 85.
 


### PR DESCRIPTION
Fixes [Docs issue#801](https://github.com/CartoDB/docs/issues/801)