### PR TITLE
Respect category type of aggregation dataview 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 4.8.1
-Released 2018-mm-dd
+## 5.0.0
+Released 2018-01-29
 
+Backward incompatible changes:
+- Aggregation dataview returns categories with the same type as the database type. For example, if we are aggretating by a numeric field, the resulting JSON will contain a number instead of a stringified number.
 
 ## 4.8.0
 Released 2018-01-04

--- a/lib/cartodb/models/dataview/aggregation.js
+++ b/lib/cartodb/models/dataview/aggregation.js
@@ -74,7 +74,7 @@ const specialNumericValuesColumns = () => `, nans_count, infinities_count`;
 
 const rankedAggregationQueryTpl = ctx => `
     SELECT
-        CAST(category AS text),
+        category,
         value,
         false as agg,
         nulls_count,
@@ -109,7 +109,7 @@ const rankedAggregationQueryTpl = ctx => `
 
 const aggregationQueryTpl = ctx => `
     SELECT
-        CAST(${ctx.column} AS text) AS category,
+        ${ctx.column} AS category,
         ${ctx.aggregationFn} AS value,
         false as agg,
         nulls_count,

--- a/lib/cartodb/models/dataview/aggregation.js
+++ b/lib/cartodb/models/dataview/aggregation.js
@@ -294,7 +294,7 @@ module.exports = class Aggregation extends BaseDataview {
             categoriesCount: categories_count,
             categories: result.rows.map(({ category, value, agg }) => {
                 return { 
-                    category: agg ? 'Others' : category,
+                    category: agg ? 'Other' : category,
                     value, 
                     agg 
                 };

--- a/lib/cartodb/models/dataview/aggregation.js
+++ b/lib/cartodb/models/dataview/aggregation.js
@@ -87,7 +87,7 @@ const rankedAggregationQueryTpl = ctx => `
         WHERE rank < ${ctx.limit}
     UNION ALL
     SELECT
-        'Other' category,
+        null category,
         ${ctx.aggregation !== 'count' ? ctx.aggregation : 'sum'}(value) as value,
         true as agg,
         nulls_count,
@@ -282,7 +282,7 @@ module.exports = class Aggregation extends BaseDataview {
             max_val = 0,
             categories_count = 0
          } = result.rows[0] || {};
-
+        
         return {
             aggregation: this.aggregation,
             count: count,
@@ -292,7 +292,13 @@ module.exports = class Aggregation extends BaseDataview {
             min: min_val,
             max: max_val,
             categoriesCount: categories_count,
-            categories: result.rows.map(({ category, value, agg }) => ({ category, value, agg }))
+            categories: result.rows.map(({ category, value, agg }) => {
+                return { 
+                    category: agg ? 'Others' : category,
+                    value, 
+                    agg 
+                };
+            })
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "windshaft-cartodb",
-  "version": "4.8.1",
+  "version": "5.0.0",
   "description": "A map tile server for CartoDB",
   "keywords": [
     "cartodb"


### PR DESCRIPTION
Currently, we cast the `category` field to string, regardless of what real type of the `category` field.

So, if we aggregate a numeric field, we are returning:
```
...
"categories": [
    {
      "category": "10",
      "value": 1,
      "agg": false
    },
    {
      "category": "4",
      "value": 1,
      "agg": false
    },
...
```

This behavior is a problem for the frontend https://github.com/CartoDB/support/issues/1248 that need to receive the real type of the value.