### PR TITLE
Fix issues related to rollout

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 ## 2.81.1
 Released 2016-mm-dd
 
+Announcements:
+ - Upgrades windshaft to [2.6.2](https://github.com/CartoDB/windshaft/releases/tag/2.6.2).
+ - Upgrades camshaft to [0.46.3](https://github.com/CartoDB/camshaft/releases/tag/0.46.3).
+
 
 ## 2.81.0
 Released 2016-11-02

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,101 +1,101 @@
 {
   "name": "windshaft-cartodb",
-  "version": "2.81.0",
+  "version": "2.81.1",
   "dependencies": {
     "body-parser": {
       "version": "1.14.2",
-      "from": "body-parser@>=1.14.0 <1.15.0",
+      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.2.0",
-          "from": "bytes@2.2.0",
+          "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
         "content-type": {
           "version": "1.0.2",
-          "from": "content-type@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "depd": {
           "version": "1.1.0",
-          "from": "depd@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "http-errors": {
           "version": "1.3.1",
-          "from": "http-errors@>=1.3.1 <1.4.0",
+          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "statuses": {
               "version": "1.3.0",
-              "from": "statuses@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
             }
           }
         },
         "iconv-lite": {
           "version": "0.4.13",
-          "from": "iconv-lite@0.4.13",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "on-finished@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "ee-first@1.1.1",
+              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "qs": {
           "version": "5.2.0",
-          "from": "qs@5.2.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
         },
         "raw-body": {
           "version": "2.1.7",
-          "from": "raw-body@>=2.1.5 <2.2.0",
+          "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "dependencies": {
             "bytes": {
               "version": "2.4.0",
-              "from": "bytes@2.4.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
             },
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@1.0.0",
+              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "type-is": {
           "version": "1.6.13",
-          "from": "type-is@>=1.6.10 <1.7.0",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@>=2.1.11 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
@@ -105,9 +105,9 @@
       }
     },
     "camshaft": {
-      "version": "0.46.2",
-      "from": "camshaft@0.46.2",
-      "resolved": "https://registry.npmjs.org/camshaft/-/camshaft-0.46.2.tgz",
+      "version": "0.46.3",
+      "from": "camshaft@0.46.3",
+      "resolved": "https://registry.npmjs.org/camshaft/-/camshaft-0.46.3.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -240,9 +240,9 @@
           }
         },
         "request": {
-          "version": "2.76.0",
+          "version": "2.78.0",
           "from": "request@>=2.69.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
@@ -587,22 +587,22 @@
     },
     "cartodb-psql": {
       "version": "0.6.1",
-      "from": "cartodb-psql@>=0.6.1 <0.7.0",
+      "from": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.6.1.tgz",
       "dependencies": {
         "pg": {
           "version": "2.6.2-cdb3",
-          "from": "git://github.com/CartoDB/node-postgres.git#2.6.2-cdb3",
+          "from": "git://github.com/CartoDB/node-postgres.git#069c5296d1a093077feff21719641bb9e71fc50e",
           "resolved": "git://github.com/CartoDB/node-postgres.git#069c5296d1a093077feff21719641bb9e71fc50e",
           "dependencies": {
             "generic-pool": {
               "version": "2.0.3",
-              "from": "generic-pool@2.0.3",
+              "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz"
             },
             "buffer-writer": {
               "version": "1.0.0",
-              "from": "buffer-writer@1.0.0",
+              "from": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
             }
           }
@@ -611,255 +611,255 @@
     },
     "cartodb-query-tables": {
       "version": "0.1.0",
-      "from": "cartodb-query-tables@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/cartodb-query-tables/-/cartodb-query-tables-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cartodb-query-tables/-/cartodb-query-tables-0.1.0.tgz"
     },
     "cartodb-redis": {
       "version": "0.13.1",
-      "from": "cartodb-redis@0.13.1",
+      "from": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-0.13.1.tgz",
       "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-0.13.1.tgz"
     },
     "debug": {
       "version": "2.2.0",
-      "from": "debug@>=2.2.0 <2.3.0",
+      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "dependencies": {
         "ms": {
           "version": "0.7.1",
-          "from": "ms@0.7.1",
+          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
     },
     "dot": {
       "version": "1.0.3",
-      "from": "dot@>=1.0.2 <1.1.0",
+      "from": "https://registry.npmjs.org/dot/-/dot-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/dot/-/dot-1.0.3.tgz"
     },
     "express": {
       "version": "4.13.4",
-      "from": "express@>=4.13.3 <4.14.0",
+      "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.2.13",
-          "from": "accepts@>=1.2.12 <1.3.0",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@>=2.1.6 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.5.3",
-              "from": "negotiator@0.5.3",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
             }
           }
         },
         "array-flatten": {
           "version": "1.1.1",
-          "from": "array-flatten@1.1.1",
+          "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
         },
         "content-disposition": {
           "version": "0.5.1",
-          "from": "content-disposition@0.5.1",
+          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
         },
         "content-type": {
           "version": "1.0.2",
-          "from": "content-type@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "cookie": {
           "version": "0.1.5",
-          "from": "cookie@0.1.5",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
+          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "depd": {
           "version": "1.1.0",
-          "from": "depd@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "escape-html@>=1.0.3 <1.1.0",
+          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "etag": {
           "version": "1.7.0",
-          "from": "etag@>=1.7.0 <1.8.0",
+          "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
         "finalhandler": {
           "version": "0.4.1",
-          "from": "finalhandler@0.4.1",
+          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "fresh": {
           "version": "0.3.0",
-          "from": "fresh@0.3.0",
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.1",
-          "from": "merge-descriptors@1.0.1",
+          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
         },
         "methods": {
           "version": "1.1.2",
-          "from": "methods@>=1.1.2 <1.2.0",
+          "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "on-finished@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "ee-first@1.1.1",
+              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.1",
-          "from": "parseurl@>=1.3.1 <1.4.0",
+          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "from": "path-to-regexp@0.1.7",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
         },
         "proxy-addr": {
           "version": "1.0.10",
-          "from": "proxy-addr@>=1.0.10 <1.1.0",
+          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "forwarded@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
               "version": "1.0.5",
-              "from": "ipaddr.js@1.0.5",
+              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
             }
           }
         },
         "qs": {
           "version": "4.0.0",
-          "from": "qs@4.0.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
         },
         "range-parser": {
           "version": "1.0.3",
-          "from": "range-parser@>=1.0.3 <1.1.0",
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
         },
         "send": {
           "version": "0.13.1",
-          "from": "send@0.13.1",
+          "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
           "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
-              "from": "destroy@>=1.0.4 <1.1.0",
+              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
-              "from": "http-errors@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "statuses": {
               "version": "1.2.1",
-              "from": "statuses@>=1.2.1 <1.3.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.10.3",
-          "from": "serve-static@>=1.10.2 <1.11.0",
+          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
           "dependencies": {
             "send": {
               "version": "0.13.2",
-              "from": "send@0.13.2",
+              "from": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
               "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
               "dependencies": {
                 "destroy": {
                   "version": "1.0.4",
-                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                 },
                 "http-errors": {
                   "version": "1.3.1",
-                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "mime@1.3.4",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
@@ -868,22 +868,22 @@
         },
         "type-is": {
           "version": "1.6.13",
-          "from": "type-is@>=1.6.6 <1.7.0",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@>=2.1.6 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
@@ -892,118 +892,118 @@
         },
         "utils-merge": {
           "version": "1.0.0",
-          "from": "utils-merge@1.0.0",
+          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         },
         "vary": {
           "version": "1.0.1",
-          "from": "vary@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
         }
       }
     },
     "fastly-purge": {
       "version": "1.0.1",
-      "from": "fastly-purge@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/fastly-purge/-/fastly-purge-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/fastly-purge/-/fastly-purge-1.0.1.tgz"
     },
     "log4js": {
       "version": "0.6.25",
-      "from": "cartodb/log4js-node#cdb",
+      "from": "git://github.com/cartodb/log4js-node.git#145d5f91e35e7fb14a6278cbf7a711ced6603727",
       "resolved": "git://github.com/cartodb/log4js-node.git#145d5f91e35e7fb14a6278cbf7a711ced6603727",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
-          "from": "readable-stream@>=1.0.2 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.3.3 <4.4.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "underscore": {
           "version": "1.8.2",
-          "from": "underscore@1.8.2",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz"
         }
       }
     },
     "lru-cache": {
       "version": "2.6.5",
-      "from": "lru-cache@2.6.5",
+      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
     },
     "lzma": {
       "version": "2.3.2",
-      "from": "lzma@>=2.3.2 <2.4.0",
+      "from": "https://registry.npmjs.org/lzma/-/lzma-2.3.2.tgz",
       "resolved": "https://registry.npmjs.org/lzma/-/lzma-2.3.2.tgz"
     },
     "node-statsd": {
       "version": "0.0.7",
-      "from": "node-statsd@>=0.0.7 <0.1.0",
+      "from": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.0.7.tgz"
     },
     "queue-async": {
       "version": "1.0.7",
-      "from": "queue-async@>=1.0.7 <1.1.0",
+      "from": "https://registry.npmjs.org/queue-async/-/queue-async-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.0.7.tgz"
     },
     "redis-mpool": {
       "version": "0.4.0",
-      "from": "redis-mpool@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.4.0.tgz",
       "dependencies": {
         "generic-pool": {
           "version": "2.1.1",
-          "from": "generic-pool@>=2.1.1 <2.2.0",
+          "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
         },
         "redis": {
           "version": "0.12.1",
-          "from": "redis@>=0.12.1 <0.13.0",
+          "from": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz",
           "resolved": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz"
         },
         "hiredis": {
           "version": "0.1.17",
-          "from": "hiredis@>=0.1.17 <0.2.0",
+          "from": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
           "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
           "dependencies": {
             "bindings": {
               "version": "1.2.1",
-              "from": "bindings@*",
+              "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
             },
             "nan": {
               "version": "1.1.2",
-              "from": "nan@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
             }
           }
@@ -1012,47 +1012,47 @@
     },
     "request": {
       "version": "2.62.0",
-      "from": "request@>=2.62.0 <2.63.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.62.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.62.0.tgz",
       "dependencies": {
         "bl": {
           "version": "1.0.3",
-          "from": "bl@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
-              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -1061,32 +1061,32 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "from": "caseless@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "extend": {
           "version": "3.0.0",
-          "from": "extend@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.1",
-          "from": "form-data@>=1.0.0-rc1 <1.1.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "dependencies": {
             "async": {
               "version": "2.1.2",
-              "from": "async@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "4.16.4",
-                  "from": "lodash@>=4.14.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz"
                 }
               }
@@ -1095,220 +1095,220 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "2.1.12",
-          "from": "mime-types@>=2.1.2 <2.2.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.24.0",
-              "from": "mime-db@>=1.24.0 <1.25.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
+          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "qs": {
           "version": "5.1.0",
-          "from": "qs@>=5.1.0 <5.2.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.3",
-          "from": "tunnel-agent@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         },
         "tough-cookie": {
           "version": "2.3.1",
-          "from": "tough-cookie@>=0.12.0",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
         },
         "http-signature": {
           "version": "0.11.0",
-          "from": "http-signature@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11",
+              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.3",
-              "from": "ctype@0.5.3",
+              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.0 <0.9.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "hawk@>=3.1.0 <3.2.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
-              "from": "hoek@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "boom@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "stringstream@>=0.0.4 <0.1.0",
+          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "delayed-stream@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "har-validator": {
           "version": "1.8.0",
-          "from": "har-validator@>=1.6.1 <2.0.0",
+          "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
           "dependencies": {
             "bluebird": {
               "version": "2.11.0",
-              "from": "bluebird@>=2.9.30 <3.0.0",
+              "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
             },
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
-              "from": "commander@>=2.8.1 <3.0.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.15.0",
-              "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "4.0.0",
-                  "from": "jsonpointer@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -1319,79 +1319,79 @@
     },
     "step": {
       "version": "0.0.6",
-      "from": "step@>=0.0.6 <0.1.0",
+      "from": "https://registry.npmjs.org/step/-/step-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/step/-/step-0.0.6.tgz"
     },
     "step-profiler": {
       "version": "0.3.0",
-      "from": "step-profiler@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/step-profiler/-/step-profiler-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/step-profiler/-/step-profiler-0.3.0.tgz"
     },
     "turbo-carto": {
       "version": "0.18.0",
-      "from": "turbo-carto@0.18.0",
+      "from": "https://registry.npmjs.org/turbo-carto/-/turbo-carto-0.18.0.tgz",
       "resolved": "https://registry.npmjs.org/turbo-carto/-/turbo-carto-0.18.0.tgz",
       "dependencies": {
         "colorbrewer": {
           "version": "1.0.0",
-          "from": "colorbrewer@1.0.0",
+          "from": "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.0.0.tgz"
         },
         "cartocolor": {
           "version": "3.0.0",
-          "from": "cartocolor@3.0.0",
+          "from": "https://registry.npmjs.org/cartocolor/-/cartocolor-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/cartocolor/-/cartocolor-3.0.0.tgz"
         },
         "es6-promise": {
           "version": "3.1.2",
-          "from": "es6-promise@3.1.2",
+          "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
         },
         "postcss": {
           "version": "5.0.19",
-          "from": "postcss@5.0.19",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
           "dependencies": {
             "supports-color": {
               "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.5.6",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         },
         "postcss-value-parser": {
           "version": "3.3.0",
-          "from": "postcss-value-parser@3.3.0",
+          "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
         }
       }
     },
     "underscore": {
       "version": "1.6.0",
-      "from": "underscore@>=1.6.0 <1.7.0",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
     },
     "windshaft": {
-      "version": "2.6.1",
-      "from": "windshaft@2.6.1",
-      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-2.6.1.tgz",
+      "version": "2.6.2",
+      "from": "windshaft@2.6.2",
+      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-2.6.2.tgz",
       "dependencies": {
         "abaculus": {
           "version": "1.1.0-cdb7",
@@ -4335,61 +4335,61 @@
     },
     "yargs": {
       "version": "5.0.0",
-      "from": "yargs@>=5.0.0 <5.1.0",
+      "from": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
       "dependencies": {
         "cliui": {
           "version": "3.2.0",
-          "from": "cliui@>=3.2.0 <4.0.0",
+          "from": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.1 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "wrap-ansi": {
               "version": "2.0.0",
-              "from": "wrap-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
             }
           }
         },
         "decamelize": {
           "version": "1.2.0",
-          "from": "decamelize@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "from": "get-caller-file@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
         },
         "lodash.assign": {
           "version": "4.2.0",
-          "from": "lodash.assign@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
         },
         "os-locale": {
           "version": "1.4.0",
-          "from": "os-locale@>=1.4.0 <2.0.0",
+          "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "dependencies": {
             "lcid": {
               "version": "1.0.0",
-              "from": "lcid@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
               "dependencies": {
                 "invert-kv": {
                   "version": "1.0.0",
-                  "from": "invert-kv@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                 }
               }
@@ -4398,27 +4398,27 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "from": "read-pkg-up@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "from": "find-up@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "dependencies": {
                 "path-exists": {
                   "version": "2.1.0",
-                  "from": "path-exists@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
@@ -4427,32 +4427,32 @@
             },
             "read-pkg": {
               "version": "1.1.0",
-              "from": "read-pkg@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
               "dependencies": {
                 "load-json-file": {
                   "version": "1.1.0",
-                  "from": "load-json-file@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.9",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
                     },
                     "parse-json": {
                       "version": "2.2.0",
-                      "from": "parse-json@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                       "dependencies": {
                         "error-ex": {
                           "version": "1.3.0",
-                          "from": "error-ex@>=1.2.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                           "dependencies": {
                             "is-arrayish": {
                               "version": "0.2.1",
-                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                              "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                             }
                           }
@@ -4461,29 +4461,29 @@
                     },
                     "pify": {
                       "version": "2.3.0",
-                      "from": "pify@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
                     },
                     "strip-bom": {
                       "version": "2.0.0",
-                      "from": "strip-bom@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                       "dependencies": {
                         "is-utf8": {
                           "version": "0.2.1",
-                          "from": "is-utf8@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                         }
                       }
@@ -4492,51 +4492,51 @@
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.5",
-                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
-                          "from": "builtin-modules@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.3.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.4",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
                         }
                       }
@@ -4545,27 +4545,27 @@
                 },
                 "path-type": {
                   "version": "1.1.0",
-                  "from": "path-type@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.9",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
                     },
                     "pify": {
                       "version": "2.3.0",
-                      "from": "pify@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
@@ -4578,56 +4578,56 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "from": "require-directory@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "from": "require-main-filename@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
         },
         "set-blocking": {
           "version": "2.0.0",
-          "from": "set-blocking@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
         },
         "string-width": {
           "version": "1.0.2",
-          "from": "string-width@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "dependencies": {
             "code-point-at": {
               "version": "1.0.1",
-              "from": "code-point-at@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.1",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                 }
               }
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.1",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.1 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
@@ -4636,27 +4636,27 @@
         },
         "which-module": {
           "version": "1.0.0",
-          "from": "which-module@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
         },
         "window-size": {
           "version": "0.2.0",
-          "from": "window-size@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
         },
         "y18n": {
           "version": "3.2.1",
-          "from": "y18n@>=3.2.1 <4.0.0",
+          "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
         },
         "yargs-parser": {
           "version": "3.2.0",
-          "from": "yargs-parser@>=3.2.0 <4.0.0",
+          "from": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "from": "camelcase@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
             }
           }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "body-parser": "~1.14.0",
-    "camshaft": "0.46.2",
+    "camshaft": "0.46.3",
     "cartodb-psql": "~0.6.1",
     "cartodb-query-tables": "~0.1.0",
     "cartodb-redis": "0.13.1",
@@ -39,7 +39,7 @@
     "step-profiler": "~0.3.0",
     "turbo-carto": "0.18.0",
     "underscore": "~1.6.0",
-    "windshaft": "2.6.1",
+    "windshaft": "2.6.2",
     "yargs": "~5.0.0"
   },
   "devDependencies": {

--- a/test/acceptance/ported/multilayer_error_cases.js
+++ b/test/acceptance/ported/multilayer_error_cases.js
@@ -257,7 +257,7 @@ describe('multilayer error cases', function() {
             layers: [
                 { options: {
                     sql: 'select * from test_table limit 1',
-                    cartocss: '#test_table::outline[nonexistent="one"], [nonexistent="two"] { marker-fill: red; }',
+                    cartocss: '#test_table::outline[address="one"], [address="two"] { marker-fill: red; }',
                     cartocss_version: '2.0.2',
                     interactivity: [ 'cartodb_id' ],
                     geom_column: 'the_geom'
@@ -282,7 +282,7 @@ describe('multilayer error cases', function() {
             var parsed = JSON.parse(res.body);
             assert.equal(parsed.errors.length, 1);
             var error = parsed.errors[0];
-            assert.ok(error.match(/column "nonexistent" does not exist/m), error);
+            assert.ok(error.match(/column "address" does not exist/m), error);
             done();
         });
     });


### PR DESCRIPTION
- Upgrades Windshaft to 2.6.2 (fix keeping alive layergroups for basemaps)
- Upgrades Camshaft to 0.46.3 (fix https://github.com/CartoDB/cartodb/issues/10443)
