### PR TITLE
Do not pass the entire res.locals to named maps provider cache

### DIFF
--- a/lib/cartodb/controllers/named_maps.js
+++ b/lib/cartodb/controllers/named_maps.js
@@ -74,8 +74,9 @@ NamedMapsController.prototype.getNamedMapProvider = function (label) {
         const { user } = res.locals;
         const { config, auth_token } = req.query;
         const { template_id } = req.params;
+        const params = Object.assign({}, res.locals);
 
-        this.namedMapProviderCache.get(user, template_id, config, auth_token, res.locals, (err, namedMapProvider) => {
+        this.namedMapProviderCache.get(user, template_id, config, auth_token, params, (err, namedMapProvider) => {
             if (err) {
                 err.label = label;
                 return next(err);
@@ -146,11 +147,17 @@ NamedMapsController.prototype.prepareLayerFilterFromPreviewLayers = function (la
             return next();
         }
 
+        const params = Object.assign({}, res.locals);
+
+        delete params.template;
+        delete params.affectedTablesAndLastUpdate;
+        delete params.namedMapProvider;
+
         // overwrites 'all' default filter
-        res.locals.layer = layerVisibilityFilter.join(',');
+        params.layer = layerVisibilityFilter.join(',');
 
         // recreates the provider
-        this.namedMapProviderCache.get(user, template_id, config, auth_token, res.locals, (err, provider) => {
+        this.namedMapProviderCache.get(user, template_id, config, auth_token, params, (err, provider) => {
             if (err) {
                 err.label = label;
                 return next(err);

--- a/lib/cartodb/controllers/named_maps.js
+++ b/lib/cartodb/controllers/named_maps.js
@@ -16,6 +16,17 @@ function numMapper(n) {
     return +n;
 }
 
+function getRequestParams(locals) {
+    const params = Object.assign({}, locals);
+
+    delete params.template;
+    delete params.affectedTablesAndLastUpdate;
+    delete params.namedMapProvider;
+    delete params.allowedQueryParams;
+
+    return params;
+}
+
 function NamedMapsController(prepareContext, namedMapProviderCache, tileBackend, previewBackend,
                              surrogateKeysCache, tablesExtentApi, metadataBackend) {
     this.namedMapProviderCache = namedMapProviderCache;
@@ -74,7 +85,7 @@ NamedMapsController.prototype.getNamedMapProvider = function (label) {
         const { user } = res.locals;
         const { config, auth_token } = req.query;
         const { template_id } = req.params;
-        const params = Object.assign({}, res.locals);
+        const params = getRequestParams(res.locals);
 
         this.namedMapProviderCache.get(user, template_id, config, auth_token, params, (err, namedMapProvider) => {
             if (err) {
@@ -147,11 +158,7 @@ NamedMapsController.prototype.prepareLayerFilterFromPreviewLayers = function (la
             return next();
         }
 
-        const params = Object.assign({}, res.locals);
-
-        delete params.template;
-        delete params.affectedTablesAndLastUpdate;
-        delete params.namedMapProvider;
+        const params = getRequestParams(res.locals);
 
         // overwrites 'all' default filter
         params.layer = layerVisibilityFilter.join(',');


### PR DESCRIPTION
## Context

We are binding objects and functions to `res.locals` to be able to share information between middlewares and we were passing the entire `res.locals` (previously res.params) to `NamedMapProviderCache`. Then `NamedMapProviderCache` passed the same `res.locals` to the `MapConfigProvider`, when it returns the MapConfig along `params`,  are the entire `res.locals`, which is passed to the renderer. At this point `params` contains a circular reference and is a class member of `mml-builder` when it tries to serialize the context of the object via `process.send` it performs a `JSON.stringify` that brokes the normal execution throwing an `Uncaught exception`. 💥  the process is in an undefined state. 🤓

cc @jorgesancha & @rochoa for awareness.
