### PR TITLE
Improve the speed of the aggregation dataview

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.3.1
+Released yyyy-mm-dd
+ - Improve the speed of the aggregation dataview #865
+
 ## 5.3.0
 Released 2018-02-12
  - Upgrades redis-mpool to 0.5.0

--- a/lib/cartodb/models/dataview/aggregation.js
+++ b/lib/cartodb/models/dataview/aggregation.js
@@ -2,19 +2,17 @@ const BaseDataview = require('./base');
 const debug = require('debug')('windshaft:dataview:aggregation');
 
 const filteredQueryTpl = ctx => `
-    (
-        SELECT *
-        FROM (${ctx.query}) _cdb_filtered_source
-        ${ctx.aggregationColumn && ctx.isFloatColumn ? `
-        WHERE
-            ${ctx.aggregationColumn} != 'infinity'::float
-        AND
-            ${ctx.aggregationColumn} != '-infinity'::float
-        AND
-            ${ctx.aggregationColumn} != 'NaN'::float` :
-        ''
-        }
-    ) filtered_source
+    SELECT *
+    FROM (${ctx.query}) _cdb_filtered_source
+    ${ctx.aggregationColumn && ctx.isFloatColumn ? `
+    WHERE
+        ${ctx.aggregationColumn} != 'infinity'::float
+    AND
+        ${ctx.aggregationColumn} != '-infinity'::float
+    AND
+        ${ctx.aggregationColumn} != 'NaN'::float` :
+    ''
+    }
 `;
 
 const summaryQueryTpl = ctx => `
@@ -43,7 +41,7 @@ const rankedCategoriesQueryTpl = ctx => `
             ${ctx.column} AS category,
             ${ctx.aggregationFn} AS value,
             row_number() OVER (ORDER BY ${ctx.aggregationFn} desc) as rank
-        FROM ${filteredQueryTpl(ctx)}
+        FROM (${filteredQueryTpl(ctx)}) filtered_source
         ${ctx.aggregationColumn !== null ? `WHERE ${ctx.aggregationColumn} IS NOT NULL` : ''}
         GROUP BY ${ctx.column}
         ORDER BY 2 DESC

--- a/lib/cartodb/models/dataview/aggregation.js
+++ b/lib/cartodb/models/dataview/aggregation.js
@@ -2,7 +2,7 @@ const BaseDataview = require('./base');
 const debug = require('debug')('windshaft:dataview:aggregation');
 
 const filteredQueryTpl = ctx => `
-    filtered_source AS (
+    (
         SELECT *
         FROM (${ctx.query}) _cdb_filtered_source
         ${ctx.aggregationColumn && ctx.isFloatColumn ? `
@@ -14,7 +14,7 @@ const filteredQueryTpl = ctx => `
             ${ctx.aggregationColumn} != 'NaN'::float` :
         ''
         }
-    )
+    ) filtered_source
 `;
 
 const summaryQueryTpl = ctx => `
@@ -43,7 +43,7 @@ const rankedCategoriesQueryTpl = ctx => `
             ${ctx.column} AS category,
             ${ctx.aggregationFn} AS value,
             row_number() OVER (ORDER BY ${ctx.aggregationFn} desc) as rank
-        FROM filtered_source
+        FROM ${filteredQueryTpl(ctx)}
         ${ctx.aggregationColumn !== null ? `WHERE ${ctx.aggregationColumn} IS NOT NULL` : ''}
         GROUP BY ${ctx.column}
         ORDER BY 2 DESC
@@ -134,7 +134,6 @@ const aggregationFnQueryTpl = ctx => `${ctx.aggregation}(${ctx.aggregationColumn
 
 const aggregationDataviewQueryTpl = ctx => `
     WITH
-    ${filteredQueryTpl(ctx)},
     ${summaryQueryTpl(ctx)},
     ${rankedCategoriesQueryTpl(ctx)},
     ${categoriesSummaryMinMaxQueryTpl(ctx)},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "windshaft-cartodb",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "A map tile server for CartoDB",
   "keywords": [
     "cartodb"


### PR DESCRIPTION
Improve the performance of the aggregation dataview.

Instead of using a CTE (WITH) for filtered_source, which is only used in
one place to calculate ranks, inject it as a subquery.

This way the planner has a chance to ignore uneeded columns as well as
to parallelize the exectution of the window function (WindowAgg in the
query plan).

That is the part that takes most of the time of the query.

The improvement is about 30-40% in speed on PG10 with 4 cores. With PG9.5 it is slightly better, but by a tiny 1%, depending on the underlying table and specific request.