### PR TITLE
[DNM] Proposal to use cache-control + surrogate-control

### DIFF
--- a/lib/cartodb/controllers/analyses.js
+++ b/lib/cartodb/controllers/analyses.js
@@ -23,7 +23,8 @@ AnalysesController.prototype.register = function(app) {
 };
 
 AnalysesController.prototype.sendResponse = function(req, res, resource) {
-    res.set('Cache-Control', 'public,max-age=10,must-revalidate');
+    res.set('Cache-Control', 'no-cache');
+    res.set('Surrogate-Control', 'max-age=10');
     this.send(req, res, resource, 200);
 };
 

--- a/lib/cartodb/controllers/layergroup.js
+++ b/lib/cartodb/controllers/layergroup.js
@@ -113,7 +113,8 @@ LayergroupController.prototype.analysisNodeStatus = function(req, res) {
                 self.sendError(req, res, err, 'GET NODE STATUS');
             } else {
                 self.sendResponse(req, res, nodeStatus, 200, {
-                    'Cache-Control': 'public,max-age=5',
+                    'Cache-Control': 'no-cache',
+                    'Surrogate-Control': 'max-age=5',
                     'Last-Modified': new Date().toUTCString()
                 });
             }

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -357,7 +357,8 @@ MapController.prototype.afterLayergroupCreate = function(req, res, mapconfig, la
 
             if (req.method === 'GET') {
                 var ttl = global.environment.varnish.layergroupTtl || 86400;
-                res.set('Cache-Control', 'public,max-age='+ttl+',must-revalidate');
+                res.set('Cache-Control', 'no-cache');
+                res.set('Surrogate-Control', 'max-age='+ttl);
                 res.set('Last-Modified', (new Date()).toUTCString());
                 res.set('X-Cache-Channel', result.getCacheChannel());
                 if (result.tables && result.tables.length > 0) {

--- a/lib/cartodb/controllers/named_maps.js
+++ b/lib/cartodb/controllers/named_maps.js
@@ -38,7 +38,8 @@ NamedMapsController.prototype.register = function(app) {
 NamedMapsController.prototype.sendResponse = function(req, res, resource, headers, namedMapProvider) {
     this.surrogateKeysCache.tag(res, new NamedMapsCacheEntry(req.context.user, namedMapProvider.getTemplateName()));
     res.set('Content-Type', headers['content-type'] || headers['Content-Type'] || 'image/png');
-    res.set('Cache-Control', 'public,max-age=7200,must-revalidate');
+    res.set('Cache-Control', 'no-cache');
+    res.set('Surrogate-Control', 'max-age=7200');
 
     var self = this;
 
@@ -53,7 +54,7 @@ NamedMapsController.prototype.sendResponse = function(req, res, resource, header
             }
             if (!result || !!result.tables) {
                 // we increase cache control as we can invalidate it
-                res.set('Cache-Control', 'public,max-age=31536000');
+                res.set('Surrogate-Control', 'max-age=31536000');
 
                 var lastModifiedDate;
                 if (Number.isFinite(result.lastUpdatedTime)) {

--- a/test/acceptance/analysis/analysis-layers.js
+++ b/test/acceptance/analysis/analysis-layers.js
@@ -318,7 +318,8 @@ describe('analysis-layers', function() {
 
             var headers = response.headers;
 
-            assert.equal(headers['cache-control'], 'public,max-age=5');
+            assert.equal(headers['cache-control'], 'no-cache');
+            assert.equal(headers['surrogate-control'], 'max-age=5');
 
             var lastModified = new Date(headers['last-modified']);
             var tenSecondsInMs = 1e5;

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -1265,7 +1265,8 @@ describe(suiteName, function() {
 
         assert.response(server, layergroupTtlRequest, layergroupTtlResponseExpectation,
             function(res) {
-                assert.equal(res.headers['cache-control'], 'public,max-age=86400,must-revalidate');
+                assert.equal(res.headers['cache-control'], 'no-cache');
+                assert.equal(res.headers['surrogate-control'], 'max-age=86400');
                 keysToDelete['map_cfg|' + LayergroupToken.parse(JSON.parse(res.body).layergroupid).token] = 0;
                 keysToDelete['user:localhost:mapviews:global'] = 5;
 
@@ -1280,7 +1281,8 @@ describe(suiteName, function() {
 
         assert.response(server, layergroupTtlRequest, layergroupTtlResponseExpectation,
             function(res) {
-                assert.equal(res.headers['cache-control'], 'public,max-age=' + layergroupTtl + ',must-revalidate');
+                assert.equal(res.headers['cache-control'], 'no-cache');
+                assert.equal(res.headers['surrogate-control'], 'max-age=' + layergroupTtl);
                 keysToDelete['map_cfg|' + LayergroupToken.parse(JSON.parse(res.body).layergroupid).token] = 0;
                 keysToDelete['user:localhost:mapviews:global'] = 5;
 


### PR DESCRIPTION
This is a proposal about changes in cache headers: cache-control + surrogate-control. This aims to fix https://github.com/CartoDB/cartodb/issues/11094 and fix https://github.com/CartoDB/cartodb/issues/11124.

Changes are based on this documentation: https://docs.fastly.com/guides/tutorials/cache-control-tutorial#when-cache-control-and-surrogate-control-headers-co-exist.

As an alternative to `Cache-Control: no-cache`, we could use `Cache-Control: max-age=0,must-revalidate` to avoid stale responses when the backend/cache layer fails to serve a response.

As stated above, this is just a proposal about the changes required in the headers. Once we agree on them, this, most likely, would require having a mechanism to use `Surrogate-Cache` header as an alternative to current implementation/behaviour.

cc @CartoDB/systems @javisantana @jorgesancha 