### PR TITLE
Use Camshaft's API to get node filters

### DIFF
--- a/lib/cartodb/backends/dataview.js
+++ b/lib/cartodb/backends/dataview.js
@@ -123,7 +123,7 @@ DataviewBackend.prototype.getDataview = function (mapConfigProvider, user, param
             var queryRewriteData = layer && layer.options.query_rewrite_data;
             if ( queryRewriteData ) {
                 if ( node.type === 'source' ) {
-                    var filters = node.filters; // TODO: node.getFilters() when available in camshaft
+                    var filters = node.getFilters();
                     var filters_disabler = Object.keys(filters).reduce(
                         function(disabler, filter_id){ disabler[filter_id] = false; return disabler; },
                         {}

--- a/lib/cartodb/models/mapconfig_overviews_adapter.js
+++ b/lib/cartodb/models/mapconfig_overviews_adapter.js
@@ -35,7 +35,7 @@ MapConfigOverviewsAdapter.prototype.getLayers = function(username, layers, analy
                            var node = _.find(analysesResults, function(a){ return a.rootNode.params.id === sourceId; });
                            if ( node ) {
                                node = node.rootNode;
-                               filters = node.filters; // TODO: node.getFilters() when available in camshaft
+                               filters = node.getFilters();
                                var filters_disabler = Object.keys(filters).reduce(
                                    function(disabler, filter_id){ disabler[filter_id] = false; return disabler; },
                                    {}


### PR DESCRIPTION
I hadn't realized getFilters() was already available in the camshaft version in use.