### PR TITLE
Removing docker windshaft-carto-testing image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ services:
   - docker
 
 before_install:
-  - docker pull cartoimages/windshaft-carto-testing
+  - docker pull cartoimages/windshaft-testing
 
 script:
-  - docker run -e POSTGIS_VERSION=2.4 -v `pwd`:/srv cartoimages/windshaft-carto-testing
+  - docker run -e POSTGIS_VERSION=2.4 -v `pwd`:/srv cartoimages/windshaft-testing bash docker-test.sh
 
 language: generic
 

--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "docker-install": "sudo apt install docker.io && sudo usermod -aG docker $(whoami)",
     "docker-pull": "docker pull cartoimages/windshaft-testing",
     "docker-test": "docker run -v `pwd`:/srv cartoimages/windshaft-testing bash docker-test.sh && docker ps --filter status=dead --filter status=exited -aq | xargs -r docker rm -v",
-    "docker-bash": "docker run  -it -v `pwd`:/srv cartoimages/windshaft-testing bash",
-    "docker-publish": "docker push cartoimages/windshaft-carto-testing"
+    "docker-bash": "docker run  -it -v `pwd`:/srv cartoimages/windshaft-testing bash"
   },
   "engines": {
     "node": ">=6.9",


### PR DESCRIPTION
We must use `cartoimages/windshaft-testing` docker image instead of the deprecated `cartoimages/windshaft-carto-testing`