### PR TITLE
Dataview factory refactor

### DIFF
--- a/lib/cartodb/models/dataview/factory.js
+++ b/lib/cartodb/models/dataview/factory.js
@@ -9,10 +9,12 @@ module.exports = class DataviewFactory {
     }
 
     static getDataview (query, dataviewDefinition) {
-        const type = dataviewDefinition.type;
+        const { type, options, sql } = dataviewDefinition;
+
         if (!this.dataviews[type]) {
             throw new Error('Invalid dataview type: "' + type + '"');
         }
-        return new this.dataviews[type](query, dataviewDefinition.options, dataviewDefinition.sql);
+
+        return new this.dataviews[type](query, options, sql);
     }
 };

--- a/lib/cartodb/models/dataview/factory.js
+++ b/lib/cartodb/models/dataview/factory.js
@@ -1,4 +1,4 @@
-var dataviews = require('./');
+const dataviews = require('./');
 
 module.exports = class DataviewFactory {
     static get dataviews() {
@@ -9,7 +9,7 @@ module.exports = class DataviewFactory {
     }
 
     static getDataview (query, dataviewDefinition) {
-        var type = dataviewDefinition.type;
+        const type = dataviewDefinition.type;
         if (!this.dataviews[type]) {
             throw new Error('Invalid dataview type: "' + type + '"');
         }

--- a/lib/cartodb/models/dataview/factory.js
+++ b/lib/cartodb/models/dataview/factory.js
@@ -1,12 +1,14 @@
 var dataviews = require('./');
 
-var DataviewFactory = {
-    dataviews: Object.keys(dataviews).reduce(function(allDataviews, dataviewClassName) {
-        allDataviews[dataviewClassName.toLowerCase()] = dataviews[dataviewClassName];
-        return allDataviews;
-    }, {}),
+module.exports = class DataviewFactory {
+    static get dataviews() {
+        return Object.keys(dataviews).reduce((allDataviews, dataviewClassName) => {
+            allDataviews[dataviewClassName.toLowerCase()] = dataviews[dataviewClassName];
+            return allDataviews;
+        }, {});
+    }
 
-    getDataview: function(query, dataviewDefinition) {
+    static getDataview (query, dataviewDefinition) {
         var type = dataviewDefinition.type;
         if (!this.dataviews[type]) {
             throw new Error('Invalid dataview type: "' + type + '"');
@@ -14,5 +16,3 @@ var DataviewFactory = {
         return new this.dataviews[type](query, dataviewDefinition.options, dataviewDefinition.sql);
     }
 };
-
-module.exports = DataviewFactory;


### PR DESCRIPTION
Uses ES6 class syntax to define static properties and methods.

`<rant>`
After using ES6 class syntax during some time I've realised that in Node we expose modules in many different ways. In some modules we expose a simple function or a collection of functions or an object with a bunch of methods or a classical function that acts like a class constructor (ES5). That's cool and you can expose whatever you want but in projects with a large code base I find that a little confusing, because you never know what it's being exposed when you require a module and you end reading the code of the required module in order to know how to use it.

In conclusion, IMHO exposing always a class you can do whatever you need to expose and it's pretty predictable for other developers.

Thoughts?
`</rant>`