### PR TITLE
Add http header to indicate a renderer timed out

### DIFF
--- a/lib/cartodb/server.js
+++ b/lib/cartodb/server.js
@@ -138,6 +138,7 @@ module.exports = function(serverOptions) {
             if (isTimeoutError(err) && isRasterFormat(format)) {
                 return callback(null, timeoutErrorTile, {
                     'Content-Type': 'image/png',
+                    'X-Response-Timeout': 'HIT'
                 }, {});
             } else {
                 return callback(err, tile, headers, stats);

--- a/test/acceptance/user-render-timeout-limit.js
+++ b/test/acceptance/user-render-timeout-limit.js
@@ -138,7 +138,15 @@ describe('user render timeout limit', function () {
             });
 
             it('layergroup creation works but tile request fails due to render timeout', function (done) {
-                this.testClient.getTile(0, 0, 0, {}, (err, res, tile) => {
+                const override = {
+                    response: {
+                        headers: {
+                            'X-Response-Timeout': 'HIT'
+                        }
+                    }
+                };
+
+                this.testClient.getTile(0, 0, 0, override, (err, res, tile) => {
                     assert.ifError(err);
 
                     assert.imageIsSimilarToFile(tile, timeoutErrorTilePath, 0.05, (err) => {
@@ -320,7 +328,14 @@ describe('user render timeout limit', function () {
                     lng: 0,
                     width: 256,
                     height: 256,
-                    format: 'png'
+                    format: 'png',
+                    // TODO: Research how to get headers from renderer through abaculus.
+                    // Abaculus is hiding http headers from renderers and returning its own headers.
+                    // response: {
+                    //     headers: {
+                    //         'X-Response-Timeout': 'HIT'
+                    //     }
+                    // }
                 };
 
                 this.testClient.getStaticCenter(params, function (err, res, tile) {


### PR DESCRIPTION
Add http header to indicate a renderer timed out while fetching raster tiles. 

Note: In map static API, `abaculus` is hiding http headers from renderers and returning its own headers. We need to research how to get headers from renderer through `abaculus` or bypassing it.

