### PR TITLE
replace timezone => offset

### DIFF
--- a/lib/cartodb/backends/dataview.js
+++ b/lib/cartodb/backends/dataview.js
@@ -104,7 +104,7 @@ function getQueryRewriteData(mapConfig, dataviewDefinition, params) {
 }
 
 function getOverrideParams(params, ownFilter) {
-    var overrideParams = _.reduce(_.pick(params, 'start', 'end', 'bins', 'timezone'),
+    var overrideParams = _.reduce(_.pick(params, 'start', 'end', 'bins', 'offset'),
         function castNumbers(overrides, val, k) {
             if (!Number.isFinite(+val)) {
                 throw new Error('Invalid number format for parameter \'' + k + '\'');

--- a/lib/cartodb/controllers/layergroup.js
+++ b/lib/cartodb/controllers/layergroup.js
@@ -89,7 +89,7 @@ LayergroupController.prototype.register = function(app) {
         'column_type', // string
         'bins', // number
         'aggregation', //string
-        'timezone', // number
+        'offset', // number
         'q' // widgets search
     ];
 

--- a/lib/cartodb/models/dataview/histogram.js
+++ b/lib/cartodb/models/dataview/histogram.js
@@ -145,9 +145,9 @@ var dateBasicsQueryTpl = dot.template([
     '        min(date_part(\'epoch\', {{=it._column}})) AS min_val,',
     '        avg(date_part(\'epoch\', {{=it._column}})) AS avg_val,',
     '        min(date_trunc(',
-    '           \'{{=it._aggregation}}\', {{=it._column}} AT TIME ZONE \'{{=it._timezone}}\'',
+    '           \'{{=it._aggregation}}\', {{=it._column}} AT TIME ZONE \'{{=it._offset}}\'',
     '        )) AS start_date,',
-    '        max({{=it._column}} AT TIME ZONE \'{{=it._timezone}}\') AS end_date,',
+    '        max({{=it._column}} AT TIME ZONE \'{{=it._offset}}\') AS end_date,',
     '        count(1) AS total_rows',
     '    FROM ({{=it._query}}) _cdb_basics',
     ')'
@@ -162,11 +162,11 @@ var dateOverrideBasicsQueryTpl = dot.template([
     '        min(',
     '           date_trunc(',
     '               \'{{=it._aggregation}}\',',
-    '               TO_TIMESTAMP({{=it._start}})::timestamp AT TIME ZONE \'{{=it._timezone}}\'',
+    '               TO_TIMESTAMP({{=it._start}})::timestamp AT TIME ZONE \'{{=it._offset}}\'',
     '           )',
     '        ) AS start_date,',
     '        max(',
-    '           TO_TIMESTAMP({{=it._end}})::timestamp AT TIME ZONE \'{{=it._timezone}}\'',
+    '           TO_TIMESTAMP({{=it._end}})::timestamp AT TIME ZONE \'{{=it._offset}}\'',
     '        ) AS end_date,',
     '        count(1) AS total_rows',
     '    FROM ({{=it._query}}) _cdb_basics',
@@ -201,7 +201,7 @@ var dateHistogramQueryTpl = dot.template([
     '      THEN 0',
     '      ELSE GREATEST(1, LEAST(',
     '        WIDTH_BUCKET(',
-    '          {{=it._column}}::timestamp AT TIME ZONE \'{{=it._timezone}}\',',
+    '          {{=it._column}}::timestamp AT TIME ZONE \'{{=it._offset}}\',',
     '          bins_array',
     '        ),',
     '        bins_number',
@@ -212,7 +212,7 @@ var dateHistogramQueryTpl = dot.template([
     '           \'epoch\', ',
     '           date_trunc(',
     '               \'{{=it._aggregation}}\', {{=it._column}}::timestamptz',
-    '           ) AT TIME ZONE \'{{=it._timezone}}\'',
+    '           ) AT TIME ZONE \'{{=it._offset}}\'',
     '       )',
     '    )::numeric AS timestamp,',
     '    min(date_part(\'epoch\', {{=it._column}}))::numeric AS min,',
@@ -243,7 +243,7 @@ Time series:
     options: {
         column: 'date', // column data type: date
         aggregation: 'day' // OPTIONAL (if undefined then it'll be built as numeric)
-        timezone: -7200 // OPTIONAL (UTC offset in seconds)
+        offset: -7200 // OPTIONAL (UTC offset in seconds)
     }
  }
  */
@@ -257,7 +257,7 @@ function Histogram(query, options, queries) {
     this.column = options.column;
     this.bins = options.bins;
     this.aggregation = options.aggregation;
-    this.timezone = options.timezone;
+    this.offset = options.offset;
 
     this._columnType = null;
 }
@@ -380,7 +380,7 @@ Histogram.prototype._buildDateHistogramQuery = function (psql, override, callbac
     var _column = this.column;
     var _query = this.query;
     var _aggregation = override && override.aggregation ? override.aggregation : this.aggregation;
-    var _timezone = override && Number.isFinite(override.timezone) ? override.timezone : this.timezone;
+    var _offset = override && Number.isFinite(override.offset) ? override.offset : this.offset;
 
     if (!_aggregation) {
         this.getAutomaticAggregation(psql, function (err, aggregation) {
@@ -403,14 +403,14 @@ Histogram.prototype._buildDateHistogramQuery = function (psql, override, callbac
             _aggregation: _aggregation,
             _start: getBinStart(override),
             _end: getBinEnd(override),
-            _timezone: getTimezone(_timezone, _aggregation)
+            _offset: getOffset(_offset, _aggregation)
         });
     } else {
         dateBasicsQuery = dateBasicsQueryTpl({
             _query: _query,
             _column: _column,
             _aggregation: _aggregation,
-            _timezone: getTimezone(_timezone, _aggregation)
+            _offset: getOffset(_offset, _aggregation)
         });
     }
 
@@ -429,7 +429,7 @@ Histogram.prototype._buildDateHistogramQuery = function (psql, override, callbac
         _query: _query,
         _column: _column,
         _aggregation: _aggregation,
-        _timezone: getTimezone(_timezone, _aggregation)
+        _offset: getOffset(_offset, _aggregation)
     });
 
     var histogramSql = [
@@ -492,7 +492,7 @@ Histogram.prototype.format = function(result, override) {
     var buckets = [];
 
     var aggregation = getAggregation(override, this.aggregation);
-    var timezone = getTimezoneParam(override, this.timezone);
+    var offset = getOffsetParam(override, this.offset);
     var binsCount = getBinsCount(override);
     var width = getWidth(override);
     var binsStart = getBinStart(override);
@@ -514,7 +514,7 @@ Histogram.prototype.format = function(result, override) {
 
     return {
         aggregation: aggregation,
-        timezone: timezone,
+        offset: offset,
         bin_width: width,
         bins_count: binsCount,
         bins_start: binsStart,
@@ -528,12 +528,12 @@ function getAggregation(override, aggregation) {
     return override && override.aggregation ? override.aggregation : aggregation;
 }
 
-function getTimezoneParam(override, timezone) {
-    if (override && override.timezone) {
-        return override.timezone;
+function getOffsetParam(override, offset) {
+    if (override && override.offset) {
+        return override.offset;
     }
-    if (timezone) {
-        return timezone;
+    if (offset) {
+        return offset;
     }
     return 0;
 }
@@ -567,8 +567,8 @@ function getWidth(override) {
     return width;
 }
 
-function getTimezone(timezone, aggregation) {
-    if (!timezone) {
+function getOffset(offset, aggregation) {
+    if (!offset) {
         return '0';
     }
 
@@ -576,8 +576,8 @@ function getTimezone(timezone, aggregation) {
         return '0';
     }
 
-    var timezoneInHours = Math.ceil(timezone / 3600);
-    return '' + timezoneInHours;
+    var offsetInHours = Math.ceil(offset / 3600);
+    return '' + offsetInHours;
 }
 
 function populateBinStart(override, firstRow) {

--- a/test/acceptance/dataviews/histogram.js
+++ b/test/acceptance/dataviews/histogram.js
@@ -132,7 +132,7 @@ describe('histogram-dataview for date column type', function() {
                 options: {
                     column: 'd',
                     aggregation: 'month',
-                    timezone: -14400 // EDT Eastern Daylight Time (GMT-4) in seconds
+                    offset: -14400 // EDT Eastern Daylight Time (GMT-4) in seconds
                 }
             },
             datetime_histogram_tz: {
@@ -143,7 +143,7 @@ describe('histogram-dataview for date column type', function() {
                 options: {
                     column: 'd',
                     aggregation: 'month',
-                    timezone: -14400 // EDT Eastern Daylight Time (GMT-4) in seconds
+                    offset: -14400 // EDT Eastern Daylight Time (GMT-4) in seconds
                 }
             },
             datetime_histogram_automatic: {
@@ -238,16 +238,16 @@ describe('histogram-dataview for date column type', function() {
     );
 
     var dateHistogramsUseCases = [{
-        desc: 'supporting timestamp with timezone',
+        desc: 'supporting timestamp with offset',
         dataviewId: 'datetime_histogram_tz'
     }, {
-        desc: 'supporting timestamp without timezone',
+        desc: 'supporting timestamp without offset',
         dataviewId: 'datetime_histogram'
     }];
 
     dateHistogramsUseCases.forEach(function (test) {
         it('should create a date histogram aggregated in months (EDT) ' + test.desc, function (done) {
-            var TIMEZONE_EDT_IN_MINUTES = -4 * 60; // EDT Eastern Daylight Time (GMT-4) in minutes
+            var OFFSET_EDT_IN_MINUTES = -4 * 60; // EDT Eastern Daylight Time (GMT-4) in minutes
 
             this.testClient = new TestClient(mapConfig, 1234);
 
@@ -260,18 +260,18 @@ describe('histogram-dataview for date column type', function() {
                 var initialTimestamp = '2007-02-01T00:00:00-04:00'; // EDT midnight
                 var binsStartInMilliseconds = dataview.bins_start * 1000;
                 var binsStartFormatted = moment.utc(binsStartInMilliseconds)
-                    .utcOffset(TIMEZONE_EDT_IN_MINUTES)
+                    .utcOffset(OFFSET_EDT_IN_MINUTES)
                     .format();
                 assert.equal(binsStartFormatted, initialTimestamp);
 
                 dataview.bins.forEach(function(bin, index) {
                     var binTimestampExpected = moment.utc(initialTimestamp)
-                        .utcOffset(TIMEZONE_EDT_IN_MINUTES)
+                        .utcOffset(OFFSET_EDT_IN_MINUTES)
                         .add(index, 'month')
                         .format();
                     var binsTimestampInMilliseconds = bin.timestamp * 1000;
                     var binTimestampFormatted = moment.utc(binsTimestampInMilliseconds)
-                        .utcOffset(TIMEZONE_EDT_IN_MINUTES)
+                        .utcOffset(OFFSET_EDT_IN_MINUTES)
                         .format();
 
                     assert.equal(binTimestampFormatted, binTimestampExpected);
@@ -344,11 +344,11 @@ describe('histogram-dataview for date column type', function() {
         });
 
 
-        it('should aggregate histogram overriding default timezone to CEST ' + test.desc, function (done) {
-            var TIMEZONE_CEST_IN_SECONDS = 2 * 3600; // Central European Summer Time (Daylight Saving Time)
-            var TIMEZONE_CEST_IN_MINUTES = 2 * 60; // Central European Summer Time (Daylight Saving Time)
+        it('should aggregate histogram overriding default offset to CEST ' + test.desc, function (done) {
+            var OFFSET_CEST_IN_SECONDS = 2 * 3600; // Central European Summer Time (Daylight Saving Time)
+            var OFFSET_CEST_IN_MINUTES = 2 * 60; // Central European Summer Time (Daylight Saving Time)
             var params = {
-                timezone: TIMEZONE_CEST_IN_SECONDS
+                offset: OFFSET_CEST_IN_SECONDS
             };
 
             this.testClient = new TestClient(mapConfig, 1234);
@@ -361,18 +361,18 @@ describe('histogram-dataview for date column type', function() {
                 var initialTimestamp = '2007-02-01T00:00:00+02:00'; // CEST midnight
                 var binsStartInMilliseconds = dataview.bins_start * 1000;
                 var binsStartFormatted = moment.utc(binsStartInMilliseconds)
-                    .utcOffset(TIMEZONE_CEST_IN_MINUTES)
+                    .utcOffset(OFFSET_CEST_IN_MINUTES)
                     .format();
                 assert.equal(binsStartFormatted, initialTimestamp);
 
                 dataview.bins.forEach(function (bin, index) {
                     var binTimestampExpected = moment.utc(initialTimestamp)
-                        .utcOffset(TIMEZONE_CEST_IN_MINUTES)
+                        .utcOffset(OFFSET_CEST_IN_MINUTES)
                         .add(index, 'month')
                         .format();
                     var binsTimestampInMilliseconds = bin.timestamp * 1000;
                     var binTimestampFormatted = moment.utc(binsTimestampInMilliseconds)
-                        .utcOffset(TIMEZONE_CEST_IN_MINUTES)
+                        .utcOffset(OFFSET_CEST_IN_MINUTES)
                         .format();
 
                     assert.equal(binTimestampFormatted, binTimestampExpected);
@@ -384,11 +384,11 @@ describe('histogram-dataview for date column type', function() {
             });
         });
 
-        it('should aggregate histogram overriding default timezone to UTC/GMT ' + test.desc, function (done) {
-            var TIMEZONE_UTC_IN_SECONDS = 0 * 3600; // UTC
-            var TIMEZONE_UTC_IN_MINUTES = 0 * 60; // UTC
+        it('should aggregate histogram overriding default offset to UTC/GMT ' + test.desc, function (done) {
+            var OFFSET_UTC_IN_SECONDS = 0 * 3600; // UTC
+            var OFFSET_UTC_IN_MINUTES = 0 * 60; // UTC
             var params = {
-                timezone: TIMEZONE_UTC_IN_SECONDS
+                offset: OFFSET_UTC_IN_SECONDS
             };
 
             this.testClient = new TestClient(mapConfig, 1234);
@@ -401,18 +401,18 @@ describe('histogram-dataview for date column type', function() {
                 var initialTimestamp = '2007-02-01T00:00:00Z'; // UTC midnight
                 var binsStartInMilliseconds = dataview.bins_start * 1000;
                 var binsStartFormatted = moment.utc(binsStartInMilliseconds)
-                    .utcOffset(TIMEZONE_UTC_IN_MINUTES)
+                    .utcOffset(OFFSET_UTC_IN_MINUTES)
                     .format();
                 assert.equal(binsStartFormatted, initialTimestamp);
 
                 dataview.bins.forEach(function (bin, index) {
                     var binTimestampExpected = moment.utc(initialTimestamp)
-                        .utcOffset(TIMEZONE_UTC_IN_MINUTES)
+                        .utcOffset(OFFSET_UTC_IN_MINUTES)
                         .add(index, 'month')
                         .format();
                     var binsTimestampInMilliseconds = bin.timestamp * 1000;
                     var binTimestampFormatted = moment.utc(binsTimestampInMilliseconds)
-                        .utcOffset(TIMEZONE_UTC_IN_MINUTES)
+                        .utcOffset(OFFSET_UTC_IN_MINUTES)
                         .format();
 
                     assert.equal(binTimestampFormatted, binTimestampExpected);
@@ -425,10 +425,10 @@ describe('histogram-dataview for date column type', function() {
         });
 
         it('should aggregate histogram using "quarter" aggregation ' + test.desc, function (done) {
-            var TIMEZONE_UTC_IN_SECONDS = 0 * 3600; // UTC
-            var TIMEZONE_UTC_IN_MINUTES = 0 * 60; // UTC
+            var OFFSET_UTC_IN_SECONDS = 0 * 3600; // UTC
+            var OFFSET_UTC_IN_MINUTES = 0 * 60; // UTC
             var params = {
-                timezone: TIMEZONE_UTC_IN_SECONDS,
+                offset: OFFSET_UTC_IN_SECONDS,
                 aggregation: 'quarter'
             };
 
@@ -442,18 +442,18 @@ describe('histogram-dataview for date column type', function() {
                 var initialTimestamp = '2007-01-01T00:00:00Z'; // UTC midnight
                 var binsStartInMilliseconds = dataview.bins_start * 1000;
                 var binsStartFormatted = moment.utc(binsStartInMilliseconds)
-                    .utcOffset(TIMEZONE_UTC_IN_MINUTES)
+                    .utcOffset(OFFSET_UTC_IN_MINUTES)
                     .format();
                 assert.equal(binsStartFormatted, initialTimestamp);
 
                 dataview.bins.forEach(function (bin, index) {
                     var binTimestampExpected = moment.utc(initialTimestamp)
-                        .utcOffset(TIMEZONE_UTC_IN_MINUTES)
+                        .utcOffset(OFFSET_UTC_IN_MINUTES)
                         .add(index * 3, 'month')
                         .format();
                     var binsTimestampInMilliseconds = bin.timestamp * 1000;
                     var binTimestampFormatted = moment.utc(binsTimestampInMilliseconds)
-                        .utcOffset(TIMEZONE_UTC_IN_MINUTES)
+                        .utcOffset(OFFSET_UTC_IN_MINUTES)
                         .format();
 
                     assert.equal(binTimestampFormatted, binTimestampExpected);
@@ -466,9 +466,9 @@ describe('histogram-dataview for date column type', function() {
         });
 
         it('bins_count should be equal to bins length filtered by start and end ' + test.desc, function (done) {
-            var TIMEZONE_UTC_IN_SECONDS = 0 * 3600; // UTC
+            var OFFSET_UTC_IN_SECONDS = 0 * 3600; // UTC
             var params = {
-                timezone: TIMEZONE_UTC_IN_SECONDS,
+                offset: OFFSET_UTC_IN_SECONDS,
                 aggregation: 'quarter',
                 start: 1167609600, // 2007-01-01T00:00:00Z, first bin start
                 end: 1214870399 // 2008-06-30T23:59:59Z, last bin end
@@ -487,9 +487,9 @@ describe('histogram-dataview for date column type', function() {
         });
 
         it('bins_count should be greater than bins length filtered by start and end ' + test.desc, function (done) {
-            var TIMEZONE_UTC_IN_SECONDS = 0 * 3600; // UTC
+            var OFFSET_UTC_IN_SECONDS = 0 * 3600; // UTC
             var params = {
-                timezone: TIMEZONE_UTC_IN_SECONDS,
+                offset: OFFSET_UTC_IN_SECONDS,
                 aggregation: 'quarter',
                 start: 1167609600, // 2007-01-01T00:00:00Z, first bin start
                 end: 1214870400 // 2008-07-01T00:00:00Z, start the next bin to the last
@@ -548,22 +548,22 @@ describe('histogram-dataview for date column type', function() {
         });
     });
 
-    it('should not apply timezone for a histogram aggregated by minutes', function (done) {
+    it('should not apply offset for a histogram aggregated by minutes', function (done) {
         var self = this;
         var params = {
-            timezone: '-3600'
+            offset: '-3600'
         };
 
         self.testClient = new TestClient(mapConfig, 1234);
 
         self.testClient.getDataview('minute_histogram', {}, function (err, dataview) {
             assert.ifError(err);
-            self.testClient.getDataview('minute_histogram', params, function (err, dataviewWithTimezone) {
+            self.testClient.getDataview('minute_histogram', params, function (err, dataviewWithOffset) {
                 assert.ifError(err);
 
-                assert.notEqual(dataview.timezone, dataviewWithTimezone.timezone);
-                dataview.timezone = dataviewWithTimezone.timezone;
-                assert.deepEqual(dataview, dataviewWithTimezone);
+                assert.notEqual(dataview.offset, dataviewWithOffset.offset);
+                dataview.offset = dataviewWithOffset.offset;
+                assert.deepEqual(dataview, dataviewWithOffset);
                 done();
             });
         });
@@ -576,10 +576,10 @@ describe('histogram-dataview for date column type', function() {
             end: 1171584600 // 2007-02-16 00:10:00 = max(date_colum)
         };
 
-        var paramsWithTimezone = {
+        var paramsWithOffset = {
             start: 1171583400, // 2007-02-15 23:50:00 = min(date_colum)
             end: 1171584600, // 2007-02-16 00:10:00 = max(date_colum)
-            timezone: '-3600'
+            offset: '-3600'
         };
 
         self.testClient = new TestClient(mapConfig, 1234);
@@ -591,13 +591,13 @@ describe('histogram-dataview for date column type', function() {
 
                 assert.deepEqual(dataview, filteredDataview);
 
-                self.testClient.getDataview('minute_histogram', paramsWithTimezone,
-                function (err, filteredWithTimezoneDataview) {
+                self.testClient.getDataview('minute_histogram', paramsWithOffset,
+                function (err, filteredWithOffsetDataview) {
                     assert.ifError(err);
 
-                    assert.notEqual(filteredWithTimezoneDataview.timezone, filteredDataview.timezone);
-                    filteredWithTimezoneDataview.timezone = filteredDataview.timezone;
-                    assert.deepEqual(filteredWithTimezoneDataview, filteredDataview);
+                    assert.notEqual(filteredWithOffsetDataview.offset, filteredDataview.offset);
+                    filteredWithOffsetDataview.offset = filteredDataview.offset;
+                    assert.deepEqual(filteredWithOffsetDataview, filteredDataview);
                     done();
                 });
             });
@@ -618,7 +618,7 @@ describe('histogram-dataview for date column type', function() {
             bin_width: 600,
             bins_count: 2,
             bins_start: 1171497600,
-            timezone: 0,
+            offset: 0,
             nulls: 0,
             bins:
             [{
@@ -649,23 +649,23 @@ describe('histogram-dataview for date column type', function() {
         });
     });
 
-    it('should return a histogram aggregated by days with timezone', function (done) {
+    it('should return a histogram aggregated by days with offset', function (done) {
         var self = this;
 
-        var paramsWithDailyAggAndTimezone = {
+        var paramsWithDailyAggAndOffset = {
             aggregation: 'day',
-            timezone: '-3600'
+            offset: '-3600'
         };
 
         // data (UTC): from 2007-02-15 23:50:00 to 2007-02-16 00:10:00
 
-        var dataviewWithDailyAggAndTimezoneFixture = {
+        var dataviewWithDailyAggAndOffsetFixture = {
             aggregation: 'day',
             bin_width: 1200,
             bins_count: 1,
             bins_start: 1171501200,
             nulls: 0,
-            timezone: -3600,
+            offset: -3600,
             bins:
             [{
                 bin: 0,
@@ -679,10 +679,10 @@ describe('histogram-dataview for date column type', function() {
         };
 
         self.testClient = new TestClient(mapConfig, 1234);
-        self.testClient.getDataview('minute_histogram', paramsWithDailyAggAndTimezone, function (err, dataview) {
+        self.testClient.getDataview('minute_histogram', paramsWithDailyAggAndOffset, function (err, dataview) {
             assert.ifError(err);
 
-            assert.deepEqual(dataview, dataviewWithDailyAggAndTimezoneFixture);
+            assert.deepEqual(dataview, dataviewWithDailyAggAndOffsetFixture);
             done();
         });
     });

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -369,7 +369,7 @@ TestClient.prototype.getDataview = function(dataviewName, params, callback) {
                 own_filter: params.hasOwnProperty('own_filter') ? params.own_filter : 1
             };
 
-            ['bbox', 'bins', 'start', 'end', 'aggregation', 'timezone'].forEach(function(extraParam) {
+            ['bbox', 'bins', 'start', 'end', 'aggregation', 'offset'].forEach(function(extraParam) {
                 if (params.hasOwnProperty(extraParam)) {
                     urlParams[extraParam] = params[extraParam];
                 }


### PR DESCRIPTION
- replaced argument nomenclature `timezone` => `offset` so I can work with a different `timezone` as a string and still set an `offset` at Builder, otherwise it would be prone to confusion

