### PR TITLE
use original column name in group by instead of alias

### DIFF
--- a/lib/cartodb/models/dataview/aggregation.js
+++ b/lib/cartodb/models/dataview/aggregation.js
@@ -120,7 +120,7 @@ const aggregationQueryTpl = ctx => `
         ${ctx.isFloatColumn ? `${specialNumericValuesColumns(ctx)}` : '' }
     FROM (${ctx.query}) _cdb_aggregation_all, summary, categories_summary_min_max, categories_summary_count
     GROUP BY
-        category,
+        ${ctx.column},
         nulls_count,
         min_val,
         max_val,


### PR DESCRIPTION
There is some problem using in the `GROUP BY` an aliased property defined in the `SELECT`:

```sql
   SELECT
        CAST(company_na AS text) AS category,
        count(company_na) AS value
    FROM scoutarticles
    GROUP BY
       category
```

There're some solutions:
1. use in the `GROUP BY` the index of the property in the `SELECT`:
```sql
   SELECT
        CAST(company_na AS text) AS category,
        count(company_na) AS value
    FROM scoutarticles
    GROUP BY
       1
```

2. use in the `GROUP BY` the original column name:
```sql
   SELECT
        CAST(company_na AS text) AS category,
        count(company_na) AS value
    FROM scoutarticles
    GROUP BY
       company_na
```

I've implemented option 2.