### PR TITLE
Upgrade camshsft to 0.59.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,9 @@
 Released 2017-mm-dd
  - Upgrades camshaft, cartodb-query-tables, and turbo-carto: better support for query variables.
 
-
 Bugfixes:
  - Bounding box parameter ignored in static named maps #735.
-
+ - camhaft 0.59.1 fixes duplicate columns in aggregate-intersection analysis
 
 ## 3.12.10
 Released 2017-09-18

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "body-parser": "~1.14.0",
-    "camshaft": "0.59.0",
+    "camshaft": "0.59.1",
     "cartodb-psql": "0.10.1",
     "cartodb-query-tables": "0.3.0",
     "cartodb-redis": "0.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,9 +219,9 @@ camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
-camshaft@0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/camshaft/-/camshaft-0.59.0.tgz#699c0834116ec87e067d42e11eea9540bddc6383"
+camshaft@0.59.1:
+  version "0.59.1"
+  resolved "https://registry.yarnpkg.com/camshaft/-/camshaft-0.59.1.tgz#a2e87fa4a0236655160cd1a6a9e966cbbf86dd43"
   dependencies:
     async "^1.5.2"
     bunyan "1.8.1"


### PR DESCRIPTION
This fixes duplicate column names in aggregate-intersection analysis

Let's add this to the next release (3.13.0), OK?