### PR TITLE
Bump windshaft version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - docker pull cartoimages/windshaft-carto-testing
 
 script:
-  - docker run -e POSTGIS_VERSION=2.4 -v `pwd`:/srv cartoimages/windshaft-carto-testing
+  - docker run -e POSTGIS_VERSION=2.4 -v `pwd`:/srv cartoimages/windshaft-carto-testing bash docker-test.sh
 
 language: generic
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,15 @@
 # Changelog
 
-## 4.8.1
+## 4.9.0
 Released 2018-mm-dd
+
+New features:
+ - Now mapnik has support for fine-grained metrics.
+ - Variables can be passed for later substitution in postgis datasource.
+
+Announcements:
+ - Upgrade windshaft to [4.3.0](https://github.com/CartoDB/windshaft/releases/tag/4.3.0). Underneath it upgrades mapnik and all the related dependencies.
+ - Use the script docker-test.sh for travis builds.
 
 
 ## 4.8.0

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "step-profiler": "~0.3.0",
     "turbo-carto": "0.20.2",
     "underscore": "~1.6.0",
-    "windshaft": "4.2.0",
+    "windshaft": "4.3.0",
     "yargs": "~5.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,33 @@
 # yarn lockfile v1
 
 
-abaculus@cartodb/abaculus#2.0.3-cdb1:
-  version "2.0.3-cdb1"
-  resolved "https://codeload.github.com/cartodb/abaculus/tar.gz/f5f34e1c80cdd8d49edd1d6fe3b2220ab2e23aaf"
+"@carto/mapnik@3.6.2-carto.1", "@carto/mapnik@~3.6.2-carto.0":
+  version "3.6.2-carto.1"
+  resolved "https://registry.yarnpkg.com/@carto/mapnik/-/mapnik-3.6.2-carto.1.tgz#149318e9a75d0a10ed8aab528c6cd64018a5a538"
   dependencies:
+    mapnik-vector-tile "1.5.0"
+    nan "~2.7.0"
+    node-pre-gyp "~0.6.30"
+    protozero "1.5.1"
+
+"@carto/tilelive-bridge@cartodb/tilelive-bridge#2.5.1-cdb1":
+  version "2.5.1-cdb1"
+  resolved "https://codeload.github.com/cartodb/tilelive-bridge/tar.gz/b0b5559f948e77b337bc9a9ae0bf6ec4249fba21"
+  dependencies:
+    "@carto/mapnik" "~3.6.2-carto.0"
+    "@mapbox/sphericalmercator" "~1.0.1"
+    mapnik-pool "~0.1.3"
+
+"@mapbox/sphericalmercator@~1.0.1":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz#70237b9774095ed1cfdbcea7a8fd1fc82b2691f2"
+
+abaculus@cartodb/abaculus#2.0.3-cdb2:
+  version "2.0.3-cdb2"
+  resolved "https://codeload.github.com/cartodb/abaculus/tar.gz/6468e0e3fddb2b23f60b9a3156117cff0307f6dc"
+  dependencies:
+    "@carto/mapnik" "~3.6.2-carto.0"
     d3-queue "^2.0.2"
-    mapnik "~3.5.0"
     sphericalmercator "1.0.x"
 
 abbrev@1:
@@ -244,9 +265,9 @@ carto@0.16.3:
     semver "^5.1.0"
     yargs "^4.2.0"
 
-"carto@github:cartodb/carto#0.15.1-cdb1":
+carto@CartoDB/carto#0.15.1-cdb1:
   version "0.15.1-cdb1"
-  resolved "https://codeload.github.com/cartodb/carto/tar.gz/8050ec843f1f32a6469e5d1cf49602773015d398"
+  resolved "https://codeload.github.com/CartoDB/carto/tar.gz/8050ec843f1f32a6469e5d1cf49602773015d398"
   dependencies:
     mapnik-reference "~6.0.2"
     optimist "~0.6.0"
@@ -823,7 +844,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -842,9 +863,9 @@ graceful-fs@^4.1.2:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-grainstore@~1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/grainstore/-/grainstore-1.8.0.tgz#9398729df88f3aecb55ffbb415d541dcca4420af"
+grainstore@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/grainstore/-/grainstore-1.8.1.tgz#5a0f9ef35dedffb4a393d5339dffc2a8ae19a897"
   dependencies:
     carto "0.16.3"
     debug "~3.1.0"
@@ -1273,18 +1294,9 @@ mapnik-reference@~8.5.3:
   dependencies:
     semver "^5.1.0"
 
-mapnik-vector-tile@~1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/mapnik-vector-tile/-/mapnik-vector-tile-1.2.2.tgz#42795ca211dd274a9a4af5bf6cfe3b0bfe0ba243"
-
-mapnik@3.5.14, mapnik@~3.5.0:
-  version "3.5.14"
-  resolved "https://registry.yarnpkg.com/mapnik/-/mapnik-3.5.14.tgz#632bd6635c72c0214a707549309ba416594afff7"
-  dependencies:
-    mapnik-vector-tile "~1.2.2"
-    nan "~2.4.0"
-    node-pre-gyp "~0.6.30"
-    protozero "~1.4.2"
+mapnik-vector-tile@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/mapnik-vector-tile/-/mapnik-vector-tile-1.5.0.tgz#c647bfb8027e9dc40db583505a436f35e2101407"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -1737,9 +1749,9 @@ propagate@0.3.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.3.1.tgz#e3a84404a7ece820dd6bbea9f6d924e3135ae09c"
 
-protozero@~1.4.2:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/protozero/-/protozero-1.4.5.tgz#80eaa80a4f9c751465c4cb2620d8233b50ec1aff"
+protozero@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/protozero/-/protozero-1.5.1.tgz#5a27df6fb6e1ed743f510812ae76c082f5b16638"
 
 proxy-addr@~2.0.2:
   version "2.0.2"
@@ -2223,20 +2235,12 @@ through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-tilelive-bridge@cartodb/tilelive-bridge#2.3.1-cdb4:
-  version "2.3.1-cdb4"
-  resolved "https://codeload.github.com/cartodb/tilelive-bridge/tar.gz/faa2b638da2d119b78281575d40255cb523f6ca6"
+tilelive-mapnik@cartodb/tilelive-mapnik#0.6.18-cdb4:
+  version "0.6.18-cdb4"
+  resolved "https://codeload.github.com/cartodb/tilelive-mapnik/tar.gz/510cfb6f033f7551f973886751643202d4cb5f4a"
   dependencies:
-    mapnik "~3.5.0"
-    mapnik-pool "~0.1.3"
-    sphericalmercator "1.0.x"
-
-tilelive-mapnik@cartodb/tilelive-mapnik#0.6.18-cdb3:
-  version "0.6.18-cdb3"
-  resolved "https://codeload.github.com/cartodb/tilelive-mapnik/tar.gz/23bd1c31dd57d0b76c86b9f1eaf62462b3c17d01"
-  dependencies:
+    "@carto/mapnik" "~3.6.2-carto.0"
     generic-pool "~2.4.0"
-    mapnik "3.5.14"
     mime "~1.3.4"
     sphericalmercator "~1.0.4"
     step "~0.0.5"
@@ -2392,18 +2396,19 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
-windshaft@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/windshaft/-/windshaft-4.2.0.tgz#6a0409832a0d3bccfa09a88a8ab8288686b6762d"
+windshaft@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/windshaft/-/windshaft-4.3.0.tgz#47fcafda4bd87beb6358e2d44b5739a367076120"
   dependencies:
-    abaculus cartodb/abaculus#2.0.3-cdb1
+    "@carto/mapnik" "3.6.2-carto.1"
+    "@carto/tilelive-bridge" cartodb/tilelive-bridge#2.5.1-cdb1
+    abaculus cartodb/abaculus#2.0.3-cdb2
     canvas cartodb/node-canvas#1.6.2-cdb2
     carto cartodb/carto#0.15.1-cdb3
     cartodb-psql "^0.10.1"
     debug "^3.1.0"
     dot "~1.0.2"
-    grainstore "~1.8.0"
-    mapnik "3.5.14"
+    grainstore "~1.8.1"
     queue-async "~1.0.7"
     redis-mpool "0.4.1"
     request "^2.83.0"
@@ -2411,8 +2416,7 @@ windshaft@4.2.0:
     sphericalmercator "1.0.4"
     step "~0.0.6"
     tilelive "5.12.2"
-    tilelive-bridge cartodb/tilelive-bridge#2.3.1-cdb4
-    tilelive-mapnik cartodb/tilelive-mapnik#0.6.18-cdb3
+    tilelive-mapnik cartodb/tilelive-mapnik#0.6.18-cdb4
     torque.js "~2.11.0"
     underscore "~1.6.0"
 


### PR DESCRIPTION
That version contains our flavor of mapnik 3.0.15 with a bunch of
patches. See
https://github.com/CartoDB/Windshaft/blob/master/NEWS.md#version-430