### PR TITLE
In vector-only map-config, only aggregate layers with points

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## 4.6.1
 Released 2018-mm-dd
+ - Allow to create vector map-config for layers that doesn't have points. Layers with lines or polygons won't be aggregated by default.
 
 
 ## 4.6.0

--- a/lib/cartodb/models/mapconfig/adapter/aggregation-mapconfig-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/aggregation-mapconfig-adapter.js
@@ -132,7 +132,7 @@ module.exports = class AggregationMapConfigAdapter {
 
             const result = res.rows[0] || {};
 
-            if (!AggregationMapConfig.supportsGeometryType(result.type)) {
+            if (!mapConfig.isVectorOnlyMapConfig() && !AggregationMapConfig.supportsGeometryType(result.type)) {
                 const message = unsupportedGeometryTypeErrorMessage({ geometryType: result.type });
                 const error = new Error(message);
                 error.type = 'layer';
@@ -143,6 +143,10 @@ module.exports = class AggregationMapConfigAdapter {
                 };
 
                 return callback(error);
+            }
+
+            if (mapConfig.isVectorOnlyMapConfig() && !AggregationMapConfig.supportsGeometryType(result.type)) {
+                return callback(null, false);
             }
 
             if (!mapConfig.doesLayerReachThreshold(index, result.count)) {

--- a/test/acceptance/aggregation.js
+++ b/test/acceptance/aggregation.js
@@ -1271,9 +1271,7 @@ describe('aggregation', function () {
 
                         const tileJSON = tile.toJSON();
 
-                        tileJSON[0].features.forEach(feature => {
-                            assert.equal(typeof feature.properties.value, 'number');
-                        });
+                        assert.equal(tileJSON[0].features.length, 7);
 
                         done();
                     });
@@ -1324,9 +1322,7 @@ describe('aggregation', function () {
 
                         const tileJSON = tile.toJSON();
 
-                        tileJSON[0].features.forEach(feature => {
-                            assert.equal(typeof feature.properties.value, 'number');
-                        });
+                        assert.equal(tileJSON[0].features.length, 7);
 
                         done();
                     });

--- a/test/acceptance/aggregation.js
+++ b/test/acceptance/aggregation.js
@@ -471,6 +471,8 @@ describe('aggregation', function () {
                         type: 'cartodb',
                         options: {
                             sql: POLYGONS_SQL_1,
+                            cartocss: '#layer { marker-width: [value]; }',
+                            cartocss_version: '2.3.0',
                             aggregation: {
                                 threshold: 1
                             }
@@ -1233,7 +1235,9 @@ describe('aggregation', function () {
                 });
             });
 
-            it('should skip aggregation w/o failing when is Vector Only MapConfig and layer has polygons', function (done) {
+
+            it('should skip aggregation w/o failing when is Vector Only MapConfig and layer has polygons',
+            function (done) {
                 this.mapConfig = createVectorMapConfig([
                     {
                         type: 'cartodb',
@@ -1244,23 +1248,90 @@ describe('aggregation', function () {
                 ]);
 
                 this.testClient = new TestClient(this.mapConfig);
-                const options = {
-                    format: 'mvt'
-                };
 
-                this.testClient.getTile(0, 0, 0, options, (err, res, tile) => {
+                this.testClient.getLayergroup((err, body) => {
                     if (err) {
                         return done(err);
                     }
 
-                    const tileJSON = tile.toJSON();
+                    assert.equal(typeof body.metadata, 'object');
+                    assert.ok(Array.isArray(body.metadata.layers));
 
-                    tileJSON[0].features.forEach(feature => assert.equal(typeof feature.properties.value, 'number'));
+                    body.metadata.layers.forEach(layer => assert.ok(!layer.meta.aggregation.mvt));
+                    body.metadata.layers.forEach(layer => assert.ok(!layer.meta.aggregation.png));
 
-                    done();
+                    const options = {
+                        format: 'mvt'
+                    };
+
+                    this.testClient.getTile(0, 0, 0, options, (err, res, tile) => {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        const tileJSON = tile.toJSON();
+
+                        tileJSON[0].features.forEach(feature => {
+                            assert.equal(typeof feature.properties.value, 'number');
+                        });
+
+                        done();
+                    });
                 });
             });
 
+            it('should skip aggregation for polygons (w/o failing) and aggregate when the layer has points',
+            function (done) {
+                this.mapConfig = createVectorMapConfig([
+                    {
+                        type: 'cartodb',
+                        options: {
+                            sql: POLYGONS_SQL_1
+                        }
+                    },
+                    {
+                        type: 'cartodb',
+                        options: {
+                            sql: POINTS_SQL_1,
+                            aggregation: {
+                                threshold: 1
+                            }
+                        }
+                    }
+                ]);
+
+                this.testClient = new TestClient(this.mapConfig);
+
+                this.testClient.getLayergroup((err, body) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    assert.equal(typeof body.metadata, 'object');
+                    assert.ok(Array.isArray(body.metadata.layers));
+
+                    assert.equal(body.metadata.layers[0].meta.aggregation.mvt, false);
+                    assert.equal(body.metadata.layers[1].meta.aggregation.mvt, true);
+
+                    const options = {
+                        format: 'mvt'
+                    };
+
+                    this.testClient.getTile(0, 0, 0, options, (err, res, tile) => {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        const tileJSON = tile.toJSON();
+
+                        tileJSON[0].features.forEach(feature => {
+                            assert.equal(typeof feature.properties.value, 'number');
+                        });
+
+                        done();
+                    });
+                });
+            });
         });
     });
 });

--- a/test/acceptance/aggregation.js
+++ b/test/acceptance/aggregation.js
@@ -1233,6 +1233,34 @@ describe('aggregation', function () {
                 });
             });
 
+            it('should skip aggregation w/o failing when is Vector Only MapConfig and layer has polygons', function (done) {
+                this.mapConfig = createVectorMapConfig([
+                    {
+                        type: 'cartodb',
+                        options: {
+                            sql: POLYGONS_SQL_1
+                        }
+                    }
+                ]);
+
+                this.testClient = new TestClient(this.mapConfig);
+                const options = {
+                    format: 'mvt'
+                };
+
+                this.testClient.getTile(0, 0, 0, options, (err, res, tile) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const tileJSON = tile.toJSON();
+
+                    tileJSON[0].features.forEach(feature => assert.equal(typeof feature.properties.value, 'number'));
+
+                    done();
+                });
+            });
+
         });
     });
 });


### PR DESCRIPTION
Since we aggregate points by default for vector-only map-config we must skip aggregation for polygon/line layers instead of responding with an error. Thus, the user doesn't have to take care of aggregation at all when is sending vector-only map-config.

cc/ @rochoa for awareness