### PR TITLE
Add cartodb_id to point-grid aggregations

### DIFF
--- a/lib/cartodb/models/aggregation/aggregation-query.js
+++ b/lib/cartodb/models/aggregation/aggregation-query.js
@@ -211,6 +211,7 @@ const aggregationQueryTemplates = {
             GROUP BY _cdb_gx, _cdb_gy ${dimensionNames(ctx)}
         )
         SELECT
+            row_number() over() AS cartodb_id,
             ST_SetSRID(ST_MakePoint((_cdb_gx+0.5)*res, (_cdb_gy+0.5)*res), 3857) AS the_geom_webmercator
             ${dimensionNames(ctx)}
             ${aggregateColumnNames(ctx)}

--- a/test/acceptance/aggregation.js
+++ b/test/acceptance/aggregation.js
@@ -1366,6 +1366,41 @@ describe('aggregation', function () {
                     });
                 });
             });
+
+            ['centroid', 'point-sample', 'point-grid'].forEach(placement => {
+                it(`cartodb_id should be present in ${placement} aggregation`, function(done) {
+                    this.mapConfig = createVectorMapConfig([
+                        {
+                            type: 'cartodb',
+                            options: {
+                                sql: POINTS_SQL_1,
+                                aggregation: {
+                                    placement: placement,
+                                    threshold: 1
+                                },
+                                cartocss: '#layer { marker-width: 1; }',
+                                cartocss_version: '2.3.0',
+                                interactivity: ['cartodb_id']
+                            }
+                        }
+                    ]);
+
+                    this.testClient = new TestClient(this.mapConfig);
+                    this.testClient.getLayergroup((err, body) => {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        assert.equal(typeof body.metadata, 'object');
+                        assert.ok(Array.isArray(body.metadata.layers));
+
+                        body.metadata.layers.forEach(layer => assert.ok(layer.meta.aggregation.mvt));
+                        body.metadata.layers.forEach(layer => assert.ok(layer.meta.aggregation.png));
+
+                        done();
+                    });
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
See #846

point-grid is missing cartodb_id, so if it's used (e.g. present in interactivity) it will fail