### PR TITLE
Close timer for response preparation

### DIFF
--- a/lib/cartodb/controllers/layergroup.js
+++ b/lib/cartodb/controllers/layergroup.js
@@ -338,6 +338,8 @@ LayergroupController.prototype.staticMap = function(req, res, width, height, zoo
 LayergroupController.prototype.sendResponse = function(req, res, body, status, headers) {
     var self = this;
 
+    req.profiler.done('res');
+
     res.set('Cache-Control', 'public,max-age=31536000');
 
     // Set Last-Modified header


### PR DESCRIPTION
Timer for affectedTables is taking everything from response timing,
adding a tag to represent all the response preparation.
That way affectedTables only represents the time for retrieving the
affected tables themselves.