### PR TITLE
Add test to detect and fix incorrect bbox filter splitting

### DIFF
--- a/lib/cartodb/models/filter/bbox.js
+++ b/lib/cartodb/models/filter/bbox.js
@@ -66,7 +66,8 @@ function getBoundingBoxes(west, south, east, north) {
         bboxes.push([west, south, east, north]);
     } else {
         bboxes.push([west, south, 180, north]);
-        bboxes.push([-180, south, east % 180, north]);
+        // here we assume west,east have been adjusted => west >= -180 => east > 180
+        bboxes.push([-180, south, east - 360, north]);
     }
 
     return bboxes;

--- a/test/unit/cartodb/model/filter/bbox-filters.test.js
+++ b/test/unit/cartodb/model/filter/bbox-filters.test.js
@@ -111,6 +111,23 @@ describe('Bounding box filter', function() {
                 createRef([-180, -45, 0, 45])
             );
         });
+
+        it('generating multiple bbox', function() {
+            var bbox = [90, -45, 190, 45];
+            var bboxFilter = createFilter(bbox);
+
+            assert.equal(bboxFilter.bboxes.length, 2);
+
+            assert.deepEqual(
+                bboxFilter.bboxes[0],
+                createRef([90, -45, 180, 45])
+            );
+            assert.deepEqual(
+                bboxFilter.bboxes[1],
+                createRef([-180, -45, -170, 45])
+            );
+        });
+
     });
 
     describe('out of bounds', function() {


### PR DESCRIPTION
When bbox crosses date line and is split in two, the eastern box wasn't correct

Fixes #694.