### PR TITLE
Do not assert inside assert.response

### DIFF
--- a/test/support/assert.js
+++ b/test/support/assert.js
@@ -126,22 +126,25 @@ assert.response = function(server, req, res, callback) {
                 // Assert response body
                 if (res.body) {
                     var eql = res.body instanceof RegExp ? res.body.test(response.body) : res.body === response.body;
-                    assert.ok(
-                        eql,
-                        colorize('[red]{Invalid response body.}\n' +
+                    if (!eql) {
+                        return callback(response, new Error(colorize(
+                            '[red]{Invalid response body.}\n' +
                             '     Expected: [green]{' + res.body + '}\n' +
-                            '     Got: [red]{' + response.body + '}')
-                    );
+                            '     Got: [red]{' + response.body + '}'))
+                        );
+                    }
                 }
 
                 // Assert response status
                 if (typeof status === 'number') {
-                    assert.equal(response.statusCode, status,
-                        colorize('[red]{Invalid response status code.}\n' +
+                    if (response.statusCode != status) {
+                        return callback(response, new Error(colorize(
+                            '[red]{Invalid response status code.}\n' +
                             '     Expected: [green]{' + status + '}\n' +
                             '     Got: [red]{' + response.statusCode + '}\n' +
-                            '     Body: ' + response.body)
-                    );
+                            '     Body: ' + response.body))
+                        );
+                    }
                 }
 
                 // Assert response headers
@@ -152,11 +155,13 @@ assert.response = function(server, req, res, callback) {
                             actual = response.headers[name.toLowerCase()],
                             expected = res.headers[name],
                             headerEql = expected instanceof RegExp ? expected.test(actual) : expected === actual;
-                        assert.ok(headerEql,
-                            colorize('Invalid response header [bold]{' + name + '}.\n' +
+                        if (!headerEql) {
+                            return callback(response, new Error(colorize(
+                                'Invalid response header [bold]{' + name + '}.\n' +
                                 '     Expected: [green]{' + expected + '}\n' +
-                                '     Got: [red]{' + actual + '}')
-                        );
+                                '     Got: [red]{' + actual + '}'))
+                            );
+                        }
                     }
                 }
 

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -617,18 +617,20 @@ TestClient.prototype.getLayergroup = function(expectedResponse, callback) {
         },
         expectedResponse,
         function(res, err) {
+            // If there is a response, we are still interested in catching the created keys
+            // to be able to delete them on the .drain() method.
+            if (res) {
+                var parsedBody = JSON.parse(res.body);
+                if (parsedBody.layergroupid) {
+                    self.keysToDelete['map_cfg|' + LayergroupToken.parse(parsedBody.layergroupid).token] = 0;
+                    self.keysToDelete['user:localhost:mapviews:global'] = 5;
+                }
+            }
             if (err) {
                 return callback(err);
             }
 
-            var parsedBody = JSON.parse(res.body);
-
-            if (parsedBody.layergroupid) {
-                self.keysToDelete['map_cfg|' + LayergroupToken.parse(parsedBody.layergroupid).token] = 0;
-                self.keysToDelete['user:localhost:mapviews:global'] = 5;
-            }
-
-            return callback(null, parsedBody);
+            return callback(null, JSON.parse(res.body));
         }
     );
 };


### PR DESCRIPTION
Preferably we should put response outside of assert and change its callback signature. However, I don't think it is worth the effort right now.

`Test-Client` should take advantage of the change to capture responses that were expected to be status>399 but ended being status~200, that way it's still possible to prune keys from Redis, not leaving the storage inconsistent between tests.

An instance of this situation: https://travis-ci.org/CartoDB/Windshaft-cartodb/builds/236337027.
The test fails because it expects a 400 error, however, the requests successes with a 200, but it's not able to prune the Redis keys because of the execution halts due to the `assert.equal` throws inside `assert.response`.