### PR TITLE
added print attributions from Docs FAQs to Static Maps API content

### DIFF
--- a/docs/static_maps_api.md
+++ b/docs/static_maps_api.md
@@ -150,6 +150,10 @@ It is important to note that generated images are cached from the live data refe
 * Image resolution is set to 72 DPI
 * JPEG quality is 85%
 * Timeout limits for generating static maps are the same across CARTO Builder and CARTO Engine. It is important to ensure timely processing of queries.
+* If you are publishing your map as a static image with the API, you must manually add [attributions](https://carto.com/attribution) for your static map image. For example, add the following attribution code:
+
+{% highlight javascript %}attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attributions">CARTO</a>
+{% endhighlight %}
 
 ## Examples
 


### PR DESCRIPTION
Moving this tiny FAQ content to its rightful section, in the Static Maps API doc.  (@namessanti , as discussed).  Needed for a cross-reference in a Guide.