### PR TITLE
Fix out of range bug in date histograms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.12.8
+Released 2017-mm-dd
+
+Bug fixes:
+- Integer out of range in date histograms. (https://github.com/CartoDB/support/issues/962)
+
 ## 3.12.7
 Released 2017-09-01
 

--- a/lib/cartodb/models/dataview/histogram.js
+++ b/lib/cartodb/models/dataview/histogram.js
@@ -198,8 +198,8 @@ var dateBasicsQueryTpl = dot.template([
 var dateOverrideBasicsQueryTpl = dot.template([
     '__cdb_basics AS (',
     '    SELECT',
-    '        max({{=it._end}}) AS __cdb_max_val,',
-    '        min({{=it._start}}) AS __cdb_min_val,',
+    '        max({{=it._end}})::float AS __cdb_max_val,',
+    '        min({{=it._start}})::float AS __cdb_min_val,',
     '        avg(date_part(\'epoch\', {{=it._column}})) AS __cdb_avg_val,',
     '        min(',
     '           date_trunc(',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "windshaft-cartodb",
-  "version": "3.12.7",
+  "version": "3.12.8",
   "description": "A map tile server for CartoDB",
   "keywords": [
     "cartodb"

--- a/test/acceptance/dataviews/histogram.js
+++ b/test/acceptance/dataviews/histogram.js
@@ -332,6 +332,21 @@ describe('histogram-dataview for date column type', function() {
             });
         });
 
+        it('should cast overridden start and end to float to avoid out of range errors ' + test.desc, function (done) {
+            var params = {
+                start: -2145916800,
+                end: 1009843199
+            };
+
+            this.testClient = new TestClient(mapConfig, 1234);
+            this.testClient.getDataview(test.dataviewId, params, function (err, dataview) {
+                assert.ok(!err, err);
+                assert.equal(dataview.type, 'histogram');
+                assert.ok(dataview.bin_width > 0, 'Unexpected bin width: ' + dataview.bin_width);
+
+                done();
+            });
+        });
 
         it('should return same histogram ' + test.desc, function (done) {
             var params = {


### PR DESCRIPTION
Fix for the bug reported at https://github.com/CartoDB/support/issues/962

The problem was that the total range between max and min timestamps is above the range of `integer` but both operands are within `integer` limits. PostgreSQL try to accommodate the result and it doesn't fit so an `out of range` error is triggered.

Making both values as double precision (float) fixes the bug.

This is consistent with the basics query with no overrides, since it gets the values from date using `datepart` function, that returns double precision.