### PR TITLE
Pixel size query for turbo-carto adapter using radians and degrees

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 Released 2016-mm-dd
 
+Bug fixes:
+ - Pixel size query for turbo-carto adapter using radians and degrees instead of meters.
+
 New features:
  - Add support for min, max, and avg operations in aggregation dataview #513.
 

--- a/lib/cartodb/models/mapconfig/adapter/turbo-carto-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/turbo-carto-adapter.js
@@ -50,7 +50,10 @@ var zoomTemplate = dot.template([
     '0',
     ')'
 ].join('\n'));
-var pixelSizeTemplate = dot.template('40075017 * cos(ST_Y(ST_Centroid({{=it._bbox}}))) / 2 ^ (({{=it._zoom}}) + 8)');
+// http://wiki.openstreetmap.org/wiki/Zoom_levels
+var pixelSizeTemplate = dot.template(
+    '40075017 * cos(radians(ST_Y(ST_Transform(ST_Centroid({{=it._bbox}}), 4326)))) / (2 ^ ({{=it._zoom}} + 8))'
+);
 var scaleDenominatorTemplate = dot.template('({{=it._pixelSize}} / 0.00028)::numeric');
 
 


### PR DESCRIPTION
It was using meters.