### PR TITLE
2.43.1 fix pg vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,25 @@
 dist: precise
 
-before_install:		
-  - lsb_release -a
-  - sudo mv /etc/apt/sources.list.d/pgdg.list* /tmp
-  - sudo apt-get -qq purge postgis* postgresql*
-  - sudo rm -Rf /var/lib/postgresql /etc/postgresql
-  - sudo apt-add-repository --yes ppa:cartodb/postgresql-9.3
-  - sudo apt-add-repository --yes ppa:cartodb/gis
-  - sudo apt-get update
-  - sudo apt-get install pkg-config libgif-dev libjpeg-dev libcairo2-dev libpango1.0-dev
-  - sudo apt-get install -q postgresql-9.3-postgis-2.1
-  - sudo apt-get install -q postgresql-contrib-9.3
-  - sudo apt-get install -q postgresql-plpython-9.3
-  - sudo apt-get install -q postgis
-  - sudo apt-get install -q gdal-bin
-  - sudo apt-get install -q ogr2ogr2-static-bin
-  - echo -e "local\tall\tall\ttrust\nhost\tall\tall\t127.0.0.1/32\ttrust\nhost\tall\tall\t::1/128\ttrust" |sudo tee /etc/postgresql/9.3/main/pg_hba.conf
-  - sudo service postgresql restart
+sudo: false
 
-before_script:
-  - psql -c 'create database template_postgis;' -U postgres
-  - psql -c 'CREATE EXTENSION postgis;' -U postgres -d template_postgis
-  - ./configure
+-addons:
+  postgresql: "9.3"
+  apt:
+    packages:
+      - postgresql-9.3-postgis-2.1
+      - postgresql-plpython-9.3
+      - pkg-config
+      - libcairo2-dev
+      - libjpeg8-dev
+      - libgif-dev
+      - libpango1.0-dev
+
+before_install:
+  - npm install -g npm@2
+  - createdb template_postgis
+  - createuser publicuser
+  - psql -c "CREATE EXTENSION postgis" template_postgis
+
 
 env:
   - NPROCS=1 JOBS=1 PGUSER=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - sudo apt-add-repository --yes ppa:cartodb/postgresql-9.3
   - sudo apt-add-repository --yes ppa:cartodb/gis
   - sudo apt-get update
+  - sudo apt-get install pkg-config libgif-dev libjpeg-dev libcairo2-dev libpango1.0-dev
   - sudo apt-get install -q postgresql-9.3-postgis-2.1
   - sudo apt-get install -q postgresql-contrib-9.3
   - sudo apt-get install -q postgresql-plpython-9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: precise
 
 sudo: false
 
--addons:
+addons:
   postgresql: "9.3"
   apt:
     packages:
@@ -19,7 +19,6 @@ before_install:
   - createdb template_postgis
   - createuser publicuser
   - psql -c "CREATE EXTENSION postgis" template_postgis
-
 
 env:
   - NPROCS=1 JOBS=1 PGUSER=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: precise
+
 before_install:		
   - lsb_release -a
   - sudo mv /etc/apt/sources.list.d/pgdg.list* /tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-sudo: false
-
-before_script:
+before_install:		
   - lsb_release -a
   - sudo mv /etc/apt/sources.list.d/pgdg.list* /tmp
   - sudo apt-get -qq purge postgis* postgresql*
@@ -17,6 +15,8 @@ before_script:
   - sudo apt-get install -q ogr2ogr2-static-bin
   - echo -e "local\tall\tall\ttrust\nhost\tall\tall\t127.0.0.1/32\ttrust\nhost\tall\tall\t::1/128\ttrust" |sudo tee /etc/postgresql/9.3/main/pg_hba.conf
   - sudo service postgresql restart
+
+before_script:
   - psql -c 'create database template_postgis;' -U postgres
   - psql -c 'CREATE EXTENSION postgis;' -U postgres -d template_postgis
   - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,24 @@
 sudo: false
 
-addons:
-  postgresql: "9.3"
-  apt:
-    packages:
-      - pkg-config
-      - libcairo2-dev
-      - libjpeg8-dev
-      - libgif-dev
-
-before_install:
-  - npm install -g npm@2
-  - createdb template_postgis
-  - createuser publicuser
-  - psql -c "CREATE EXTENSION postgis" template_postgis
+before_script:
+  - lsb_release -a
+  - sudo mv /etc/apt/sources.list.d/pgdg.list* /tmp
+  - sudo apt-get -qq purge postgis* postgresql*
+  - sudo rm -Rf /var/lib/postgresql /etc/postgresql
+  - sudo apt-add-repository --yes ppa:cartodb/postgresql-9.3
+  - sudo apt-add-repository --yes ppa:cartodb/gis
+  - sudo apt-get update
+  - sudo apt-get install -q postgresql-9.3-postgis-2.1
+  - sudo apt-get install -q postgresql-contrib-9.3
+  - sudo apt-get install -q postgresql-plpython-9.3
+  - sudo apt-get install -q postgis
+  - sudo apt-get install -q gdal-bin
+  - sudo apt-get install -q ogr2ogr2-static-bin
+  - echo -e "local\tall\tall\ttrust\nhost\tall\tall\t127.0.0.1/32\ttrust\nhost\tall\tall\t::1/128\ttrust" |sudo tee /etc/postgresql/9.3/main/pg_hba.conf
+  - sudo service postgresql restart
+  - psql -c 'create database template_postgis;' -U postgres
+  - psql -c 'CREATE EXTENSION postgis;' -U postgres -d template_postgis
+  - ./configure
 
 env:
   - NPROCS=1 JOBS=1 PGUSER=postgres

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.43.2
+
+Released 2017-09-01
+
+Bug fixes:
+ - Adding a new cartodb-psql fixing a pg vulnerability
+ 
+
 ## 2.43.1
 
 Released 2016-05-19

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "windshaft-cartodb",
-  "version": "2.42.3",
+  "version": "2.43.1",
   "dependencies": {
     "body-parser": {
       "version": "1.14.2",
@@ -18,9 +18,9 @@
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "depd": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "from": "depd@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
         },
         "http-errors": {
           "version": "1.3.1",
@@ -28,14 +28,14 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "dependencies": {
             "inherits": {
-              "version": "2.0.1",
+              "version": "2.0.3",
               "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "statuses": {
-              "version": "1.2.1",
+              "version": "1.3.1",
               "from": "statuses@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
             }
           }
         },
@@ -62,14 +62,14 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
         },
         "raw-body": {
-          "version": "2.1.6",
+          "version": "2.1.7",
           "from": "raw-body@>=2.1.5 <2.2.0",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "dependencies": {
             "bytes": {
-              "version": "2.3.0",
-              "from": "bytes@2.3.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+              "version": "2.4.0",
+              "from": "bytes@2.4.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
             },
             "unpipe": {
               "version": "1.0.0",
@@ -79,9 +79,9 @@
           }
         },
         "type-is": {
-          "version": "1.6.12",
-          "from": "type-is@>=1.6.6 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+          "version": "1.6.15",
+          "from": "type-is@>=1.6.10 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -89,14 +89,14 @@
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.11",
-              "from": "mime-types@>=2.1.10 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "version": "2.1.16",
+              "from": "mime-types@>=2.1.15 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.23.0",
-                  "from": "mime-db@>=1.23.0 <1.24.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                  "version": "1.29.0",
+                  "from": "mime-db@>=1.29.0 <1.30.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
                 }
               }
             }
@@ -114,10 +114,38 @@
           "from": "async@>=1.5.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
+        "cartodb-psql": {
+          "version": "0.6.2",
+          "from": "cartodb-psql@>=0.6.1 <0.7.0",
+          "dependencies": {
+            "pg": {
+              "version": "2.6.2-cdb4",
+              "from": "git://github.com/CartoDB/node-postgres.git#2.6.2-cdb4",
+              "resolved": "git://github.com/CartoDB/node-postgres.git#9fad6b99e5355285343f7b0ea1eb5e6d3f888edf",
+              "dependencies": {
+                "generic-pool": {
+                  "version": "2.0.3",
+                  "from": "generic-pool@2.0.3",
+                  "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz"
+                },
+                "buffer-writer": {
+                  "version": "1.0.0",
+                  "from": "buffer-writer@1.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+                },
+                "js-string-escape": {
+                  "version": "1.0.1",
+                  "from": "js-string-escape@1.0.1",
+                  "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
         "request": {
-          "version": "2.72.0",
+          "version": "2.81.0",
           "from": "request@>=2.69.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
@@ -125,58 +153,14 @@
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
-              "version": "1.4.1",
+              "version": "1.6.0",
               "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
-            },
-            "bl": {
-              "version": "1.1.2",
-              "from": "bl@>=1.1.2 <1.2.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
             },
             "caseless": {
-              "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+              "version": "0.12.0",
+              "from": "caseless@>=0.12.0 <0.13.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
@@ -191,9 +175,9 @@
               }
             },
             "extend": {
-              "version": "3.0.0",
+              "version": "3.0.1",
               "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
@@ -201,118 +185,50 @@
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
-              "version": "1.0.0-rc4",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+              "version": "2.1.4",
+              "from": "form-data@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "from": "asynckit@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                }
+              }
             },
             "har-validator": {
-              "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "version": "4.2.1",
+              "from": "har-validator@>=4.2.1 <4.3.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
               "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
-                  "from": "chalk@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "ajv": {
+                  "version": "4.11.8",
+                  "from": "ajv@>=4.9.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
                   "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    "co": {
+                      "version": "4.6.0",
+                      "from": "co@>=4.6.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
                     },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
+                    "json-stable-stringify": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.13.1",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
                       "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        "jsonify": {
+                          "version": "0.0.0",
+                          "from": "jsonify@>=0.0.0 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                         }
                       }
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
-                "pinkie-promise": {
-                  "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    }
-                  }
+                "har-schema": {
+                  "version": "1.0.5",
+                  "from": "har-schema@>=1.0.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
                 }
               }
             },
@@ -354,31 +270,43 @@
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
-                  "version": "1.2.2",
+                  "version": "1.4.1",
                   "from": "jsprim@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
                   "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
                     "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                      "version": "1.3.0",
+                      "from": "extsprintf@1.3.0",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
                     },
                     "json-schema": {
-                      "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                     },
                     "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                      "version": "1.10.0",
+                      "from": "verror@1.10.0",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "sshpk": {
-                  "version": "1.8.3",
+                  "version": "1.13.1",
                   "from": "sshpk@>=1.7.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
@@ -391,34 +319,34 @@
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "dashdash": {
-                      "version": "1.13.1",
+                      "version": "1.14.1",
                       "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz"
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                     },
                     "getpass": {
-                      "version": "0.1.6",
+                      "version": "0.1.7",
                       "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
                     },
                     "jsbn": {
-                      "version": "0.1.0",
+                      "version": "0.1.1",
                       "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
                     },
                     "tweetnacl": {
-                      "version": "0.13.3",
-                      "from": "tweetnacl@>=0.13.0 <0.14.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                      "version": "0.14.5",
+                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
                     }
                   }
                 }
@@ -440,31 +368,36 @@
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.1.11",
+              "version": "2.1.16",
               "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.23.0",
-                  "from": "mime-db@>=1.23.0 <1.24.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                  "version": "1.29.0",
+                  "from": "mime-db@>=1.29.0 <1.30.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
                 }
               }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.2",
               "from": "oauth-sign@>=0.8.1 <0.9.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
             },
+            "performance-now": {
+              "version": "0.2.0",
+              "from": "performance-now@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+            },
             "qs": {
-              "version": "6.1.0",
-              "from": "qs@>=6.1.0 <6.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
+              "version": "6.4.0",
+              "from": "qs@>=6.4.0 <6.5.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "from": "safe-buffer@>=5.0.1 <6.0.0",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
@@ -472,38 +405,135 @@
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
-              "version": "2.2.2",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+              "version": "2.3.2",
+              "from": "tough-cookie@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "from": "punycode@>=1.4.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                }
+              }
             },
             "tunnel-agent": {
-              "version": "0.4.3",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+              "version": "0.6.0",
+              "from": "tunnel-agent@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "from": "uuid@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
             }
           }
         }
       }
     },
     "cartodb-psql": {
-      "version": "0.6.1",
-      "from": "cartodb-psql@>=0.6.1 <0.7.0",
-      "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.6.1.tgz",
+      "version": "0.10.1",
+      "from": "cartodb-psql@0.10.1",
+      "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.10.1.tgz",
       "dependencies": {
         "pg": {
-          "version": "2.6.2-cdb3",
-          "from": "git://github.com/CartoDB/node-postgres.git#2.6.2-cdb3",
-          "resolved": "git://github.com/CartoDB/node-postgres.git#069c5296d1a093077feff21719641bb9e71fc50e",
+          "version": "6.1.6",
+          "from": "cartodb/node-postgres#6.1.6-cdb1",
+          "resolved": "git://github.com/cartodb/node-postgres.git#3eef52dd1e655f658a4ee8ac5697688b3ecfed44",
           "dependencies": {
-            "generic-pool": {
-              "version": "2.0.3",
-              "from": "generic-pool@2.0.3",
-              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz"
-            },
             "buffer-writer": {
-              "version": "1.0.0",
-              "from": "buffer-writer@1.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+              "version": "1.0.1",
+              "from": "buffer-writer@1.0.1",
+              "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz"
+            },
+            "js-string-escape": {
+              "version": "1.0.1",
+              "from": "js-string-escape@1.0.1",
+              "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz"
+            },
+            "packet-reader": {
+              "version": "0.2.0",
+              "from": "packet-reader@0.2.0",
+              "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz"
+            },
+            "pg-connection-string": {
+              "version": "0.1.3",
+              "from": "pg-connection-string@0.1.3",
+              "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
+            },
+            "pg-pool": {
+              "version": "1.8.0",
+              "from": "pg-pool@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
+              "dependencies": {
+                "generic-pool": {
+                  "version": "2.4.3",
+                  "from": "generic-pool@2.4.3",
+                  "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.0",
+                  "from": "object-assign@4.1.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+                }
+              }
+            },
+            "pg-types": {
+              "version": "1.12.1",
+              "from": "pg-types@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+              "dependencies": {
+                "postgres-array": {
+                  "version": "1.0.2",
+                  "from": "postgres-array@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz"
+                },
+                "postgres-bytea": {
+                  "version": "1.0.0",
+                  "from": "postgres-bytea@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
+                },
+                "postgres-date": {
+                  "version": "1.0.3",
+                  "from": "postgres-date@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz"
+                },
+                "postgres-interval": {
+                  "version": "1.1.1",
+                  "from": "postgres-interval@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
+                  "dependencies": {
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "pgpass": {
+              "version": "1.0.2",
+              "from": "pgpass@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+              "dependencies": {
+                "split": {
+                  "version": "1.0.1",
+                  "from": "split@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+                  "dependencies": {
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.2",
+              "from": "semver@4.3.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz"
             }
           }
         }
@@ -515,45 +545,9 @@
       "resolved": "https://registry.npmjs.org/cartodb-query-tables/-/cartodb-query-tables-0.1.0.tgz"
     },
     "cartodb-redis": {
-      "version": "0.13.0",
+      "version": "0.13.2",
       "from": "cartodb-redis@>=0.13.0 <0.14.0",
-      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-0.13.0.tgz",
-      "dependencies": {
-        "redis-mpool": {
-          "version": "0.1.0",
-          "from": "git://github.com/CartoDB/node-redis-mpool.git#0.1.0",
-          "resolved": "git://github.com/CartoDB/node-redis-mpool.git#47510b8d4525ee24aa2e5328976372274a1d144e",
-          "dependencies": {
-            "generic-pool": {
-              "version": "2.1.1",
-              "from": "generic-pool@>=2.1.1 <2.2.0",
-              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
-            },
-            "redis": {
-              "version": "0.12.1",
-              "from": "redis@>=0.12.1 <0.13.0",
-              "resolved": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz"
-            },
-            "hiredis": {
-              "version": "0.1.17",
-              "from": "hiredis@>=0.1.17 <0.2.0",
-              "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
-              "dependencies": {
-                "bindings": {
-                  "version": "1.2.1",
-                  "from": "bindings@*",
-                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                },
-                "nan": {
-                  "version": "1.1.2",
-                  "from": "nan@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-0.13.2.tgz"
     },
     "debug": {
       "version": "2.2.0",
@@ -583,14 +577,14 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.1.11",
+              "version": "2.1.16",
               "from": "mime-types@>=2.1.6 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.23.0",
-                  "from": "mime-db@>=1.23.0 <1.24.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                  "version": "1.29.0",
+                  "from": "mime-db@>=1.29.0 <1.30.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
                 }
               }
             },
@@ -627,9 +621,9 @@
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "depd": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "from": "depd@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
@@ -648,7 +642,7 @@
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@>=1.0.0 <1.1.0",
+              "from": "unpipe@1.0.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
@@ -733,9 +727,9 @@
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
+                  "version": "2.0.3",
                   "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
@@ -757,14 +751,55 @@
           }
         },
         "serve-static": {
-          "version": "1.10.2",
+          "version": "1.10.3",
           "from": "serve-static@>=1.10.2 <1.11.0",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+          "dependencies": {
+            "send": {
+              "version": "0.13.2",
+              "from": "send@0.13.2",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+              "dependencies": {
+                "destroy": {
+                  "version": "1.0.4",
+                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                },
+                "http-errors": {
+                  "version": "1.3.1",
+                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                }
+              }
+            }
+          }
         },
         "type-is": {
-          "version": "1.6.12",
+          "version": "1.6.15",
           "from": "type-is@>=1.6.6 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -772,14 +807,14 @@
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.11",
+              "version": "2.1.16",
               "from": "mime-types@>=2.1.6 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.23.0",
-                  "from": "mime-db@>=1.23.0 <1.24.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                  "version": "1.29.0",
+                  "from": "mime-db@>=1.29.0 <1.30.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
                 }
               }
             }
@@ -833,9 +868,9 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
-              "version": "2.0.1",
+              "version": "2.0.3",
               "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
         },
@@ -872,9 +907,9 @@
       "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.0.7.tgz"
     },
     "redis-mpool": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "from": "redis-mpool@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.4.1.tgz",
       "dependencies": {
         "generic-pool": {
           "version": "2.1.1",
@@ -887,19 +922,19 @@
           "resolved": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz"
         },
         "hiredis": {
-          "version": "0.1.17",
-          "from": "hiredis@>=0.1.17 <0.2.0",
-          "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
+          "version": "0.5.0",
+          "from": "hiredis@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.5.0.tgz",
           "dependencies": {
             "bindings": {
-              "version": "1.2.1",
-              "from": "bindings@*",
-              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+              "version": "1.3.0",
+              "from": "bindings@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
             },
             "nan": {
-              "version": "1.1.2",
-              "from": "nan@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+              "version": "2.7.0",
+              "from": "nan@>=2.3.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
             }
           }
         }
@@ -926,9 +961,9 @@
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
+                  "version": "2.0.3",
                   "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
@@ -960,9 +995,9 @@
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "extend": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "extend@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -970,14 +1005,21 @@
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
-          "version": "1.0.0-rc4",
+          "version": "1.0.1",
           "from": "form-data@>=1.0.0-rc1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "dependencies": {
             "async": {
-              "version": "1.5.2",
-              "from": "async@>=1.5.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+              "version": "2.5.0",
+              "from": "async@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@>=4.14.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+                }
+              }
             }
           }
         },
@@ -987,21 +1029,21 @@
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
-          "version": "2.1.11",
-          "from": "mime-types@>=2.1.10 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "version": "2.1.16",
+          "from": "mime-types@>=2.1.2 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.23.0",
-              "from": "mime-db@>=1.23.0 <1.24.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+              "version": "1.29.0",
+              "from": "mime-db@>=1.29.0 <1.30.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
             }
           }
         },
         "node-uuid": {
-          "version": "1.4.7",
+          "version": "1.4.8",
           "from": "node-uuid@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
         },
         "qs": {
           "version": "5.1.0",
@@ -1014,9 +1056,16 @@
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         },
         "tough-cookie": {
-          "version": "2.2.2",
+          "version": "2.3.2",
           "from": "tough-cookie@>=0.12.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "from": "punycode@>=1.4.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+            }
+          }
         },
         "http-signature": {
           "version": "0.11.0",
@@ -1105,9 +1154,9 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
           "dependencies": {
             "bluebird": {
-              "version": "2.10.2",
+              "version": "2.11.0",
               "from": "bluebird@>=2.9.30 <3.0.0",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
             },
             "chalk": {
               "version": "1.1.3",
@@ -1130,9 +1179,9 @@
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
+                      "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
@@ -1142,9 +1191,9 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
+                      "version": "2.1.1",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
@@ -1156,21 +1205,14 @@
               }
             },
             "commander": {
-              "version": "2.9.0",
+              "version": "2.11.0",
               "from": "commander@>=2.8.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
             },
             "is-my-json-valid": {
-              "version": "2.13.1",
+              "version": "2.16.1",
               "from": "is-my-json-valid@>=2.12.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -1190,9 +1232,9 @@
                   }
                 },
                 "jsonpointer": {
-                  "version": "2.0.0",
-                  "from": "jsonpointer@2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                  "version": "4.0.1",
+                  "from": "jsonpointer@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
@@ -1212,7 +1254,8 @@
     },
     "step-profiler": {
       "version": "0.3.0",
-      "from": "step-profiler@>=0.3.0 <0.4.0"
+      "from": "step-profiler@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/step-profiler/-/step-profiler-0.3.0.tgz"
     },
     "turbo-carto": {
       "version": "0.9.2",
@@ -1240,9 +1283,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
           "dependencies": {
             "supports-color": {
-              "version": "3.1.2",
+              "version": "3.2.3",
               "from": "supports-color@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
@@ -1252,9 +1295,9 @@
               }
             },
             "source-map": {
-              "version": "0.5.6",
+              "version": "0.5.7",
               "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
             },
             "js-base64": {
               "version": "2.1.9",
@@ -1298,7 +1341,7 @@
           }
         },
         "carto": {
-          "version": "0.15.1-cdb1",
+          "version": "0.15.1-cdb2",
           "from": "https://github.com/CartoDB/carto/tarball/0.15.1-cdb2",
           "resolved": "https://github.com/CartoDB/carto/tarball/0.15.1-cdb2",
           "dependencies": {
@@ -1321,6 +1364,34 @@
                   "version": "0.0.10",
                   "from": "minimist@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "cartodb-psql": {
+          "version": "0.6.2",
+          "from": "cartodb-psql@>=0.6.1 <0.7.0",
+          "dependencies": {
+            "pg": {
+              "version": "2.6.2-cdb4",
+              "from": "git://github.com/CartoDB/node-postgres.git#2.6.2-cdb4",
+              "resolved": "git://github.com/CartoDB/node-postgres.git#9fad6b99e5355285343f7b0ea1eb5e6d3f888edf",
+              "dependencies": {
+                "generic-pool": {
+                  "version": "2.0.3",
+                  "from": "generic-pool@2.0.3",
+                  "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz"
+                },
+                "buffer-writer": {
+                  "version": "1.0.0",
+                  "from": "buffer-writer@1.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+                },
+                "js-string-escape": {
+                  "version": "1.0.1",
+                  "from": "js-string-escape@1.0.1",
+                  "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz"
                 }
               }
             }
@@ -2120,683 +2191,23 @@
                   }
                 },
                 "zipfile": {
-                  "version": "0.5.9",
+                  "version": "0.5.11",
                   "from": "zipfile@>=0.5.5 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/zipfile/-/zipfile-0.5.9.tgz",
+                  "resolved": "https://registry.npmjs.org/zipfile/-/zipfile-0.5.11.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "2.1.0",
-                      "from": "nan@>=2.1.0 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+                      "version": "2.4.0",
+                      "from": "nan@>=2.4.0 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
                     },
                     "node-pre-gyp": {
-                      "version": "0.6.17",
-                      "from": "node-pre-gyp@~0.6.17",
+                      "version": "0.6.32",
+                      "from": "node-pre-gyp@>=0.6.30 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
                       "dependencies": {
-                        "nopt": {
-                          "version": "3.0.6",
-                          "from": "nopt@~3.0.1",
-                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                          "dependencies": {
-                            "abbrev": {
-                              "version": "1.0.7",
-                              "from": "abbrev@1",
-                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                            }
-                          }
-                        },
-                        "npmlog": {
-                          "version": "2.0.0",
-                          "from": "npmlog@~2.0.0",
-                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi": {
-                              "version": "0.3.0",
-                              "from": "ansi@~0.3.0",
-                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-                            },
-                            "are-we-there-yet": {
-                              "version": "1.0.4",
-                              "from": "are-we-there-yet@~1.0.0",
-                              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
-                              "dependencies": {
-                                "delegates": {
-                                  "version": "0.1.0",
-                                  "from": "delegates@^0.1.0",
-                                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-                                },
-                                "readable-stream": {
-                                  "version": "1.1.13",
-                                  "from": "readable-stream@^1.1.13",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                                  "dependencies": {
-                                    "core-util-is": {
-                                      "version": "1.0.2",
-                                      "from": "core-util-is@~1.0.0",
-                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                    },
-                                    "isarray": {
-                                      "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                    },
-                                    "string_decoder": {
-                                      "version": "0.10.31",
-                                      "from": "string_decoder@~0.10.x",
-                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                    },
-                                    "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "inherits@~2.0.1",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "gauge": {
-                              "version": "1.2.2",
-                              "from": "gauge@~1.2.0",
-                              "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
-                              "dependencies": {
-                                "has-unicode": {
-                                  "version": "1.0.1",
-                                  "from": "has-unicode@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
-                                },
-                                "lodash.pad": {
-                                  "version": "3.1.1",
-                                  "from": "lodash.pad@^3.0.0",
-                                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
-                                  "dependencies": {
-                                    "lodash._basetostring": {
-                                      "version": "3.0.1",
-                                      "from": "lodash._basetostring@^3.0.0",
-                                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                                    },
-                                    "lodash._createpadding": {
-                                      "version": "3.6.1",
-                                      "from": "lodash._createpadding@^3.0.0",
-                                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                                      "dependencies": {
-                                        "lodash.repeat": {
-                                          "version": "3.0.1",
-                                          "from": "lodash.repeat@^3.0.0",
-                                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "lodash.padleft": {
-                                  "version": "3.1.1",
-                                  "from": "lodash.padleft@^3.0.0",
-                                  "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
-                                  "dependencies": {
-                                    "lodash._basetostring": {
-                                      "version": "3.0.1",
-                                      "from": "lodash._basetostring@^3.0.0",
-                                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                                    },
-                                    "lodash._createpadding": {
-                                      "version": "3.6.1",
-                                      "from": "lodash._createpadding@^3.0.0",
-                                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                                      "dependencies": {
-                                        "lodash.repeat": {
-                                          "version": "3.0.1",
-                                          "from": "lodash.repeat@^3.0.0",
-                                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "lodash.padright": {
-                                  "version": "3.1.1",
-                                  "from": "lodash.padright@^3.0.0",
-                                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
-                                  "dependencies": {
-                                    "lodash._basetostring": {
-                                      "version": "3.0.1",
-                                      "from": "lodash._basetostring@^3.0.0",
-                                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                                    },
-                                    "lodash._createpadding": {
-                                      "version": "3.6.1",
-                                      "from": "lodash._createpadding@^3.0.0",
-                                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                                      "dependencies": {
-                                        "lodash.repeat": {
-                                          "version": "3.0.1",
-                                          "from": "lodash.repeat@^3.0.0",
-                                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "request": {
-                          "version": "2.67.0",
-                          "from": "request@2.x",
-                          "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-                          "dependencies": {
-                            "bl": {
-                              "version": "1.0.0",
-                              "from": "bl@~1.0.0",
-                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-                              "dependencies": {
-                                "readable-stream": {
-                                  "version": "2.0.4",
-                                  "from": "readable-stream@~2.0.0",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                                  "dependencies": {
-                                    "core-util-is": {
-                                      "version": "1.0.2",
-                                      "from": "core-util-is@~1.0.0",
-                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                    },
-                                    "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "inherits@~2.0.1",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                    },
-                                    "isarray": {
-                                      "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                    },
-                                    "process-nextick-args": {
-                                      "version": "1.0.3",
-                                      "from": "process-nextick-args@~1.0.0",
-                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                                    },
-                                    "string_decoder": {
-                                      "version": "0.10.31",
-                                      "from": "string_decoder@~0.10.x",
-                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                    },
-                                    "util-deprecate": {
-                                      "version": "1.0.2",
-                                      "from": "util-deprecate@~1.0.1",
-                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "caseless": {
-                              "version": "0.11.0",
-                              "from": "caseless@~0.11.0",
-                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                            },
-                            "extend": {
-                              "version": "3.0.0",
-                              "from": "extend@~3.0.0",
-                              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                            },
-                            "forever-agent": {
-                              "version": "0.6.1",
-                              "from": "forever-agent@~0.6.1",
-                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                            },
-                            "form-data": {
-                              "version": "1.0.0-rc3",
-                              "from": "form-data@~1.0.0-rc3",
-                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-                              "dependencies": {
-                                "async": {
-                                  "version": "1.5.0",
-                                  "from": "async@^1.4.0",
-                                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-                                }
-                              }
-                            },
-                            "json-stringify-safe": {
-                              "version": "5.0.1",
-                              "from": "json-stringify-safe@~5.0.1",
-                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                            },
-                            "mime-types": {
-                              "version": "2.1.7",
-                              "from": "mime-types@~2.1.7",
-                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-                              "dependencies": {
-                                "mime-db": {
-                                  "version": "1.19.0",
-                                  "from": "mime-db@~1.19.0",
-                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-                                }
-                              }
-                            },
-                            "node-uuid": {
-                              "version": "1.4.7",
-                              "from": "node-uuid@~1.4.7",
-                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-                            },
-                            "qs": {
-                              "version": "5.2.0",
-                              "from": "qs@~5.2.0",
-                              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-                            },
-                            "tunnel-agent": {
-                              "version": "0.4.1",
-                              "from": "tunnel-agent@~0.4.1",
-                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                            },
-                            "tough-cookie": {
-                              "version": "2.2.1",
-                              "from": "tough-cookie@~2.2.0",
-                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-                            },
-                            "http-signature": {
-                              "version": "1.1.0",
-                              "from": "http-signature@~1.1.0",
-                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-                              "dependencies": {
-                                "assert-plus": {
-                                  "version": "0.1.5",
-                                  "from": "assert-plus@^0.1.5",
-                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                                },
-                                "jsprim": {
-                                  "version": "1.2.2",
-                                  "from": "jsprim@^1.2.2",
-                                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                                  "dependencies": {
-                                    "extsprintf": {
-                                      "version": "1.0.2",
-                                      "from": "extsprintf@1.0.2",
-                                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                                    },
-                                    "json-schema": {
-                                      "version": "0.2.2",
-                                      "from": "json-schema@0.2.2",
-                                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-                                    },
-                                    "verror": {
-                                      "version": "1.3.6",
-                                      "from": "verror@1.3.6",
-                                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                                    }
-                                  }
-                                },
-                                "sshpk": {
-                                  "version": "1.7.0",
-                                  "from": "sshpk@^1.7.0",
-                                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
-                                  "dependencies": {
-                                    "asn1": {
-                                      "version": "0.2.3",
-                                      "from": "asn1@>=0.2.3 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                                    },
-                                    "assert-plus": {
-                                      "version": "0.2.0",
-                                      "from": "assert-plus@>=0.2.0 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                                    },
-                                    "dashdash": {
-                                      "version": "1.10.1",
-                                      "from": "dashdash@>=1.10.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                                      "dependencies": {
-                                        "assert-plus": {
-                                          "version": "0.1.5",
-                                          "from": "assert-plus@0.1.x",
-                                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                                        }
-                                      }
-                                    },
-                                    "jsbn": {
-                                      "version": "0.1.0",
-                                      "from": "jsbn@>=0.1.0 <0.2.0",
-                                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                                    },
-                                    "tweetnacl": {
-                                      "version": "0.13.2",
-                                      "from": "tweetnacl@>=0.13.0 <1.0.0",
-                                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
-                                    },
-                                    "jodid25519": {
-                                      "version": "1.0.2",
-                                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                                    },
-                                    "ecc-jsbn": {
-                                      "version": "0.1.1",
-                                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "oauth-sign": {
-                              "version": "0.8.0",
-                              "from": "oauth-sign@~0.8.0",
-                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                            },
-                            "hawk": {
-                              "version": "3.1.2",
-                              "from": "hawk@~3.1.0",
-                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-                              "dependencies": {
-                                "hoek": {
-                                  "version": "2.16.3",
-                                  "from": "hoek@2.x.x",
-                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                                },
-                                "boom": {
-                                  "version": "2.10.1",
-                                  "from": "boom@2.x.x",
-                                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                                },
-                                "cryptiles": {
-                                  "version": "2.0.5",
-                                  "from": "cryptiles@2.x.x",
-                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                                },
-                                "sntp": {
-                                  "version": "1.0.9",
-                                  "from": "sntp@1.x.x",
-                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                                }
-                              }
-                            },
-                            "aws-sign2": {
-                              "version": "0.6.0",
-                              "from": "aws-sign2@~0.6.0",
-                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                            },
-                            "stringstream": {
-                              "version": "0.0.5",
-                              "from": "stringstream@~0.0.4",
-                              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                            },
-                            "combined-stream": {
-                              "version": "1.0.5",
-                              "from": "combined-stream@~1.0.5",
-                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                              "dependencies": {
-                                "delayed-stream": {
-                                  "version": "1.0.0",
-                                  "from": "delayed-stream@~1.0.0",
-                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "isstream": {
-                              "version": "0.1.2",
-                              "from": "isstream@~0.1.2",
-                              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                            },
-                            "is-typedarray": {
-                              "version": "1.0.0",
-                              "from": "is-typedarray@~1.0.0",
-                              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-                            },
-                            "har-validator": {
-                              "version": "2.0.3",
-                              "from": "har-validator@~2.0.2",
-                              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.1",
-                                  "from": "chalk@^1.1.1",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.1.0",
-                                      "from": "ansi-styles@^2.1.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.3",
-                                      "from": "escape-string-regexp@^1.0.2",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "has-ansi@^2.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@^2.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.0",
-                                      "from": "strip-ansi@^3.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@^2.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "supports-color@^2.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "commander": {
-                                  "version": "2.9.0",
-                                  "from": "commander@^2.9.0",
-                                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                                  "dependencies": {
-                                    "graceful-readlink": {
-                                      "version": "1.0.1",
-                                      "from": "graceful-readlink@>= 1.0.0",
-                                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                                    }
-                                  }
-                                },
-                                "is-my-json-valid": {
-                                  "version": "2.12.3",
-                                  "from": "is-my-json-valid@^2.12.3",
-                                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-                                  "dependencies": {
-                                    "generate-function": {
-                                      "version": "2.0.0",
-                                      "from": "generate-function@^2.0.0",
-                                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                                    },
-                                    "generate-object-property": {
-                                      "version": "1.2.0",
-                                      "from": "generate-object-property@^1.1.0",
-                                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                                      "dependencies": {
-                                        "is-property": {
-                                          "version": "1.0.2",
-                                          "from": "is-property@^1.0.0",
-                                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                                        }
-                                      }
-                                    },
-                                    "jsonpointer": {
-                                      "version": "2.0.0",
-                                      "from": "jsonpointer@2.0.0",
-                                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                                    },
-                                    "xtend": {
-                                      "version": "4.0.1",
-                                      "from": "xtend@^4.0.0",
-                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                                    }
-                                  }
-                                },
-                                "pinkie-promise": {
-                                  "version": "2.0.0",
-                                  "from": "pinkie-promise@^2.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                                  "dependencies": {
-                                    "pinkie": {
-                                      "version": "2.0.1",
-                                      "from": "pinkie@^2.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "semver": {
-                          "version": "5.1.0",
-                          "from": "semver@~5.1.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                        },
-                        "tar": {
-                          "version": "2.2.1",
-                          "from": "tar@~2.2.0",
-                          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-                          "dependencies": {
-                            "block-stream": {
-                              "version": "0.0.8",
-                              "from": "block-stream@*",
-                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                            },
-                            "fstream": {
-                              "version": "1.0.8",
-                              "from": "fstream@^1.0.2",
-                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-                              "dependencies": {
-                                "graceful-fs": {
-                                  "version": "4.1.2",
-                                  "from": "graceful-fs@^4.1.2",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@2",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        },
-                        "tar-pack": {
-                          "version": "3.1.0",
-                          "from": "tar-pack@~3.1.0",
-                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "graceful-fs@4.1",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                            },
-                            "uid-number": {
-                              "version": "0.0.3",
-                              "from": "uid-number@0.0.3",
-                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
-                            },
-                            "once": {
-                              "version": "1.1.1",
-                              "from": "once@~1.1.1",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-                            },
-                            "debug": {
-                              "version": "0.7.4",
-                              "from": "debug@~0.7.2",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                            },
-                            "rimraf": {
-                              "version": "2.2.8",
-                              "from": "rimraf@~2.2.0",
-                              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                            },
-                            "fstream": {
-                              "version": "1.0.8",
-                              "from": "fstream@^1.0.2",
-                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-                              "dependencies": {
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@~2.0.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                }
-                              }
-                            },
-                            "fstream-ignore": {
-                              "version": "1.0.3",
-                              "from": "fstream-ignore@~1.0.3",
-                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-                              "dependencies": {
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@2",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "minimatch": {
-                                  "version": "3.0.0",
-                                  "from": "minimatch@^3.0.0",
-                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                                  "dependencies": {
-                                    "brace-expansion": {
-                                      "version": "1.1.1",
-                                      "from": "brace-expansion@^1.0.0",
-                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                                      "dependencies": {
-                                        "balanced-match": {
-                                          "version": "0.2.1",
-                                          "from": "balanced-match@^0.2.0",
-                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-                                        },
-                                        "concat-map": {
-                                          "version": "0.0.1",
-                                          "from": "concat-map@0.0.1",
-                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "readable-stream": {
-                              "version": "1.0.33",
-                              "from": "readable-stream@~1.0.2",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "from": "core-util-is@~1.0.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@~0.10.x",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@~2.0.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
                         "mkdirp": {
                           "version": "0.5.1",
-                          "from": "mkdirp@~0.5.0",
+                          "from": "mkdirp@>=0.5.1 <0.6.0",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                           "dependencies": {
                             "minimist": {
@@ -2806,74 +2217,579 @@
                             }
                           }
                         },
+                        "nopt": {
+                          "version": "3.0.6",
+                          "from": "nopt@>=3.0.6 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.9",
+                              "from": "abbrev@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+                            }
+                          }
+                        },
+                        "npmlog": {
+                          "version": "4.0.2",
+                          "from": "npmlog@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+                          "dependencies": {
+                            "are-we-there-yet": {
+                              "version": "1.1.2",
+                              "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                              "dependencies": {
+                                "delegates": {
+                                  "version": "1.0.0",
+                                  "from": "delegates@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                                },
+                                "readable-stream": {
+                                  "version": "2.2.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+                                  "dependencies": {
+                                    "buffer-shims": {
+                                      "version": "1.0.0",
+                                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                                    },
+                                    "core-util-is": {
+                                      "version": "1.0.2",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "1.0.0",
+                                      "from": "isarray@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.3",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.7",
+                                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.2",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "console-control-strings": {
+                              "version": "1.1.0",
+                              "from": "console-control-strings@>=1.1.0 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+                            },
+                            "gauge": {
+                              "version": "2.7.2",
+                              "from": "gauge@>=2.7.1 <2.8.0",
+                              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
+                              "dependencies": {
+                                "aproba": {
+                                  "version": "1.0.4",
+                                  "from": "aproba@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
+                                },
+                                "supports-color": {
+                                  "version": "0.2.0",
+                                  "from": "supports-color@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                                },
+                                "has-unicode": {
+                                  "version": "2.0.1",
+                                  "from": "has-unicode@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "4.1.0",
+                                  "from": "object-assign@>=4.1.0 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+                                },
+                                "signal-exit": {
+                                  "version": "3.0.2",
+                                  "from": "signal-exit@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                                },
+                                "string-width": {
+                                  "version": "1.0.2",
+                                  "from": "string-width@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                                  "dependencies": {
+                                    "code-point-at": {
+                                      "version": "1.1.0",
+                                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                                    },
+                                    "is-fullwidth-code-point": {
+                                      "version": "1.0.0",
+                                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.1",
+                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "from": "strip-ansi@>=3.0.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "wide-align": {
+                                  "version": "1.1.0",
+                                  "from": "wide-align@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "set-blocking": {
+                              "version": "2.0.0",
+                              "from": "set-blocking@>=2.0.0 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                            }
+                          }
+                        },
                         "rc": {
-                          "version": "1.1.5",
-                          "from": "rc@~1.1.0",
-                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
+                          "version": "1.1.6",
+                          "from": "rc@>=1.1.6 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
                           "dependencies": {
                             "deep-extend": {
-                              "version": "0.4.0",
-                              "from": "deep-extend@~0.4.0",
-                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                              "version": "0.4.1",
+                              "from": "deep-extend@>=0.4.0 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                             },
                             "ini": {
                               "version": "1.3.4",
-                              "from": "ini@~1.3.0",
+                              "from": "ini@>=1.3.0 <1.4.0",
                               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "from": "minimist@^1.2.0",
+                              "from": "minimist@>=1.2.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                             },
                             "strip-json-comments": {
                               "version": "1.0.4",
-                              "from": "strip-json-comments@~1.0.4",
+                              "from": "strip-json-comments@>=1.0.4 <1.1.0",
                               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                             }
                           }
                         },
+                        "request": {
+                          "version": "2.79.0",
+                          "from": "request@>=2.79.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+                          "dependencies": {
+                            "aws-sign2": {
+                              "version": "0.6.0",
+                              "from": "aws-sign2@>=0.6.0 <0.7.0",
+                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                            },
+                            "aws4": {
+                              "version": "1.5.0",
+                              "from": "aws4@>=1.2.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+                            },
+                            "caseless": {
+                              "version": "0.11.0",
+                              "from": "caseless@>=0.11.0 <0.12.0",
+                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                            },
+                            "combined-stream": {
+                              "version": "1.0.5",
+                              "from": "combined-stream@>=1.0.5 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                              "dependencies": {
+                                "delayed-stream": {
+                                  "version": "1.0.0",
+                                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "extend": {
+                              "version": "3.0.0",
+                              "from": "extend@>=3.0.0 <3.1.0",
+                              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                            },
+                            "forever-agent": {
+                              "version": "0.6.1",
+                              "from": "forever-agent@>=0.6.1 <0.7.0",
+                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                            },
+                            "form-data": {
+                              "version": "2.1.2",
+                              "from": "form-data@>=2.1.1 <2.2.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+                              "dependencies": {
+                                "asynckit": {
+                                  "version": "0.4.0",
+                                  "from": "asynckit@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                                }
+                              }
+                            },
+                            "har-validator": {
+                              "version": "2.0.6",
+                              "from": "har-validator@>=2.0.6 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.3",
+                                  "from": "chalk@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.2.1",
+                                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.5",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.1",
+                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "from": "supports-color@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "commander": {
+                                  "version": "2.9.0",
+                                  "from": "commander@>=2.9.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                                  "dependencies": {
+                                    "graceful-readlink": {
+                                      "version": "1.0.1",
+                                      "from": "graceful-readlink@>=1.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "is-my-json-valid": {
+                                  "version": "2.15.0",
+                                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                                  "dependencies": {
+                                    "generate-function": {
+                                      "version": "2.0.0",
+                                      "from": "generate-function@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                                    },
+                                    "generate-object-property": {
+                                      "version": "1.2.0",
+                                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                                      "dependencies": {
+                                        "is-property": {
+                                          "version": "1.0.2",
+                                          "from": "is-property@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                                        }
+                                      }
+                                    },
+                                    "jsonpointer": {
+                                      "version": "4.0.0",
+                                      "from": "jsonpointer@>=4.0.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.1",
+                                      "from": "xtend@>=4.0.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.1",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "hawk": {
+                              "version": "3.1.3",
+                              "from": "hawk@>=3.1.3 <3.2.0",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                              "dependencies": {
+                                "hoek": {
+                                  "version": "2.16.3",
+                                  "from": "hoek@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                                },
+                                "boom": {
+                                  "version": "2.10.1",
+                                  "from": "boom@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                                },
+                                "cryptiles": {
+                                  "version": "2.0.5",
+                                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                                },
+                                "sntp": {
+                                  "version": "1.0.9",
+                                  "from": "sntp@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                                }
+                              }
+                            },
+                            "http-signature": {
+                              "version": "1.1.1",
+                              "from": "http-signature@>=1.1.0 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.2.0",
+                                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                                },
+                                "jsprim": {
+                                  "version": "1.3.1",
+                                  "from": "jsprim@>=1.2.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                                  "dependencies": {
+                                    "extsprintf": {
+                                      "version": "1.0.2",
+                                      "from": "extsprintf@1.0.2",
+                                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                                    },
+                                    "json-schema": {
+                                      "version": "0.2.3",
+                                      "from": "json-schema@0.2.3",
+                                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                                    },
+                                    "verror": {
+                                      "version": "1.3.6",
+                                      "from": "verror@1.3.6",
+                                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                                    }
+                                  }
+                                },
+                                "sshpk": {
+                                  "version": "1.10.1",
+                                  "from": "sshpk@>=1.7.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                                  "dependencies": {
+                                    "asn1": {
+                                      "version": "0.2.3",
+                                      "from": "asn1@>=0.2.3 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                                    },
+                                    "assert-plus": {
+                                      "version": "1.0.0",
+                                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                                    },
+                                    "dashdash": {
+                                      "version": "1.14.1",
+                                      "from": "dashdash@>=1.12.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                                    },
+                                    "getpass": {
+                                      "version": "0.1.6",
+                                      "from": "getpass@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                                    },
+                                    "jsbn": {
+                                      "version": "0.1.0",
+                                      "from": "jsbn@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                                    },
+                                    "tweetnacl": {
+                                      "version": "0.14.5",
+                                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                                    },
+                                    "jodid25519": {
+                                      "version": "1.0.2",
+                                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                                    },
+                                    "ecc-jsbn": {
+                                      "version": "0.1.1",
+                                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                                    },
+                                    "bcrypt-pbkdf": {
+                                      "version": "1.0.0",
+                                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "is-typedarray": {
+                              "version": "1.0.0",
+                              "from": "is-typedarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                            },
+                            "isstream": {
+                              "version": "0.1.2",
+                              "from": "isstream@>=0.1.2 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                            },
+                            "json-stringify-safe": {
+                              "version": "5.0.1",
+                              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                            },
+                            "mime-types": {
+                              "version": "2.1.13",
+                              "from": "mime-types@>=2.1.7 <2.2.0",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+                              "dependencies": {
+                                "mime-db": {
+                                  "version": "1.25.0",
+                                  "from": "mime-db@>=1.25.0 <1.26.0",
+                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+                                }
+                              }
+                            },
+                            "oauth-sign": {
+                              "version": "0.8.2",
+                              "from": "oauth-sign@>=0.8.1 <0.9.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                            },
+                            "qs": {
+                              "version": "6.3.0",
+                              "from": "qs@>=6.3.0 <6.4.0",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+                            },
+                            "stringstream": {
+                              "version": "0.0.5",
+                              "from": "stringstream@>=0.0.4 <0.1.0",
+                              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "2.3.2",
+                              "from": "tough-cookie@>=2.3.0 <2.4.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.4.1",
+                                  "from": "punycode@>=1.4.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                                }
+                              }
+                            },
+                            "tunnel-agent": {
+                              "version": "0.4.3",
+                              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+                            },
+                            "uuid": {
+                              "version": "3.0.1",
+                              "from": "uuid@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+                            }
+                          }
+                        },
                         "rimraf": {
-                          "version": "2.4.4",
-                          "from": "rimraf@~2.4.0",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+                          "version": "2.5.4",
+                          "from": "rimraf@>=2.5.4 <2.6.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                           "dependencies": {
                             "glob": {
-                              "version": "5.0.15",
-                              "from": "glob@^5.0.14",
-                              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                              "version": "7.1.1",
+                              "from": "glob@>=7.0.5 <8.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                               "dependencies": {
+                                "fs.realpath": {
+                                  "version": "1.0.0",
+                                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                                },
                                 "inflight": {
-                                  "version": "1.0.4",
-                                  "from": "inflight@^1.0.4",
-                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "version": "1.0.6",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                                   "dependencies": {
                                     "wrappy": {
-                                      "version": "1.0.1",
-                                      "from": "wrappy@1",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                      "version": "1.0.2",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
                                 },
                                 "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@2",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                  "version": "2.0.3",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                                 },
                                 "minimatch": {
-                                  "version": "3.0.0",
-                                  "from": "minimatch@2 || 3",
-                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                                  "version": "3.0.3",
+                                  "from": "minimatch@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                                   "dependencies": {
                                     "brace-expansion": {
-                                      "version": "1.1.1",
-                                      "from": "brace-expansion@^1.0.0",
-                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                                      "version": "1.1.6",
+                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                       "dependencies": {
                                         "balanced-match": {
-                                          "version": "0.2.1",
-                                          "from": "balanced-match@^0.2.0",
-                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                          "version": "0.4.2",
+                                          "from": "balanced-match@>=0.4.1 <0.5.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                         },
                                         "concat-map": {
                                           "version": "0.0.1",
@@ -2885,23 +2801,188 @@
                                   }
                                 },
                                 "once": {
-                                  "version": "1.3.3",
-                                  "from": "once@^1.3.0",
-                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "version": "1.4.0",
+                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                                   "dependencies": {
                                     "wrappy": {
-                                      "version": "1.0.1",
-                                      "from": "wrappy@1",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                      "version": "1.0.2",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
                                 },
                                 "path-is-absolute": {
-                                  "version": "1.0.0",
-                                  "from": "path-is-absolute@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                  "version": "1.0.1",
+                                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                                 }
                               }
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "5.3.0",
+                          "from": "semver@>=5.3.0 <5.4.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                        },
+                        "tar": {
+                          "version": "2.2.1",
+                          "from": "tar@>=2.2.1 <2.3.0",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                          "dependencies": {
+                            "block-stream": {
+                              "version": "0.0.9",
+                              "from": "block-stream@*",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+                            },
+                            "fstream": {
+                              "version": "1.0.10",
+                              "from": "fstream@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.11",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "from": "inherits@>=2.0.0 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                            }
+                          }
+                        },
+                        "tar-pack": {
+                          "version": "3.3.0",
+                          "from": "tar-pack@>=3.3.0 <3.4.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+                          "dependencies": {
+                            "debug": {
+                              "version": "2.2.0",
+                              "from": "debug@>=2.2.0 <2.3.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "dependencies": {
+                                "ms": {
+                                  "version": "0.7.1",
+                                  "from": "ms@0.7.1",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                }
+                              }
+                            },
+                            "fstream": {
+                              "version": "1.0.10",
+                              "from": "fstream@>=1.0.10 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.11",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.3",
+                                  "from": "inherits@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                }
+                              }
+                            },
+                            "fstream-ignore": {
+                              "version": "1.0.5",
+                              "from": "fstream-ignore@>=1.0.5 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                              "dependencies": {
+                                "inherits": {
+                                  "version": "2.0.3",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "3.0.3",
+                                  "from": "minimatch@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.6",
+                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "0.4.2",
+                                          "from": "balanced-match@>=0.4.1 <0.5.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "concat-map@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@>=1.3.3 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "2.1.5",
+                              "from": "readable-stream@>=2.1.4 <2.2.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                              "dependencies": {
+                                "buffer-shims": {
+                                  "version": "1.0.0",
+                                  "from": "buffer-shims@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                                },
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.3",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                },
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "from": "isarray@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.7",
+                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.2",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "uid-number": {
+                              "version": "0.0.6",
+                              "from": "uid-number@>=0.0.6 <0.1.0",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                             }
                           }
                         }
@@ -2910,589 +2991,753 @@
                   }
                 },
                 "sqlite3": {
-                  "version": "3.1.4",
+                  "version": "3.1.9",
                   "from": "sqlite3@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.9.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "2.3.3",
-                      "from": "nan@>=2.3.3 <2.4.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.3.tgz"
+                      "version": "2.6.2",
+                      "from": "nan@>=2.6.2 <2.7.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
                     },
                     "node-pre-gyp": {
-                      "version": "0.6.28",
-                      "from": "node-pre-gyp@>=0.6.28 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.28.tgz"
-                    },
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    },
-                    "ansi": {
-                      "version": "0.3.1",
-                      "from": "ansi@>=0.3.1 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
-                    },
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    },
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                    },
-                    "are-we-there-yet": {
-                      "version": "1.1.2",
-                      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "async": {
-                      "version": "1.5.2",
-                      "from": "async@>=1.5.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "from": "assert-plus@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                    },
-                    "aws-sign2": {
-                      "version": "0.6.0",
-                      "from": "aws-sign2@>=0.6.0 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                    },
-                    "aws4": {
-                      "version": "1.4.1",
-                      "from": "aws4@>=1.2.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
-                    },
-                    "balanced-match": {
-                      "version": "0.4.1",
-                      "from": "balanced-match@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
-                    },
-                    "block-stream": {
-                      "version": "0.0.9",
-                      "from": "block-stream@*",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
-                    },
-                    "boom": {
-                      "version": "2.10.1",
-                      "from": "boom@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
-                    "brace-expansion": {
-                      "version": "1.1.4",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz"
-                    },
-                    "caseless": {
-                      "version": "0.11.0",
-                      "from": "caseless@>=0.11.0 <0.12.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                    },
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "chalk@>=1.1.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "from": "combined-stream@>=1.0.5 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-                    },
-                    "commander": {
-                      "version": "2.9.0",
-                      "from": "commander@>=2.9.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <2.3.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-                    },
-                    "deep-extend": {
-                      "version": "0.4.1",
-                      "from": "deep-extend@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
-                    },
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                    },
-                    "delegates": {
-                      "version": "1.0.0",
-                      "from": "delegates@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "extend": {
-                      "version": "3.0.0",
-                      "from": "extend@>=3.0.0 <3.1.0",
-                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@>=0.6.1 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc4",
-                      "from": "form-data@>=1.0.0-rc3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
-                    },
-                    "fstream": {
-                      "version": "1.0.9",
-                      "from": "fstream@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.9.tgz"
-                    },
-                    "fstream-ignore": {
-                      "version": "1.0.4",
-                      "from": "fstream-ignore@>=1.0.3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.4.tgz"
-                    },
-                    "gauge": {
-                      "version": "1.2.7",
-                      "from": "gauge@>=1.2.5 <1.3.0",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
-                    },
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-                    },
-                    "glob": {
-                      "version": "7.0.3",
-                      "from": "glob@>=7.0.0 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.4",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
-                    },
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    },
-                    "har-validator": {
-                      "version": "2.0.6",
-                      "from": "har-validator@>=2.0.6 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-                    },
-                    "has-unicode": {
-                      "version": "2.0.0",
-                      "from": "has-unicode@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
-                    },
-                    "hawk": {
-                      "version": "3.1.3",
-                      "from": "hawk@>=3.1.3 <3.2.0",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
-                    "http-signature": {
-                      "version": "1.1.1",
-                      "from": "http-signature@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@>=1.3.0 <1.4.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.13.1",
-                      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
-                    },
-                    "is-property": {
-                      "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0",
-                      "from": "is-typedarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@>=0.1.2 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "jsbn": {
-                      "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                    },
-                    "jsprim": {
-                      "version": "1.2.2",
-                      "from": "jsprim@>=1.2.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
-                    },
-                    "lodash._baseslice": {
-                      "version": "4.0.0",
-                      "from": "lodash._baseslice@>=4.0.0 <4.1.0",
-                      "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz"
-                    },
-                    "lodash._basetostring": {
-                      "version": "4.12.0",
-                      "from": "lodash._basetostring@>=4.12.0 <4.13.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz"
-                    },
-                    "lodash.pad": {
-                      "version": "4.4.0",
-                      "from": "lodash.pad@>=4.1.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz"
-                    },
-                    "lodash.padend": {
-                      "version": "4.5.0",
-                      "from": "lodash.padend@>=4.1.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz"
-                    },
-                    "lodash.padstart": {
-                      "version": "4.5.0",
-                      "from": "lodash.padstart@>=4.1.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz"
-                    },
-                    "lodash.tostring": {
-                      "version": "4.1.3",
-                      "from": "lodash.tostring@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.3.tgz"
-                    },
-                    "mime-db": {
-                      "version": "1.23.0",
-                      "from": "mime-db@>=1.23.0 <1.24.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.11",
-                      "from": "mime-types@>=2.1.7 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-                    },
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                    },
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "ms@0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7",
-                      "from": "node-uuid@>=1.4.7 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-                    },
-                    "nopt": {
-                      "version": "3.0.6",
-                      "from": "nopt@>=3.0.1 <3.1.0",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
-                    },
-                    "npmlog": {
-                      "version": "2.0.3",
-                      "from": "npmlog@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.2",
-                      "from": "oauth-sign@>=0.8.1 <0.9.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    },
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "qs": {
-                      "version": "6.1.0",
-                      "from": "qs@>=6.1.0 <6.2.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "2.1.2",
-                      "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz"
-                    },
-                    "request": {
-                      "version": "2.72.0",
-                      "from": "request@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz"
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "from": "rimraf@>=2.5.0 <2.6.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
-                    },
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "semver@>=5.1.0 <5.2.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5",
-                      "from": "stringstream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                    },
-                    "strip-json-comments": {
-                      "version": "1.0.4",
-                      "from": "strip-json-comments@>=1.0.4 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    },
-                    "tar": {
-                      "version": "2.2.1",
-                      "from": "tar@>=2.2.0 <2.3.0",
-                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.2",
-                      "from": "tough-cookie@>=2.2.0 <2.3.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.3",
-                      "from": "tunnel-agent@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.13.3",
-                      "from": "tweetnacl@>=0.13.0 <0.14.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
-                    },
-                    "uid-number": {
-                      "version": "0.0.6",
-                      "from": "uid-number@>=0.0.6 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    },
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    },
-                    "bl": {
-                      "version": "1.1.2",
-                      "from": "bl@>=1.1.2 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                      "version": "0.6.36",
+                      "from": "node-pre-gyp@>=0.6.36 <0.7.0",
                       "dependencies": {
-                        "readable-stream": {
-                          "version": "2.0.6",
-                          "from": "readable-stream@>=2.0.5 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-                        }
-                      }
-                    },
-                    "dashdash": {
-                      "version": "1.13.1",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "getpass": {
-                      "version": "0.1.6",
-                      "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.6",
-                      "from": "rc@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@>=1.2.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.8.3",
-                      "from": "sshpk@>=1.7.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "tar-pack": {
-                      "version": "3.1.3",
-                      "from": "tar-pack@>=3.1.0 <3.2.0",
-                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "2.0.6",
-                          "from": "readable-stream@>=2.0.4 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "mkdirp@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "nopt": {
+                          "version": "4.0.1",
+                          "from": "nopt@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.1.0",
+                              "from": "abbrev@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+                            },
+                            "osenv": {
+                              "version": "0.1.4",
+                              "from": "osenv@>=0.1.4 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+                              "dependencies": {
+                                "os-homedir": {
+                                  "version": "1.0.2",
+                                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                                },
+                                "os-tmpdir": {
+                                  "version": "1.0.2",
+                                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "npmlog": {
+                          "version": "4.1.2",
+                          "from": "npmlog@>=4.0.2 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+                          "dependencies": {
+                            "are-we-there-yet": {
+                              "version": "1.1.4",
+                              "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+                              "dependencies": {
+                                "delegates": {
+                                  "version": "1.0.0",
+                                  "from": "delegates@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                                },
+                                "readable-stream": {
+                                  "version": "2.3.3",
+                                  "from": "readable-stream@>=2.0.6 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.2",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.3",
+                                      "from": "inherits@>=2.0.3 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "1.0.0",
+                                      "from": "isarray@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.7",
+                                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                                    },
+                                    "safe-buffer": {
+                                      "version": "5.1.1",
+                                      "from": "safe-buffer@>=5.1.1 <5.2.0",
+                                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "1.0.3",
+                                      "from": "string_decoder@>=1.0.3 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.2",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "console-control-strings": {
+                              "version": "1.1.0",
+                              "from": "console-control-strings@>=1.1.0 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+                            },
+                            "gauge": {
+                              "version": "2.7.4",
+                              "from": "gauge@>=2.7.3 <2.8.0",
+                              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                              "dependencies": {
+                                "aproba": {
+                                  "version": "1.1.2",
+                                  "from": "aproba@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
+                                },
+                                "has-unicode": {
+                                  "version": "2.0.1",
+                                  "from": "has-unicode@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "4.1.1",
+                                  "from": "object-assign@>=4.1.0 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                                },
+                                "signal-exit": {
+                                  "version": "3.0.2",
+                                  "from": "signal-exit@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                                },
+                                "string-width": {
+                                  "version": "1.0.2",
+                                  "from": "string-width@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                                  "dependencies": {
+                                    "code-point-at": {
+                                      "version": "1.1.0",
+                                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                                    },
+                                    "is-fullwidth-code-point": {
+                                      "version": "1.0.0",
+                                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.1",
+                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "from": "strip-ansi@>=3.0.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "wide-align": {
+                                  "version": "1.1.2",
+                                  "from": "wide-align@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+                                }
+                              }
+                            },
+                            "set-blocking": {
+                              "version": "2.0.0",
+                              "from": "set-blocking@>=2.0.0 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "rc": {
+                          "version": "1.2.1",
+                          "from": "rc@>=1.1.7 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.4.2",
+                              "from": "deep-extend@>=0.4.0 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
+                            },
+                            "ini": {
+                              "version": "1.3.4",
+                              "from": "ini@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "from": "minimist@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "from": "strip-json-comments@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "request": {
+                          "version": "2.81.0",
+                          "from": "request@>=2.81.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                          "dependencies": {
+                            "aws-sign2": {
+                              "version": "0.6.0",
+                              "from": "aws-sign2@>=0.6.0 <0.7.0",
+                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                            },
+                            "aws4": {
+                              "version": "1.6.0",
+                              "from": "aws4@>=1.2.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+                            },
+                            "caseless": {
+                              "version": "0.12.0",
+                              "from": "caseless@>=0.12.0 <0.13.0",
+                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+                            },
+                            "combined-stream": {
+                              "version": "1.0.5",
+                              "from": "combined-stream@>=1.0.5 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                              "dependencies": {
+                                "delayed-stream": {
+                                  "version": "1.0.0",
+                                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "extend": {
+                              "version": "3.0.1",
+                              "from": "extend@>=3.0.0 <3.1.0",
+                              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+                            },
+                            "forever-agent": {
+                              "version": "0.6.1",
+                              "from": "forever-agent@>=0.6.1 <0.7.0",
+                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                            },
+                            "form-data": {
+                              "version": "2.1.4",
+                              "from": "form-data@>=2.1.1 <2.2.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                              "dependencies": {
+                                "asynckit": {
+                                  "version": "0.4.0",
+                                  "from": "asynckit@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                                }
+                              }
+                            },
+                            "har-validator": {
+                              "version": "4.2.1",
+                              "from": "har-validator@>=4.2.1 <4.3.0",
+                              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                              "dependencies": {
+                                "ajv": {
+                                  "version": "4.11.8",
+                                  "from": "ajv@>=4.9.1 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                                  "dependencies": {
+                                    "co": {
+                                      "version": "4.6.0",
+                                      "from": "co@>=4.6.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                                    },
+                                    "json-stable-stringify": {
+                                      "version": "1.0.1",
+                                      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                                      "dependencies": {
+                                        "jsonify": {
+                                          "version": "0.0.0",
+                                          "from": "jsonify@>=0.0.0 <0.1.0",
+                                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "har-schema": {
+                                  "version": "1.0.5",
+                                  "from": "har-schema@>=1.0.5 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                                }
+                              }
+                            },
+                            "hawk": {
+                              "version": "3.1.3",
+                              "from": "hawk@>=3.1.3 <3.2.0",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                              "dependencies": {
+                                "hoek": {
+                                  "version": "2.16.3",
+                                  "from": "hoek@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                                },
+                                "boom": {
+                                  "version": "2.10.1",
+                                  "from": "boom@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                                },
+                                "cryptiles": {
+                                  "version": "2.0.5",
+                                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                                },
+                                "sntp": {
+                                  "version": "1.0.9",
+                                  "from": "sntp@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                                }
+                              }
+                            },
+                            "http-signature": {
+                              "version": "1.1.1",
+                              "from": "http-signature@>=1.1.0 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.2.0",
+                                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                                },
+                                "jsprim": {
+                                  "version": "1.4.1",
+                                  "from": "jsprim@>=1.2.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                                  "dependencies": {
+                                    "assert-plus": {
+                                      "version": "1.0.0",
+                                      "from": "assert-plus@1.0.0",
+                                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                                    },
+                                    "extsprintf": {
+                                      "version": "1.3.0",
+                                      "from": "extsprintf@1.3.0",
+                                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+                                    },
+                                    "json-schema": {
+                                      "version": "0.2.3",
+                                      "from": "json-schema@0.2.3",
+                                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                                    },
+                                    "verror": {
+                                      "version": "1.10.0",
+                                      "from": "verror@1.10.0",
+                                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.2",
+                                          "from": "core-util-is@1.0.2",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "sshpk": {
+                                  "version": "1.13.1",
+                                  "from": "sshpk@>=1.7.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                                  "dependencies": {
+                                    "asn1": {
+                                      "version": "0.2.3",
+                                      "from": "asn1@>=0.2.3 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                                    },
+                                    "assert-plus": {
+                                      "version": "1.0.0",
+                                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                                    },
+                                    "dashdash": {
+                                      "version": "1.14.1",
+                                      "from": "dashdash@>=1.12.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                                    },
+                                    "getpass": {
+                                      "version": "0.1.7",
+                                      "from": "getpass@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
+                                    },
+                                    "jsbn": {
+                                      "version": "0.1.1",
+                                      "from": "jsbn@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                                    },
+                                    "tweetnacl": {
+                                      "version": "0.14.5",
+                                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                                    },
+                                    "ecc-jsbn": {
+                                      "version": "0.1.1",
+                                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                                    },
+                                    "bcrypt-pbkdf": {
+                                      "version": "1.0.1",
+                                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "is-typedarray": {
+                              "version": "1.0.0",
+                              "from": "is-typedarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                            },
+                            "isstream": {
+                              "version": "0.1.2",
+                              "from": "isstream@>=0.1.2 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                            },
+                            "json-stringify-safe": {
+                              "version": "5.0.1",
+                              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                            },
+                            "mime-types": {
+                              "version": "2.1.16",
+                              "from": "mime-types@>=2.1.7 <2.2.0",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                              "dependencies": {
+                                "mime-db": {
+                                  "version": "1.29.0",
+                                  "from": "mime-db@>=1.29.0 <1.30.0",
+                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                                }
+                              }
+                            },
+                            "oauth-sign": {
+                              "version": "0.8.2",
+                              "from": "oauth-sign@>=0.8.1 <0.9.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                            },
+                            "performance-now": {
+                              "version": "0.2.0",
+                              "from": "performance-now@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+                            },
+                            "qs": {
+                              "version": "6.4.0",
+                              "from": "qs@>=6.4.0 <6.5.0",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+                            },
+                            "safe-buffer": {
+                              "version": "5.1.1",
+                              "from": "safe-buffer@>=5.0.1 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                            },
+                            "stringstream": {
+                              "version": "0.0.5",
+                              "from": "stringstream@>=0.0.4 <0.1.0",
+                              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "2.3.2",
+                              "from": "tough-cookie@>=2.3.0 <2.4.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.4.1",
+                                  "from": "punycode@>=1.4.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                                }
+                              }
+                            },
+                            "tunnel-agent": {
+                              "version": "0.6.0",
+                              "from": "tunnel-agent@>=0.6.0 <0.7.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+                            },
+                            "uuid": {
+                              "version": "3.1.0",
+                              "from": "uuid@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.6.1",
+                          "from": "rimraf@>=2.6.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "7.1.2",
+                              "from": "glob@>=7.0.5 <8.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                              "dependencies": {
+                                "fs.realpath": {
+                                  "version": "1.0.0",
+                                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                                },
+                                "inflight": {
+                                  "version": "1.0.6",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.2",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.3",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "3.0.4",
+                                  "from": "minimatch@>=3.0.4 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.8",
+                                      "from": "brace-expansion@>=1.1.7 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "1.0.0",
+                                          "from": "balanced-match@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "concat-map@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.4.0",
+                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.2",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "path-is-absolute": {
+                                  "version": "1.0.1",
+                                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "5.4.1",
+                          "from": "semver@>=5.3.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+                        },
+                        "tar": {
+                          "version": "2.2.1",
+                          "from": "tar@>=2.2.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                          "dependencies": {
+                            "block-stream": {
+                              "version": "0.0.9",
+                              "from": "block-stream@*",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+                            },
+                            "fstream": {
+                              "version": "1.0.11",
+                              "from": "fstream@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.11",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                            }
+                          }
+                        },
+                        "tar-pack": {
+                          "version": "3.4.0",
+                          "from": "tar-pack@>=3.4.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+                          "dependencies": {
+                            "debug": {
+                              "version": "2.6.8",
+                              "from": "debug@>=2.2.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                              "dependencies": {
+                                "ms": {
+                                  "version": "2.0.0",
+                                  "from": "ms@2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "fstream": {
+                              "version": "1.0.11",
+                              "from": "fstream@>=1.0.10 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.11",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.3",
+                                  "from": "inherits@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                }
+                              }
+                            },
+                            "fstream-ignore": {
+                              "version": "1.0.5",
+                              "from": "fstream-ignore@>=1.0.5 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                              "dependencies": {
+                                "inherits": {
+                                  "version": "2.0.3",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "3.0.4",
+                                  "from": "minimatch@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.8",
+                                      "from": "brace-expansion@>=1.1.7 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "1.0.0",
+                                          "from": "balanced-match@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "concat-map@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.4.0",
+                              "from": "once@>=1.3.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "2.3.3",
+                              "from": "readable-stream@>=2.1.4 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.3",
+                                  "from": "inherits@>=2.0.3 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                },
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "from": "isarray@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.7",
+                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                                },
+                                "safe-buffer": {
+                                  "version": "5.1.1",
+                                  "from": "safe-buffer@>=5.1.1 <5.2.0",
+                                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "1.0.3",
+                                  "from": "string_decoder@>=1.0.3 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.2",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "uid-number": {
+                              "version": "0.0.6",
+                              "from": "uid-number@>=0.0.6 <0.0.7",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                            }
+                          }
                         }
                       }
                     }
@@ -3997,9 +4242,40 @@
           }
         },
         "torque.js": {
-          "version": "2.11.4",
+          "version": "2.11.5",
           "from": "torque.js@>=2.11.0 <2.12.0",
-          "resolved": "https://registry.npmjs.org/torque.js/-/torque.js-2.11.4.tgz"
+          "resolved": "https://registry.npmjs.org/torque.js/-/torque.js-2.11.5.tgz",
+          "dependencies": {
+            "carto": {
+              "version": "0.15.1-cdb1",
+              "from": "cartodb/carto#0.15.1-cdb1",
+              "resolved": "git://github.com/cartodb/carto.git#8050ec843f1f32a6469e5d1cf49602773015d398",
+              "dependencies": {
+                "mapnik-reference": {
+                  "version": "6.0.5",
+                  "from": "mapnik-reference@>=6.0.2 <6.1.0",
+                  "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "windshaft-cartodb",
-  "version": "2.43.1",
+  "version": "2.43.2",
   "description": "A map tile server for CartoDB",
   "keywords": [
     "cartodb"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "body-parser": "~1.14.0",
     "camshaft": "0.8.0",
-    "cartodb-psql": "~0.6.1",
+    "cartodb-psql": "0.10.1",
     "cartodb-query-tables": "~0.1.0",
     "cartodb-redis": "~0.13.0",
     "debug": "~2.2.0",

--- a/test/support/prepare_db.sh
+++ b/test/support/prepare_db.sh
@@ -83,7 +83,7 @@ if test x"$PREPARE_PGSQL" = xyes; then
 
   cat sql/_CDB_QueryStatements.sql | psql -v ON_ERROR_STOP=1 ${TEST_DB} || exit 1
 
-  SQL_SCRIPTS='CDB_QueryTables CDB_CartodbfyTable CDB_TableMetadata CDB_ForeignTable CDB_UserTables CDB_ColumnNames CDB_ZoomFromScale CDB_Overviews CDB_QuantileBins CDB_JenksBins CDB_HeadsTailsBins CDB_EqualIntervalBins CDB_Hexagon CDB_XYZ'
+  SQL_SCRIPTS='CDB_QueryTables CDB_CartodbfyTable CDB_TableMetadata CDB_ForeignTable CDB_UserTables CDB_ColumnNames CDB_ZoomFromScale CDB_OverviewsSupport CDB_Overviews CDB_QuantileBins CDB_JenksBins CDB_HeadsTailsBins CDB_EqualIntervalBins CDB_Hexagon CDB_XYZ'
   for i in ${SQL_SCRIPTS}
   do
     curl -L -s https://github.com/CartoDB/cartodb-postgresql/raw/master/scripts-available/$i.sql -o sql/$i.sql


### PR DESCRIPTION
Adding a new cartodb-psql fixing a pg vulnerability ("cartodb-psql": "0.10.1")

This will be the tag 2.43.2

-----------------

More info about pg vulnerability 
https://node-postgres.com/announcements#2017-08-12-code-execution-vulnerability