### PR TITLE
Timeseries: Avoid collisions with columns named 'timestamp'

### DIFF
--- a/lib/cartodb/models/dataview/histograms/date-histogram.js
+++ b/lib/cartodb/models/dataview/histograms/date-histogram.js
@@ -56,7 +56,7 @@ __wd_buckets AS
         ${ctx.query}
     ) __source, __wd_tz
     ${condition_str}
-    GROUP BY timestamp, __wd_tz.name
+    GROUP BY 1, __wd_tz.name
 ),`;
 }
 

--- a/lib/cartodb/models/dataview/histograms/numeric-histogram.js
+++ b/lib/cartodb/models/dataview/histograms/numeric-histogram.js
@@ -28,7 +28,7 @@ const binsQueryTpl = ctx => `
             ) AS quartile
             FROM __cdb_filtered_source) _cdb_quartiles
             WHERE quartile = 1 or quartile = 3
-            GROUP BY quartile
+            GROUP BY 1
         ) __cdb_iqr
     ),
     __cdb_bins AS (
@@ -137,8 +137,8 @@ FROM
 (
     ${ctx.query}
 ) __cdb_filtered_source_query${extra_tables}
-GROUP BY bin${extra_groupby}
-ORDER BY bin;`;
+GROUP BY 10${extra_groupby}
+ORDER BY 10;`;
     }
 
     _hasOverridenBins (override) {


### PR DESCRIPTION
PR to avoid name clashes when the dataset column in named `timestamp` which trigger and invalid `GROUP BY` so you could get several bins with the same number. For example:
```json
{"aggregation":"decade","offset":0,"timestamp_start":631152000,"bin_width":315576000,"bins_count":3,"bins_start":631152000,"nulls":0,"bins":[{"bin":0,"min":631152000,"max":631152000,"avg":631152000,"freq":123,"timestamp":631152000},{"bin":0,"min":631152000,"max":631152000,"avg":631152000,"freq":119,"timestamp":631152000},{"bin":0,"min":631152000,"max":631152000,"avg":631152000,"freq":122,"timestamp":631152000},{"bin":0,"min":631152000,"max":631152000,"avg":631152000,"freq":120,"timestamp":631152000},{"bin":1,"min":946684800,"max":946684800,"avg":946684800,"freq":116,"timestamp":946684800},{"bin":1,"min":946684800,"max":946684800,"avg":946684800,"freq":127,"timestamp":946684800},{"bin":1,"min":946684800,"max":946684800,"avg":946684800,"freq":120,"timestamp":946684800},{"bin":1,"min":946684800,"max":946684800,"avg":946684800,"freq":129,"timestamp":946684800},{"bin":1,"min":946684800,"max":946684800,"avg":946684800,"freq":126,"timestamp":946684800},{"bin":1,"min":946684800,"max":946684800,"avg":946684800,"freq":124,"timestamp":946684800},{"bin":1,"min":946684800,"max":946684800,"avg":946684800,"freq":125,"timestamp":946684800},{"bin":2,"min":1262304000,"max":1262304000,"avg":1262304000,"freq":116,"timestamp":1262304000},{"bin":2,"min":1262304000,"max":1262304000,"avg":1262304000,"freq":110,"timestamp":1262304000},{"bin":2,"min":1262304000,"max":1262304000,"avg":1262304000,"freq":112,"timestamp":1262304000},{"bin":2,"min":1262304000,"max":1262304000,"avg":1262304000,"freq":117,"timestamp":1262304000},{"bin":2,"min":1262304000,"max":1262304000,"avg":1262304000,"freq":113,"timestamp":1262304000}],"type":"histogram"}
```

Now:
```json
{"aggregation":"decade","offset":0,"timestamp_start":631152000,"bin_width":315576000,"bins_count":3,"bins_start":631152000,"nulls":0,"bins":[{"bin":0,"min":631152000,"max":631152000,"avg":631152000,"freq":607,"timestamp":631152000},{"bin":1,"min":946684800,"max":946684800,"avg":946684800,"freq":1241,"timestamp":946684800},{"bin":2,"min":1262304000,"max":1262304000,"avg":1262304000,"freq":568,"timestamp":1262304000}],"type":"histogram"}
```

Fixes https://github.com/CartoDB/Windshaft-cartodb/issues/827