### PR TITLE
removing raster image on timeout error

### DIFF
--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -338,7 +338,7 @@ var config = {
     // Use this as a feature flags enabling/disabling mechanism
     ,enabledFeatures: {
         // whether it should intercept tile render errors an act based on them, enabled by default.
-        onTileErrorStrategy: true,
+        onTileErrorStrategy: false,
         // whether the affected tables for a given SQL must query directly postgresql or use the SQL API
         cdbQueryTablesFromPostgres: true,
         // whether in mapconfig is available stats & metadata for each layer

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -338,7 +338,7 @@ var config = {
     // Use this as a feature flags enabling/disabling mechanism
     ,enabledFeatures: {
         // whether it should intercept tile render errors an act based on them, enabled by default.
-        onTileErrorStrategy: true,
+        onTileErrorStrategy: false,
         // whether the affected tables for a given SQL must query directly postgresql or use the SQL API
         cdbQueryTablesFromPostgres: true,
         // whether in mapconfig is available stats & metadata for each layer

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -338,7 +338,7 @@ var config = {
     // Use this as a feature flags enabling/disabling mechanism
     ,enabledFeatures: {
         // whether it should intercept tile render errors an act based on them, enabled by default.
-        onTileErrorStrategy: true,
+        onTileErrorStrategy: false,
         // whether the affected tables for a given SQL must query directly postgresql or use the SQL API
         cdbQueryTablesFromPostgres: true,
         // whether in mapconfig is available stats & metadata for each layer

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -333,7 +333,7 @@ var config = {
     // Use this as a feature flags enabling/disabling mechanism
     ,enabledFeatures: {
         // whether it should intercept tile render errors an act based on them, enabled by default.
-        onTileErrorStrategy: true,
+        onTileErrorStrategy: false,
         // whether the affected tables for a given SQL must query directly postgresql or use the SQL API
         cdbQueryTablesFromPostgres: true,
         // whether in mapconfig is available stats & metadata for each layer


### PR DESCRIPTION
Tile render timeout is showing cartofante and we don't want to show it anymore.

The real change to remove it is an infrastructure task (changing the config example file, nothing happens), but I create this PR for consistency

More info --> https://github.com/CartoDB/cartodb/issues/13447