### PR TITLE
removed "default" text from Limits descriptions

### DIFF
--- a/docs/static_maps_api.md
+++ b/docs/static_maps_api.md
@@ -146,9 +146,9 @@ It is important to note that generated images are cached from the live data refe
 
 ### Limits
 
-* While images can encompass an entirety of a map, the default limit for pixel range is 8192 x 8192.
-* Image resolution by default is set to 72 DPI
-* JPEG quality by default is 85%
+* While images can encompass an entirety of a map, the limit for pixel range is 8192 x 8192.
+* Image resolution is set to 72 DPI
+* JPEG quality is 85%
 * Timeout limits for generating static maps are the same across CARTO Builder and CARTO Engine. It is important to ensure timely processing of queries.
 
 ## Examples


### PR DESCRIPTION
As per a customer Support inquiry, I removed "default" from the Static Maps Limits section, as it was confusing to the user that a default value could be changed.

@rochoa , okay to merge this minor edit?