### PR TITLE
Postgis permission error

### DIFF
--- a/lib/cartodb/backends/pg_connection.js
+++ b/lib/cartodb/backends/pg_connection.js
@@ -110,8 +110,6 @@ function isNameNotFoundError (err) {
 //
 PgConnection.prototype.setDBConn = function(dbowner, params, callback) {
     _.defaults(params, {
-        // dbuser: global.environment.postgres.user,
-        // dbpassword: global.environment.postgres.password,
         dbhost: global.environment.postgres.host,
         dbport: global.environment.postgres.port
     });

--- a/lib/cartodb/middleware/error-middleware.js
+++ b/lib/cartodb/middleware/error-middleware.js
@@ -62,9 +62,9 @@ const offendingRelationRegex = /permission denied for relation (\w+)/i;
 
 function getOffendingRelationFromError(err) {
     if (err.message) {
-        const relation = offendingRelationRegex.exec(err.message);
-        if (relation && relation.length > 1) {
-            return relation[1];
+        const relations = offendingRelationRegex.exec(err.message);
+        if (relations && relations.length > 1) {
+            return relations[1];
         }
     }
     return null;

--- a/lib/cartodb/middleware/error-middleware.js
+++ b/lib/cartodb/middleware/error-middleware.js
@@ -88,7 +88,6 @@ function populateErrors (errors) {
 
         if (isPermissionDeniedForRelationError(error)) {
             error.info = getOffendingRelationFromError(error);
-            error.message = 'permission denied for relation';
             error.type = error.type || 'auth';
             error.subtype = 'permission-denied-relation';
             error.http_status = 403;

--- a/lib/cartodb/middleware/error-middleware.js
+++ b/lib/cartodb/middleware/error-middleware.js
@@ -54,6 +54,22 @@ function isTimeoutError (err) {
     return isRenderTimeoutError(err) || isDatasourceTimeoutError(err);
 }
 
+function isPermissionDeniedForRelationError(err) {
+    return err.message && err.message.match(/permission denied for relation/i);   
+}
+
+const offendingRelationRegex = /permission denied for relation (\w+)/i;
+
+function getOffendingRelationFromError(err) {
+    if (err.message) {
+        const relation = offendingRelationRegex.exec(err.message);
+        if (relation && relation.length > 1) {
+            return relation[1];
+        }
+    }
+    return null;
+}
+
 function populateTimeoutErrors (errors) {
     return errors.map(function (error) {
         if (isRenderTimeoutError(error)) {
@@ -68,6 +84,17 @@ function populateTimeoutErrors (errors) {
             error.message = 'You are over platform\'s limits. Please contact us to know more details';
             error.type = 'limit';
             error.http_status = 429;
+        }
+
+        if (isPermissionDeniedForRelationError(error)) {
+            error.info = getOffendingRelationFromError(error);
+            error.message = 'permission denied for relation';
+            error.type = error.type || 'auth';
+            error.subtype = 'permission-denied-relation';
+            error.http_status = 403;
+
+            // console.log('error');
+            // console.log(error);
         }
 
         return error;
@@ -136,7 +163,8 @@ var ERROR_INFO_TO_EXPOSE = {
     layer: true,
     type: true,
     analysis: true,
-    subtype: true
+    subtype: true,
+    info: true
 };
 
 function shouldBeExposed (prop) {

--- a/lib/cartodb/middleware/error-middleware.js
+++ b/lib/cartodb/middleware/error-middleware.js
@@ -7,7 +7,7 @@ module.exports = function errorMiddleware (/* options */) {
         // jshint maxcomplexity:9
         var allErrors = Array.isArray(err) ? err : [err];
 
-        allErrors = populateTimeoutErrors(allErrors);
+        allErrors = populateErrors(allErrors);
 
         const label = err.label || 'UNKNOWN';
         err = allErrors[0] || new Error(label);
@@ -70,7 +70,7 @@ function getOffendingRelationFromError(err) {
     return null;
 }
 
-function populateTimeoutErrors (errors) {
+function populateErrors (errors) {
     return errors.map(function (error) {
         if (isRenderTimeoutError(error)) {
             error.subtype = 'render';

--- a/lib/cartodb/middleware/error-middleware.js
+++ b/lib/cartodb/middleware/error-middleware.js
@@ -92,9 +92,6 @@ function populateTimeoutErrors (errors) {
             error.type = error.type || 'auth';
             error.subtype = 'permission-denied-relation';
             error.http_status = 403;
-
-            // console.log('error');
-            // console.log(error);
         }
 
         return error;

--- a/test/acceptance/auth/authorization.js
+++ b/test/acceptance/auth/authorization.js
@@ -94,10 +94,15 @@ describe('authorization', function() {
             testClientGet.getTile(0, 0, 0, params, function(err, res, body) {
 
                 assert.ifError(err);
+                assert.equal(403, res.statusCode);
 
                 assert.ok(body.hasOwnProperty('errors'));
                 assert.equal(body.errors.length, 1);
                 assert.ok(body.errors[0].match(/permission denied/), body.errors[0]);
+
+                assert.equal(body.errors_with_context.length, 1);
+                assert.equal(body.errors_with_context[0].type, 'auth');
+                assert.equal(body.errors_with_context[0].subtype, 'permission-denied-relation');
 
                 testClientGet.drain(done);
             });
@@ -125,7 +130,10 @@ describe('authorization', function() {
 
             assert.ok(layergroupResult.hasOwnProperty('errors'));
             assert.equal(layergroupResult.errors.length, 1);
-            assert.ok(layergroupResult.errors[0].match(/permission denied/), layergroupResult.errors[0]);
+
+            assert.ok(layergroupResult.hasOwnProperty('errors_with_context'));    
+            assert.equal(layergroupResult.errors_with_context[0].type, 'layer');
+            assert.equal(layergroupResult.errors_with_context[0].subtype, 'permission-denied-relation');
 
             testClient.drain(done);
         });
@@ -203,6 +211,10 @@ describe('authorization', function() {
             assert.ok(layergroupResult.hasOwnProperty('errors'));
             assert.equal(layergroupResult.errors.length, 1);
             assert.ok(layergroupResult.errors[0].match(/permission denied/), layergroupResult.errors[0]);
+
+            assert.ok(layergroupResult.hasOwnProperty('errors_with_context'));
+            assert.equal(layergroupResult.errors_with_context[0].type, 'layer');
+            assert.equal(layergroupResult.errors_with_context[0].subtype, 'permission-denied-relation');
             
             testClient.drain(done);
         });
@@ -424,6 +436,10 @@ describe('authorization', function() {
             assert.ok(body.hasOwnProperty('errors'));
             assert.equal(body.errors.length, 1);
             assert.ok(body.errors[0].match(/permission denied/), body.errors[0]);
+
+            assert.ok(body.hasOwnProperty('errors_with_context'));
+            assert.equal(body.errors_with_context[0].type, 'auth');
+            assert.equal(body.errors_with_context[0].subtype, 'permission-denied-relation');
 
             testClient.drain(done);
         });

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -1336,7 +1336,10 @@ describe(suiteName, function() {
                 status: 403
             },
             function(res) {
-                assert.ok(res.body.match(/permission denied for relation test_table_private_1/));
+                var parsedBody = JSON.parse(res.body);
+                assert.ok(parsedBody.errors[0].match(/permission denied for relation/));
+                assert.equal(parsedBody.errors_with_context[0].subtype, 'permission-denied-relation');
+                assert.equal(parsedBody.errors_with_context[0].info, 'test_table_private_1');
                 done();
             }
         );

--- a/test/acceptance/named_layers.js
+++ b/test/acceptance/named_layers.js
@@ -659,7 +659,9 @@ describe('named_layers', function() {
                 }
 
                 var parsedBody = JSON.parse(response.body);
-                assert.ok(parsedBody.errors[0].match(/permission denied for relation test_table_private_1/));
+                assert.ok(parsedBody.errors[0].search(/permission denied for relation/i) >= 0);
+                assert.equal(parsedBody.errors_with_context[0].info, 'test_table_private_1');
+
 
                 return null;
             },

--- a/test/acceptance/turbo-carto/regressions.js
+++ b/test/acceptance/turbo-carto/regressions.js
@@ -79,7 +79,7 @@ describe('turbo-carto regressions', function() {
         ].join('\n');
 
         this.testClient = new TestClient(makeMapconfig('SELECT * FROM test_table_private_1', cartocss));
-        this.testClient.getLayergroup({ response: TestClient.RESPONSE.ERROR }, function(err, layergroup) {
+        this.testClient.getLayergroup({ response: TestClient.RESPONSE.GENERAL_AUTH_ERROR }, function(err, layergroup) {
             assert.ok(!err, err);
 
             assert.ok(!layergroup.hasOwnProperty('layergroupid'));
@@ -88,7 +88,8 @@ describe('turbo-carto regressions', function() {
             var turboCartoError = layergroup.errors_with_context[0];
             assert.ok(turboCartoError);
             assert.equal(turboCartoError.type, 'layer');
-            assert.ok(turboCartoError.message.match(/permission\sdenied\sfor\srelation\stest_table_private_1/));
+            assert.ok(turboCartoError.message.search(/permission denied for relation/i) >= 0);
+            assert.equal(turboCartoError.info, 'test_table_private_1');
 
             done();
         });

--- a/test/acceptance/turbo-carto/regressions.js
+++ b/test/acceptance/turbo-carto/regressions.js
@@ -79,7 +79,7 @@ describe('turbo-carto regressions', function() {
         ].join('\n');
 
         this.testClient = new TestClient(makeMapconfig('SELECT * FROM test_table_private_1', cartocss));
-        this.testClient.getLayergroup({ response: TestClient.RESPONSE.GENERIC_AUTH_ERROR }, function(err, layergroup) {
+        this.testClient.getLayergroup({ response: TestClient.RESPONSE.UNAUTHORIZED_ERROR }, function(err, layergroup) {
             assert.ok(!err, err);
 
             assert.ok(!layergroup.hasOwnProperty('layergroupid'));

--- a/test/acceptance/turbo-carto/regressions.js
+++ b/test/acceptance/turbo-carto/regressions.js
@@ -79,7 +79,7 @@ describe('turbo-carto regressions', function() {
         ].join('\n');
 
         this.testClient = new TestClient(makeMapconfig('SELECT * FROM test_table_private_1', cartocss));
-        this.testClient.getLayergroup({ response: TestClient.RESPONSE.GENERAL_AUTH_ERROR }, function(err, layergroup) {
+        this.testClient.getLayergroup({ response: TestClient.RESPONSE.GENERIC_AUTH_ERROR }, function(err, layergroup) {
             assert.ok(!err, err);
 
             assert.ok(!layergroup.hasOwnProperty('layergroupid'));

--- a/test/acceptance/turbo-carto/regressions.js
+++ b/test/acceptance/turbo-carto/regressions.js
@@ -79,7 +79,7 @@ describe('turbo-carto regressions', function() {
         ].join('\n');
 
         this.testClient = new TestClient(makeMapconfig('SELECT * FROM test_table_private_1', cartocss));
-        this.testClient.getLayergroup({ response: TestClient.RESPONSE.UNAUTHORIZED_ERROR }, function(err, layergroup) {
+        this.testClient.getLayergroup({ response: TestClient.RESPONSE.FORBIDDEN_ERROR }, function(err, layergroup) {
             assert.ok(!err, err);
 
             assert.ok(!layergroup.hasOwnProperty('layergroupid'));

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -48,13 +48,13 @@ module.exports.RESPONSE = {
             'Content-Type': 'application/json; charset=utf-8'
         }
     },
-    GENERIC_AUTH_ERROR: {
+    UNAUTHORIZED_ERROR: {
         status: 403,
         headers: {
             'Content-Type': 'application/json; charset=utf-8'
         }
     },
-    APIKEY_NOT_FOUND_AUTH_ERROR: {
+    FORBIDDEN_ERROR: {
         status: 401,
         headers: {
             'Content-Type': 'application/json; charset=utf-8'

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -48,8 +48,14 @@ module.exports.RESPONSE = {
             'Content-Type': 'application/json; charset=utf-8'
         }
     },
-    GENERAL_AUTH_ERROR: {
+    GENERIC_AUTH_ERROR: {
         status: 403,
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+        }
+    },
+    APIKEY_NOT_FOUND_AUTH_ERROR: {
+        status: 401,
         headers: {
             'Content-Type': 'application/json; charset=utf-8'
         }

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -47,6 +47,12 @@ module.exports.RESPONSE = {
         headers: {
             'Content-Type': 'application/json; charset=utf-8'
         }
+    },
+    GENERAL_AUTH_ERROR: {
+        status: 403,
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+        }
     }
 };
 

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -49,13 +49,13 @@ module.exports.RESPONSE = {
         }
     },
     UNAUTHORIZED_ERROR: {
-        status: 403,
+        status: 401,
         headers: {
             'Content-Type': 'application/json; charset=utf-8'
         }
     },
     FORBIDDEN_ERROR: {
-        status: 401,
+        status: 403,
         headers: {
             'Content-Type': 'application/json; charset=utf-8'
         }


### PR DESCRIPTION
Reformat `Postgis permission denied for relation` error, removing technical information.

- set error message as: `'permission denied for relation'`
- type as `'auth'` if none set before (eg. `'layer'`)
- add info field with offending relation name