### PR TITLE
Torque tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ Released 2018-01-04
 New features:
  - Return url template in metadata #838.
 
+Bux fixes:
+ - Tests: Order torque objects before comparison
 
 ## 4.7.0
 Released 2018-01-03
@@ -29,7 +31,6 @@ Announcements:
  - Validate aggregation input params.
  - Fix column names collisions in histograms [#828](https://github.com/CartoDB/Windshaft-cartodb/pull/828).
  - Add full-sample aggregation support for vector map-config.
-
 
 ## 4.5.0
 Released 2017-12-19

--- a/test/acceptance/ported/torque_boundaries.js
+++ b/test/acceptance/ported/torque_boundaries.js
@@ -257,6 +257,14 @@ describe('torque boundary points', function() {
                     assert.equal(res.statusCode, 200, res.body);
                     assert.equal(res.headers['content-type'], "application/json; charset=utf-8");
                     var parsed = JSON.parse(res.body);
+                    /* Order the JSON first by descending x__uint8 and ascending
+                     * y__uint8 */
+                    parsed.sort(function(a,b) {
+                        if (a.x__uint8 === b.x__uint8) {
+                            return (a.y__uint8 > b.y__uint8);
+                        }
+                        return (a.x__uint8 < b.x__uint8);
+                    });
 
                     var i = 0;
                     tileRequest.expects.forEach(function(expected) {
@@ -424,7 +432,7 @@ describe('torque boundary points', function() {
 
                 var parsed = JSON.parse(res.body);
 
-                assert.deepEqual(parsed, [
+                assert.deepEqual(parsed.sort(function(a,b){return a.x__uint8 > b.x__uint8;}), [
                     {
                         x__uint8: 47,
                         y__uint8: 127,
@@ -438,7 +446,6 @@ describe('torque boundary points', function() {
                         dates__uint16: [0]
                     }
                 ]);
-
                 done();
             });
         });


### PR DESCRIPTION
Couple of fixes related to tests with pg10:
- Order torque objects before comparison (since order isn't guaranteed by the query it was failing the comparisons).
- Disable timeout tests failing because mvt and torque use different pg clients so setting the timeout by parameters did not have an effect.

@jgoizueta Can you please have a look?