### PR TITLE
Do not use distinct when calculating quantiles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.12.9
+Released 2017-mm-dd
+
+Bug fixes:
+- Do not use distinct when calculating quantiles. #743
+
 ## 3.12.8
 Released 2017-09-07
 

--- a/lib/cartodb/backends/turbo-carto-postgres-datasource.js
+++ b/lib/cartodb/backends/turbo-carto-postgres-datasource.js
@@ -21,10 +21,10 @@ function createTemplate(method) {
 }
 
 var methods = {
-    quantiles: 'CDB_QuantileBins(array_agg(distinct({{=it._column}}::numeric)), {{=it._buckets}}) as quantiles',
+    quantiles: 'CDB_QuantileBins(array_agg({{=it._column}}::numeric), {{=it._buckets}}) as quantiles',
     equal: 'CDB_EqualIntervalBins(array_agg({{=it._column}}::numeric), {{=it._buckets}}) as equal',
-    jenks: 'CDB_JenksBins(array_agg(distinct({{=it._column}}::numeric)), {{=it._buckets}}) as jenks',
-    headtails: 'CDB_HeadsTailsBins(array_agg(distinct({{=it._column}}::numeric)), {{=it._buckets}}) as headtails'
+    jenks: 'CDB_JenksBins(array_agg({{=it._column}}::numeric), {{=it._buckets}}) as jenks',
+    headtails: 'CDB_HeadsTailsBins(array_agg({{=it._column}}::numeric), {{=it._buckets}}) as headtails'
 };
 
 var methodTemplates = Object.keys(methods).reduce(function(methodTemplates, methodName) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "windshaft-cartodb",
-  "version": "3.12.8",
+  "version": "3.12.9",
   "description": "A map tile server for CartoDB",
   "keywords": [
     "cartodb"


### PR DESCRIPTION
Bonus track: This has no problems with `NULLs` since there was already a NULL check in the query. So we can deploy this as a full solution to #718, even though https://github.com/CartoDB/cartodb-postgresql/pull/307 is not ready yet.