### PR TITLE
Allow to set resource URL templates with substitution tokens

### DIFF
--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -23,6 +23,21 @@ var config = {
     // "tiles/layergroup" is for compatibility with versions up to 1.6.x
     ,base_url_detached: '(?:/api/v1/map|/user/:user/api/v1/map|/tiles/layergroup)'
 
+    // Resource URLs expose endpoints to request/retrieve metadata associated to Maps: dataviews, analysis node status.
+    //
+    // This URLs depend on how `base_url_detached` and `user_from_host` are configured: the application can be
+    // configured to accept request with the {user} in the header host or in the request path.
+    // It also might depend on the configured cdn_url via `serverMetadata.cdn_url`.
+    //
+    // This template allows to make the endpoints generation more flexible, the template exposes the following params:
+    //  1. {{=it.cdn_url}}: will be used when `serverMetadata.cdn_url` exists.
+    //  2. {{=it.user}}: will use the username as extraced from `user_from_host` or `base_url_detached`.
+    //  3. {{=it.port}}: will use the `port` from this very same configuration file.
+    ,resources_url_templates: {
+        http: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map',
+        https: 'https://{{=it.cdn_url}}/{{=it.user}}/api/v1/map'
+    }
+
     // Maximum number of connections for one process
     // 128 is a good value with a limit of 1024 open file descriptors
     ,maxConnections:128

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -35,7 +35,7 @@ var config = {
     //  3. {{=it.port}}: will use the `port` from this very same configuration file.
     ,resources_url_templates: {
         http: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map',
-        https: 'https://{{=it.cdn_url}}/{{=it.user}}/api/v1/map'
+        https: 'http://localhost.lan:{{=it.port}}/user/{{=it.user}}/api/v1/map'
     }
 
     // Maximum number of connections for one process

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -23,6 +23,21 @@ var config = {
     // "tiles/layergroup" is for compatibility with versions up to 1.6.x
     ,base_url_detached: '(?:/api/v1/map|/user/:user/api/v1/map|/tiles/layergroup)'
 
+    // Resource URLs expose endpoints to request/retrieve metadata associated to Maps: dataviews, analysis node status.
+    //
+    // This URLs depend on how `base_url_detached` and `user_from_host` are configured: the application can be
+    // configured to accept request with the {user} in the header host or in the request path.
+    // It also might depend on the configured cdn_url via `serverMetadata.cdn_url`.
+    //
+    // This template allows to make the endpoints generation more flexible, the template exposes the following params:
+    //  1. {{=it.cdn_url}}: will be used when `serverMetadata.cdn_url` exists.
+    //  2. {{=it.user}}: will use the username as extraced from `user_from_host` or `base_url_detached`.
+    //  3. {{=it.port}}: will use the `port` from this very same configuration file.
+    ,resources_url_templates: {
+        http: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map',
+        https: 'https://{{=it.cdn_url}}/{{=it.user}}/api/v1/map'
+    }
+
     // Maximum number of connections for one process
     // 128 is a good value with a limit of 1024 open file descriptors
     ,maxConnections:128

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -34,7 +34,7 @@ var config = {
     //  2. {{=it.user}}: will use the username as extraced from `user_from_host` or `base_url_detached`.
     //  3. {{=it.port}}: will use the `port` from this very same configuration file.
     ,resources_url_templates: {
-        http: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map',
+        http: 'http://{{=it.cdn_url}}/{{=it.user}}/api/v1/map',
         https: 'https://{{=it.cdn_url}}/{{=it.user}}/api/v1/map'
     }
 

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -23,6 +23,21 @@ var config = {
     // "/tiles/layergroup" is for compatibility with versions up to 1.6.x
     ,base_url_detached: '(?:/api/v1/map|/user/:user/api/v1/map|/tiles/layergroup)'
 
+    // Resource URLs expose endpoints to request/retrieve metadata associated to Maps: dataviews, analysis node status.
+    //
+    // This URLs depend on how `base_url_detached` and `user_from_host` are configured: the application can be
+    // configured to accept request with the {user} in the header host or in the request path.
+    // It also might depend on the configured cdn_url via `serverMetadata.cdn_url`.
+    //
+    // This template allows to make the endpoints generation more flexible, the template exposes the following params:
+    //  1. {{=it.cdn_url}}: will be used when `serverMetadata.cdn_url` exists.
+    //  2. {{=it.user}}: will use the username as extraced from `user_from_host` or `base_url_detached`.
+    //  3. {{=it.port}}: will use the `port` from this very same configuration file.
+    ,resources_url_templates: {
+        http: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map',
+        https: 'https://{{=it.cdn_url}}/{{=it.user}}/api/v1/map'
+    }
+
     // Maximum number of connections for one process
     // 128 is a good value with a limit of 1024 open file descriptors
     ,maxConnections:128

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -23,6 +23,21 @@ var config = {
     // "tiles/layergroup" is for compatibility with versions up to 1.6.x
     ,base_url_detached: '(?:/api/v1/map|/user/:user/api/v1/map|/tiles/layergroup)'
 
+    // Resource URLs expose endpoints to request/retrieve metadata associated to Maps: dataviews, analysis node status.
+    //
+    // This URLs depend on how `base_url_detached` and `user_from_host` are configured: the application can be
+    // configured to accept request with the {user} in the header host or in the request path.
+    // It also might depend on the configured cdn_url via `serverMetadata.cdn_url`.
+    //
+    // This template allows to make the endpoints generation more flexible, the template exposes the following params:
+    //  1. {{=it.cdn_url}}: will be used when `serverMetadata.cdn_url` exists.
+    //  2. {{=it.user}}: will use the username as extraced from `user_from_host` or `base_url_detached`.
+    //  3. {{=it.port}}: will use the `port` from this very same configuration file.
+    ,resources_url_templates: {
+        http: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map',
+        https: 'https://{{=it.cdn_url}}/{{=it.user}}/api/v1/map'
+    }
+
     // Maximum number of connections for one process
     // 128 is a good value with a limit of 1024 open file descriptors
     ,maxConnections:128

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -34,8 +34,7 @@ var config = {
     //  2. {{=it.user}}: will use the username as extraced from `user_from_host` or `base_url_detached`.
     //  3. {{=it.port}}: will use the `port` from this very same configuration file.
     ,resources_url_templates: {
-        http: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map',
-        https: 'https://{{=it.cdn_url}}/{{=it.user}}/api/v1/map'
+        http: 'http://{{=it.user}}.localhost.lan:{{=it.port}}/api/v1/map'
     }
 
     // Maximum number of connections for one process

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -1,4 +1,6 @@
 var _ = require('underscore');
+var dot = require('dot');
+dot.templateSettings.strip = false;
 var assert = require('assert');
 var step = require('step');
 var windshaft = require('windshaft');
@@ -44,6 +46,20 @@ function MapController(authApi, pgConnection, templateMaps, mapBackend, metadata
     this.layergroupAffectedTables = layergroupAffectedTables;
 
     this.mapConfigAdapter = mapConfigAdapter;
+
+    this.resourcesUrlTemplates = null;
+    if (global.environment.resources_url_templates) {
+        var templates = global.environment.resources_url_templates;
+
+        if (templates.http) {
+            this.resourcesUrlTemplates = this.resourcesUrlTemplates || {};
+            this.resourcesUrlTemplates.http = dot.template(templates.http + '/{{=it.resource}}');
+        }
+        if (templates.https) {
+            this.resourcesUrlTemplates = this.resourcesUrlTemplates || {};
+            this.resourcesUrlTemplates.https = dot.template(templates.https + '/{{=it.resource}}');
+        }
+    }
 }
 
 util.inherits(MapController, BaseController);
@@ -187,8 +203,8 @@ MapController.prototype.create = function(req, res, prepareConfigFn) {
                 self.sendError(req, res, err, 'ANONYMOUS LAYERGROUP');
             } else {
                 var analysesResults = context.analysesResults || [];
-                addDataviewsAndWidgetsUrls(req.context.user, layergroup, mapConfig.obj());
-                addAnalysesMetadata(req.context.user, layergroup, analysesResults, true);
+                self.addDataviewsAndWidgetsUrls(req.context.user, layergroup, mapConfig.obj());
+                self.addAnalysesMetadata(req.context.user, layergroup, analysesResults, true);
                 addContextMetadata(layergroup, mapConfig.obj(), context);
                 res.set('X-Layergroup-Id', layergroup.layergroupid);
                 self.send(req, res, layergroup, 200);
@@ -260,8 +276,8 @@ MapController.prototype.instantiateTemplate = function(req, res, prepareParamsFn
                 layergroup.layergroupid = cdbuser + '@' + templateHash + '@' + layergroup.layergroupid;
 
                 var _mapConfig = mapConfig.obj();
-                addDataviewsAndWidgetsUrls(cdbuser, layergroup, _mapConfig);
-                addAnalysesMetadata(cdbuser, layergroup, mapConfigProvider.analysesResults);
+                self.addDataviewsAndWidgetsUrls(cdbuser, layergroup, _mapConfig);
+                self.addAnalysesMetadata(cdbuser, layergroup, mapConfigProvider.analysesResults);
                 addContextMetadata(layergroup, _mapConfig, mapConfigProvider.context);
 
                 res.set('X-Layergroup-Id', layergroup.layergroupid);
@@ -370,7 +386,7 @@ function getLastUpdatedTime(analysesResults, lastUpdateTime) {
     }, lastUpdateTime);
 }
 
-function addAnalysesMetadata(username, layergroup, analysesResults, includeQuery) {
+MapController.prototype.addAnalysesMetadata = function(username, layergroup, analysesResults, includeQuery) {
     includeQuery = includeQuery || false;
     analysesResults = analysesResults || [];
     layergroup.metadata.analyses = [];
@@ -383,7 +399,7 @@ function addAnalysesMetadata(username, layergroup, analysesResults, includeQuery
                     var nodeResource = layergroup.layergroupid + '/analysis/node/' + node.id();
                     var nodeRepr = {
                         status: node.getStatus(),
-                        url: getUrls(username, nodeResource)
+                        url: this.getUrls(username, nodeResource)
                     };
                     if (includeQuery) {
                         nodeRepr.query = node.getQuery();
@@ -395,30 +411,30 @@ function addAnalysesMetadata(username, layergroup, analysesResults, includeQuery
                 }
 
                 return nodesIdMap;
-            }, {})
+            }.bind(this), {})
         });
-    });
-}
+    }.bind(this));
+};
 
 // TODO this should take into account several URL patterns
-function addDataviewsAndWidgetsUrls(username, layergroup, mapConfig) {
-    addDataviewsUrls(username, layergroup, mapConfig);
-    addWidgetsUrl(username, layergroup, mapConfig);
-}
+MapController.prototype.addDataviewsAndWidgetsUrls = function(username, layergroup, mapConfig) {
+    this.addDataviewsUrls(username, layergroup, mapConfig);
+    this.addWidgetsUrl(username, layergroup, mapConfig);
+};
 
-function addDataviewsUrls(username, layergroup, mapConfig) {
+MapController.prototype.addDataviewsUrls = function(username, layergroup, mapConfig) {
     layergroup.metadata.dataviews = layergroup.metadata.dataviews || {};
     var dataviews = mapConfig.dataviews || {};
 
     Object.keys(dataviews).forEach(function(dataviewName) {
         var resource = layergroup.layergroupid + '/dataview/' + dataviewName;
         layergroup.metadata.dataviews[dataviewName] = {
-            url: getUrls(username, resource)
+            url: this.getUrls(username, resource)
         };
-    });
-}
+    }.bind(this));
+};
 
-function addWidgetsUrl(username, layergroup, mapConfig) {
+MapController.prototype.addWidgetsUrl = function(username, layergroup, mapConfig) {
     if (layergroup.metadata && Array.isArray(layergroup.metadata.layers) && Array.isArray(mapConfig.layers)) {
         layergroup.metadata.layers = layergroup.metadata.layers.map(function(layer, layerIndex) {
             var mapConfigLayer = mapConfig.layers[layerIndex];
@@ -428,16 +444,19 @@ function addWidgetsUrl(username, layergroup, mapConfig) {
                     var resource = layergroup.layergroupid + '/' + layerIndex + '/widget/' + widgetName;
                     layer.widgets[widgetName] = {
                         type: mapConfigLayer.options.widgets[widgetName].type,
-                        url: getUrls(username, resource)
+                        url: this.getUrls(username, resource)
                     };
-                });
+                }.bind(this));
             }
             return layer;
-        });
+        }.bind(this));
     }
-}
+};
 
-function getUrls(username, resource) {
+MapController.prototype.getUrls = function(username, resource) {
+    if (this.resourcesUrlTemplates) {
+        return this.getUrlsFromTemplate(username, resource);
+    }
     var cdnUrl = global.environment.serverMetadata && global.environment.serverMetadata.cdn_url;
     if (cdnUrl) {
         return {
@@ -450,4 +469,29 @@ function getUrls(username, resource) {
             http: 'http://' + username + '.' + 'localhost.lan:' + port +  '/api/v1/map/' + resource
         };
     }
-}
+};
+
+MapController.prototype.getUrlsFromTemplate = function(username, resource) {
+    var urls = {};
+    var cdnUrl = global.environment.serverMetadata && global.environment.serverMetadata.cdn_url;
+
+    if (this.resourcesUrlTemplates.http) {
+        urls.http = this.resourcesUrlTemplates.http({
+            cdn_url: cdnUrl,
+            user: username,
+            port: global.environment.port,
+            resource: resource
+        });
+    }
+
+    if (this.resourcesUrlTemplates.https) {
+        urls.https = this.resourcesUrlTemplates.https({
+            cdn_url: cdnUrl,
+            user: username,
+            port: global.environment.port,
+            resource: resource
+        });
+    }
+
+    return urls;
+};

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -477,7 +477,7 @@ MapController.prototype.getUrlsFromTemplate = function(username, resource) {
 
     if (this.resourcesUrlTemplates.http) {
         urls.http = this.resourcesUrlTemplates.http({
-            cdn_url: cdnUrl,
+            cdn_url: cdnUrl.http,
             user: username,
             port: global.environment.port,
             resource: resource
@@ -486,7 +486,7 @@ MapController.prototype.getUrlsFromTemplate = function(username, resource) {
 
     if (this.resourcesUrlTemplates.https) {
         urls.https = this.resourcesUrlTemplates.https({
-            cdn_url: cdnUrl,
+            cdn_url: cdnUrl.https,
             user: username,
             port: global.environment.port,
             resource: resource

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -473,7 +473,7 @@ MapController.prototype.getUrls = function(username, resource) {
 
 MapController.prototype.getUrlsFromTemplate = function(username, resource) {
     var urls = {};
-    var cdnUrl = global.environment.serverMetadata && global.environment.serverMetadata.cdn_url;
+    var cdnUrl = global.environment.serverMetadata && global.environment.serverMetadata.cdn_url || {};
 
     if (this.resourcesUrlTemplates.http) {
         urls.http = this.resourcesUrlTemplates.http({


### PR DESCRIPTION
This closes #493.

@CartoDB/systems Do you think this could work for you?

cc @luisbosque 