### PR TITLE
Adapter.getMapConfig interface

### DIFF
--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -175,15 +175,12 @@ MapController.prototype.create = function(req, res, prepareConfigFn) {
             assert.ifError(err);
             var next = this;
             analysesResults = _analysesResults;
-            self.namedLayersAdapter.getLayers(req.context.user, requestMapConfig.layers, self.pgConnection,
-                function(err, layers, datasource) {
+            self.namedLayersAdapter.getMapConfig(req.context.user, requestMapConfig, self.pgConnection,
+                function(err, requestMapConfig, datasource) {
                     if (err) {
                         return next(err);
                     }
 
-                    if (layers) {
-                        requestMapConfig.layers = layers;
-                    }
                     return next(null, requestMapConfig, datasource);
                 }
             );

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -210,13 +210,9 @@ MapController.prototype.create = function(req, res, prepareConfigFn) {
             assert.ifError(err);
 
             var next = this;
-            self.turboCartoAdapter.getLayers(req.context.user, requestMapConfig.layers, function (err, layers) {
+            self.turboCartoAdapter.getMapConfig(req.context.user, requestMapConfig, function (err, requestMapConfig) {
                 if (err) {
                     return next(err);
-                }
-
-                if (layers) {
-                    requestMapConfig.layers = layers;
                 }
 
                 return next(null, requestMapConfig, datasource);

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -188,15 +188,10 @@ MapController.prototype.create = function(req, res, prepareConfigFn) {
         function addOverviewsInformation(err, requestMapConfig, datasource) {
             assert.ifError(err);
             var next = this;
-            self.overviewsAdapter.getLayers(
-                req.context.user, requestMapConfig.layers, analysesResults,
-                function(err, layers) {
+            self.overviewsAdapter.getMapConfig(req.context.user, requestMapConfig, analysesResults,
+                function(err, requestMapConfig) {
                     if (err) {
                         return next(err);
-                    }
-
-                    if (layers) {
-                        requestMapConfig.layers = layers;
                     }
 
                     return next(null, requestMapConfig, datasource);

--- a/lib/cartodb/models/mapconfig/adapter/mapconfig-named-layers-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/mapconfig-named-layers-adapter.js
@@ -8,11 +8,13 @@ function MapConfigNamedLayersAdapter(templateMaps) {
 
 module.exports = MapConfigNamedLayersAdapter;
 
-MapConfigNamedLayersAdapter.prototype.getLayers = function(username, layers, dbMetadata, callback) {
+MapConfigNamedLayersAdapter.prototype.getMapConfig = function(username, requestMapConfig, dbMetadata, callback) {
     var self = this;
 
+    var layers = requestMapConfig.layers;
+
     if (!layers) {
-        return callback(null);
+        return callback(null, requestMapConfig);
     }
 
     var adaptLayersQueue = queue(layers.length);
@@ -96,7 +98,9 @@ MapConfigNamedLayersAdapter.prototype.getLayers = function(username, layers, dbM
 
         });
 
-        return callback(null, layers, datasourceBuilder.build());
+        requestMapConfig.layers = layers;
+
+        return callback(null, requestMapConfig, datasourceBuilder.build());
     }
 
 
@@ -114,7 +118,7 @@ MapConfigNamedLayersAdapter.prototype.getLayers = function(username, layers, dbM
             adaptLayersQueue.awaitAll(layersAdaptQueueFinish);
         });
     } else {
-        return callback(null, layers, datasourceBuilder.build());
+        return callback(null, requestMapConfig, datasourceBuilder.build());
     }
 
 };

--- a/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
@@ -9,11 +9,13 @@ function MapConfigOverviewsAdapter(overviewsMetadataApi, filterStatsApi) {
 
 module.exports = MapConfigOverviewsAdapter;
 
-MapConfigOverviewsAdapter.prototype.getLayers = function(username, layers, analysesResults, callback) {
+MapConfigOverviewsAdapter.prototype.getMapConfig = function(username, requestMapConfig, analysesResults, callback) {
   var self = this;
 
+  var layers = requestMapConfig.layers;
+
   if (!layers || layers.length === 0) {
-      return callback(null, layers);
+      return callback(null, requestMapConfig);
   }
 
   var augmentLayersQueue = queue(layers.length);
@@ -85,7 +87,9 @@ MapConfigOverviewsAdapter.prototype.getLayers = function(username, layers, analy
         return callback(new Error('Missing layers array from layergroup config'));
     }
 
-    return callback(null, layers);
+    requestMapConfig.layers = layers;
+
+    return callback(null, requestMapConfig);
   }
 
   layers.forEach(function(layer) {

--- a/lib/cartodb/models/mapconfig/adapter/turbo-carto-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/turbo-carto-adapter.js
@@ -11,11 +11,13 @@ function TurboCartoAdapter(turboCartoParser) {
 
 module.exports = TurboCartoAdapter;
 
-TurboCartoAdapter.prototype.getLayers = function (username, layers, callback) {
+TurboCartoAdapter.prototype.getMapConfig = function (username, requestMapConfig, callback) {
     var self = this;
 
+    var layers = requestMapConfig.layers;
+
     if (!layers || layers.length === 0) {
-        return callback(null, layers);
+        return callback(null, requestMapConfig);
     }
 
     var parseCartoQueue = queue(layers.length);
@@ -29,7 +31,9 @@ TurboCartoAdapter.prototype.getLayers = function (username, layers, callback) {
             return callback(err);
         }
 
-        return callback(null, layers);
+        requestMapConfig.layers = layers;
+
+        return callback(null, requestMapConfig);
     });
 };
 

--- a/lib/cartodb/models/mapconfig/adapter/turbo-carto-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/turbo-carto-adapter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var queue = require('queue-async');
-var SubstitutionTokens = require('../substitution-tokens');
+var SubstitutionTokens = require('../../../utils/substitution-tokens');
 
 function TurboCartoAdapter(turboCartoParser) {
     this.turboCartoParser = turboCartoParser;

--- a/lib/cartodb/models/mapconfig/provider/named-map-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/named-map-provider.js
@@ -131,15 +131,12 @@ NamedMapMapConfigProvider.prototype.getMapConfig = function(callback) {
             assert.ifError(err);
             var next = this;
             self.analysesResults = analysesResults || [];
-            self.namedLayersAdapter.getLayers(self.owner, _mapConfig.layers, self.pgConnection,
-                function(err, layers, datasource) {
+            self.namedLayersAdapter.getMapConfig(self.owner, _mapConfig, self.pgConnection,
+                function(err, _mapConfig, datasource) {
                     if (err) {
                         return next(err);
                     }
 
-                    if (layers) {
-                        _mapConfig.layers = layers;
-                    }
                     return next(null, _mapConfig, datasource);
                 }
             );

--- a/lib/cartodb/models/mapconfig/provider/named-map-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/named-map-provider.js
@@ -145,13 +145,9 @@ NamedMapMapConfigProvider.prototype.getMapConfig = function(callback) {
             assert.ifError(err);
             var next = this;
 
-            self.overviewsAdapter.getLayers(self.owner, _mapConfig.layers, self.analysesResults, function(err, layers) {
+            self.overviewsAdapter.getMapConfig(self.owner, _mapConfig, self.analysesResults, function(err, _mapConfig) {
                 if (err) {
                     return next(err);
-                }
-
-                if (layers) {
-                    _mapConfig.layers = layers;
                 }
 
                 return next(null, _mapConfig, datasource);

--- a/lib/cartodb/models/mapconfig/provider/named-map-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/named-map-provider.js
@@ -164,13 +164,9 @@ NamedMapMapConfigProvider.prototype.getMapConfig = function(callback) {
             assert.ifError(err);
             var next = this;
 
-            self.turboCartoAdapter.getLayers(self.owner, _mapConfig.layers, function (err, layers) {
+            self.turboCartoAdapter.getMapConfig(self.owner, _mapConfig, function (err, _mapConfig) {
                 if (err) {
                     return next(err);
-                }
-
-                if (layers) {
-                    _mapConfig.layers = layers;
                 }
 
                 return next(null, _mapConfig, datasource);

--- a/lib/cartodb/server.js
+++ b/lib/cartodb/server.js
@@ -37,7 +37,7 @@ var timeoutErrorTile = require('fs').readFileSync(timeoutErrorTilePath, {encodin
 var MapConfigOverviewsAdapter = require('./models/mapconfig/adapter/mapconfig-overviews-adapter');
 
 var TurboCartoParser = require('./utils/style/turbo-carto-parser');
-var TurboCartoAdapter = require('./utils/style/turbo-carto-adapter');
+var TurboCartoAdapter = require('./models/mapconfig/adapter/turbo-carto-adapter');
 
 module.exports = function(serverOptions) {
     // Make stats client globally accessible

--- a/test/integration/mapconfig_named_layers_datasource.js
+++ b/test/integration/mapconfig_named_layers_datasource.js
@@ -294,9 +294,9 @@ describe('named_layers datasources', function() {
 
     testScenarios.forEach(function(testScenario) {
         it('should return a list of layers ' + testScenario.desc, function(done) {
-            mapConfigNamedLayersAdapter.getLayers(username, testScenario.config.layers, pgConnection,
-                function(err, layers, datasource) {
-                    testScenario.test(err, layers, datasource, done);
+            mapConfigNamedLayersAdapter.getMapConfig(username, testScenario.config, pgConnection,
+                function(err, mapConfig, datasource) {
+                    testScenario.test(err, mapConfig.layers, datasource, done);
                 }
             );
         });

--- a/test/integration/mapconfig_named_layers_expanded.js
+++ b/test/integration/mapconfig_named_layers_expanded.js
@@ -147,10 +147,10 @@ describe('mapconfig-named-layers-adapter', function() {
         var missingNamedMapLayerConfig = makeNamedMapLayerConfig({
             config: {}
         });
-        mapConfigNamedLayersAdapter.getLayers(username, missingNamedMapLayerConfig.layers, pgConnection,
-            function(err, layers, datasource) {
+        mapConfigNamedLayersAdapter.getMapConfig(username, missingNamedMapLayerConfig, pgConnection,
+            function(err, mapConfig, datasource) {
                 assert.ok(err);
-                assert.ok(!layers);
+                assert.ok(!mapConfig);
                 assert.ok(!datasource);
                 assert.equal(err.message, 'Missing Named Map `name` in layer options');
 
@@ -164,10 +164,10 @@ describe('mapconfig-named-layers-adapter', function() {
         var nonExistentNamedMapLayerConfig = makeNamedMapLayerConfig({
             name: missingTemplateName
         });
-        mapConfigNamedLayersAdapter.getLayers(username, nonExistentNamedMapLayerConfig.layers, pgConnection,
-            function(err, layers, datasource) {
+        mapConfigNamedLayersAdapter.getMapConfig(username, nonExistentNamedMapLayerConfig, pgConnection,
+            function(err, mapConfig, datasource) {
                 assert.ok(err);
-                assert.ok(!layers);
+                assert.ok(!mapConfig);
                 assert.ok(!datasource);
                 assert.equal(
                     err.message, "Template '" + missingTemplateName + "' of user '" + username + "' not found"
@@ -187,10 +187,10 @@ describe('mapconfig-named-layers-adapter', function() {
             var nonAuthTokensNamedMapLayerConfig = makeNamedMapLayerConfig({
                 name: tokenAuthTemplateName
             });
-            mapConfigNamedLayersAdapter.getLayers(username, nonAuthTokensNamedMapLayerConfig.layers, pgConnection,
-                function(err, layers, datasource) {
+            mapConfigNamedLayersAdapter.getMapConfig(username, nonAuthTokensNamedMapLayerConfig, pgConnection,
+                function(err, mapConfig, datasource) {
                     assert.ok(err);
-                    assert.ok(!layers);
+                    assert.ok(!mapConfig);
                     assert.ok(!datasource);
                     assert.equal(err.message, "Unauthorized '" + tokenAuthTemplateName + "' template instantiation");
 
@@ -209,10 +209,10 @@ describe('mapconfig-named-layers-adapter', function() {
             var nestedNamedMapLayerConfig = makeNamedMapLayerConfig({
                 name: nestedNamedMapTemplateName
             });
-            mapConfigNamedLayersAdapter.getLayers(username, nestedNamedMapLayerConfig.layers, pgConnection,
-                function(err, layers, datasource) {
+            mapConfigNamedLayersAdapter.getMapConfig(username, nestedNamedMapLayerConfig, pgConnection,
+                function(err, mapConfig, datasource) {
                     assert.ok(err);
-                    assert.ok(!layers);
+                    assert.ok(!mapConfig);
                     assert.ok(!datasource);
                     assert.equal(err.message, 'Nested named layers are not allowed');
 
@@ -226,9 +226,10 @@ describe('mapconfig-named-layers-adapter', function() {
         var validNamedMapMapLayerConfig = makeNamedMapLayerConfig({
             name: templateName
         });
-        mapConfigNamedLayersAdapter.getLayers(username, validNamedMapMapLayerConfig.layers, pgConnection,
-            function(err, layers, datasource) {
+        mapConfigNamedLayersAdapter.getMapConfig(username, validNamedMapMapLayerConfig, pgConnection,
+            function(err, mapConfig, datasource) {
                 assert.ok(!err);
+                var layers = mapConfig.layers;
                 assert.ok(layers.length, 1);
                 assert.ok(layers[0].type, 'cartodb');
                 assert.notEqual(datasource.getLayerDatasource(0), undefined);
@@ -248,9 +249,10 @@ describe('mapconfig-named-layers-adapter', function() {
                 name: tokenAuthTemplateName,
                 auth_tokens: ['valid1']
             });
-            mapConfigNamedLayersAdapter.getLayers(username, validAuthTokensNamedMapLayerConfig.layers, pgConnection,
-                function(err, layers, datasource) {
+            mapConfigNamedLayersAdapter.getMapConfig(username, validAuthTokensNamedMapLayerConfig, pgConnection,
+                function(err, mapConfig, datasource) {
                     assert.ok(!err);
+                    var layers = mapConfig.layers;
                     assert.equal(layers.length, 1);
                     assert.notEqual(datasource.getLayerDatasource(0), undefined);
 
@@ -270,9 +272,10 @@ describe('mapconfig-named-layers-adapter', function() {
                 name: multipleLayersTemplateName,
                 auth_tokens: ['valid2']
             });
-            mapConfigNamedLayersAdapter.getLayers(username, multipleLayersNamedMapLayerConfig.layers, pgConnection,
-                function(err, layers, datasource) {
+            mapConfigNamedLayersAdapter.getMapConfig(username, multipleLayersNamedMapLayerConfig, pgConnection,
+                function(err, mapConfig, datasource) {
                     assert.ok(!err);
+                    var layers = mapConfig.layers;
                     assert.equal(layers.length, 2);
 
                     assert.equal(layers[0].type, 'mapnik');
@@ -306,9 +309,10 @@ describe('mapconfig-named-layers-adapter', function() {
                 },
                 auth_tokens: ['valid2']
             });
-            mapConfigNamedLayersAdapter.getLayers(username, multipleLayersNamedMapLayerConfig.layers, pgConnection,
-                function(err, layers, datasource) {
+            mapConfigNamedLayersAdapter.getMapConfig(username, multipleLayersNamedMapLayerConfig, pgConnection,
+                function(err, mapConfig, datasource) {
                     assert.ok(!err);
+                    var layers = mapConfig.layers;
                     assert.equal(layers.length, 2);
 
                     assert.equal(layers[0].type, 'mapnik');

--- a/test/integration/mapconfig_overviews_adapter.js
+++ b/test/integration/mapconfig_overviews_adapter.js
@@ -33,8 +33,13 @@ describe('MapConfigOverviewsAdapter', function() {
             }
         };
 
-        mapConfigOverviewsAdapter.getLayers('localhost', [layer_without_overviews], [], function(err, layers) {
+        var _mapConfig = {
+            layers: [layer_without_overviews]
+        };
+
+        mapConfigOverviewsAdapter.getMapConfig('localhost', _mapConfig, [], function(err, mapConfig) {
             assert.ok(!err);
+            var layers = mapConfig.layers;
             assert.equal(layers.length, 1);
             assert.equal(layers[0].type, 'cartodb');
             assert.equal(layers[0].options.sql, sql);
@@ -52,7 +57,7 @@ describe('MapConfigOverviewsAdapter', function() {
         var sql = 'SELECT * FROM test_table_overviews';
         var cartocss = '#layer { marker-fill: black; }';
         var cartocss_version = '2.3.0';
-        var layer_without_overviews = {
+        var layer_with_overviews = {
             type: 'cartodb',
             options: {
                 sql: sql,
@@ -61,8 +66,13 @@ describe('MapConfigOverviewsAdapter', function() {
             }
         };
 
-        mapConfigOverviewsAdapter.getLayers('localhost', [layer_without_overviews], [], function(err, layers) {
+        var _mapConfig = {
+            layers: [layer_with_overviews]
+        };
+
+        mapConfigOverviewsAdapter.getMapConfig('localhost', _mapConfig, [], function(err, mapConfig) {
             assert.ok(!err);
+            var layers = mapConfig.layers;
             assert.equal(layers.length, 1);
             assert.equal(layers[0].type, 'cartodb');
             assert.equal(layers[0].options.sql, sql);


### PR DESCRIPTION
Unify adapters interface to respond to getMapConfig instead of getLayers.