### PR TITLE
Blind revert of refactor of affected tables [DNM]

### DIFF
--- a/lib/cartodb/controllers/layergroup.js
+++ b/lib/cartodb/controllers/layergroup.js
@@ -59,9 +59,7 @@ LayergroupController.prototype.register = function(app) {
         getTile(this.tileBackend, 'map_tile'),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         incrementSuccessMetrics(global.statsClient),
         sendResponse(),
         incrementErrorMetrics(global.statsClient),
@@ -78,9 +76,7 @@ LayergroupController.prototype.register = function(app) {
         getTile(this.tileBackend, 'map_tile'),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         incrementSuccessMetrics(global.statsClient),
         sendResponse(),
         incrementErrorMetrics(global.statsClient),
@@ -98,9 +94,7 @@ LayergroupController.prototype.register = function(app) {
         getTile(this.tileBackend, 'maplayer_tile'),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         incrementSuccessMetrics(global.statsClient),
         sendResponse(),
         incrementErrorMetrics(global.statsClient),
@@ -117,9 +111,7 @@ LayergroupController.prototype.register = function(app) {
         getFeatureAttributes(this.attributesBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         sendResponse()
     );
 
@@ -135,9 +127,7 @@ LayergroupController.prototype.register = function(app) {
         getPreviewImageByCenter(this.previewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         sendResponse()
     );
 
@@ -151,9 +141,7 @@ LayergroupController.prototype.register = function(app) {
         getPreviewImageByBoundingBox(this.previewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         sendResponse()
     );
 
@@ -185,9 +173,7 @@ LayergroupController.prototype.register = function(app) {
         getDataview(this.dataviewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         sendResponse()
     );
 
@@ -201,9 +187,7 @@ LayergroupController.prototype.register = function(app) {
         getDataview(this.dataviewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         sendResponse()
     );
 
@@ -217,9 +201,7 @@ LayergroupController.prototype.register = function(app) {
         dataviewSearch(this.dataviewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         sendResponse()
     );
 
@@ -233,9 +215,7 @@ LayergroupController.prototype.register = function(app) {
         dataviewSearch(this.dataviewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        this.affectedTables(),
         sendResponse()
     );
 
@@ -245,6 +225,7 @@ LayergroupController.prototype.register = function(app) {
         userMiddleware(),
         this.prepareContext,
         analysisNodeStatus(this.analysisStatusBackend),
+        this.affectedTables(),
         sendResponse()
     );
 };
@@ -301,18 +282,9 @@ function createMapStoreMapConfigProvider (mapStore, userLimitsApi, forcedFormat 
             params.layer = params.layer || 'all';
         }
 
-        const mapConfigProvider = new MapStoreMapConfigProvider(mapStore, user, userLimitsApi, params);
+        res.locals.mapConfigProvider = new MapStoreMapConfigProvider(mapStore, user, userLimitsApi, params);
 
-        mapConfigProvider.getMapConfig((err, mapconfig) => {
-            if (err) {
-                return next(err);
-            }
-
-            res.locals.mapConfigProvider = mapConfigProvider;
-            res.locals.mapconfig = mapconfig;
-
-            next();
-        });
+        next();
     };
 }
 
@@ -507,83 +479,76 @@ function setCacheControlHeader () {
     };
 }
 
-function getAffectedTables (layergroupAffectedTables, pgConnection) {
-    return function getAffectedTablesMiddleware (req, res, next) {
-        const { user, dbname, token, mapconfig } = res.locals;
+LayergroupController.prototype.affectedTables = function () {
+    return function affectedTablesMiddleware (req, res, next) {
+        const { user, dbname, token } = res.locals;
 
-        if (layergroupAffectedTables.hasAffectedTables(dbname, token)) {
-            res.locals.affectedTables = layergroupAffectedTables.get(dbname, token);
-            return next();
-        }
+        this.getAffectedTables(user, dbname, token, (err, affectedTables) => {
+            req.profiler.done('affectedTables');
 
-        pgConnection.getConnection(user, (err, connection) => {
             if (err) {
                 global.logger.warn('ERROR generating cache channel:', err);
-                return next();
             }
 
-            const sql = [];
-            mapconfig.getLayers().forEach(function(layer) {
-                sql.push(layer.options.sql);
-                if (layer.options.affected_tables) {
-                    layer.options.affected_tables.map(function(table) {
-                        sql.push(`SELECT * FROM ${table} LIMIT 0`);
-                    });
-                }
-            });
+            if (!!affectedTables) {
+                res.set('X-Cache-Channel', affectedTables.getCacheChannel());
+                this.surrogateKeysCache.tag(res, affectedTables);
+            }
 
-            QueryTables.getAffectedTablesFromQuery(connection, sql.join(';'), (err, affectedTables) => {
-                req.profiler.done('getAffectedTablesFromQuery');
+            next();
+        });
+    }.bind(this);
+};
+
+LayergroupController.prototype.getAffectedTables = function (user, dbName, layergroupId, callback) {
+    if (this.layergroupAffectedTables.hasAffectedTables(dbName, layergroupId)) {
+        return callback(null, this.layergroupAffectedTables.get(dbName, layergroupId));
+    }
+
+    this.mapStore.load(layergroupId, (err, mapConfig) => {
+        if (err) {
+            return callback(err);
+        }
+
+        var queries = [];
+        mapConfig.getLayers().forEach(function(layer) {
+            queries.push(layer.options.sql);
+            if (layer.options.affected_tables) {
+                layer.options.affected_tables.map(function(table) {
+                    queries.push('SELECT * FROM ' + table + ' LIMIT 0');
+                });
+            }
+        });
+
+        const sql = queries.length ? queries.join(';') : null;
+
+        if ( ! sql ) {
+            return callback(new Error("this request doesn't need an X-Cache-Channel generated"));
+        }
+
+        this.pgConnection.getConnection(user, (err, connection) => {
+            if (err) {
+                return callback(err);
+            }
+
+            QueryTables.getAffectedTablesFromQuery(connection, sql, (err, tables) => {
                 if (err) {
-                    global.logger.warn('ERROR generating cache channel: ', err);
-                    return next();
+                    return callback(err);
                 }
 
                 // feed affected tables cache so it can be reused from, for instance, map controller
-                layergroupAffectedTables.set(dbname, token, affectedTables);
+                this.layergroupAffectedTables.set(dbName, layergroupId, tables);
 
-                res.locals.affectedTables = affectedTables;
-
-                next();
+                callback(null, tables);
             });
         });
-    };
-}
-
-function setCacheChannelHeader () {
-    return function setCacheChannelHeaderMiddleware (req, res, next) {
-        const { affectedTables } = res.locals;
-
-        if (affectedTables) {
-            res.set('X-Cache-Channel', affectedTables.getCacheChannel());
-        }
-
-        next();
-    };
-}
-
-function setSurrogateKeyHeader (surrogateKeysCache) {
-    return function setSurrogateKeyHeaderMiddleware (req, res, next) {
-        const { affectedTables } = res.locals;
-
-        if (affectedTables) {
-            surrogateKeysCache.tag(res, affectedTables);
-        }
-
-        next();
-    };
-}
-
-function incrementSuccessMetrics (statsClient) {
-    return function incrementSuccessMetricsMiddleware (req, res, next) {
-        const formatStat = parseFormat(req.params.format);
+    });
 
         statsClient.increment('windshaft.tiles.success');
         statsClient.increment(`windshaft.tiles.${formatStat}.success`);
 
         next();
-    };
-}
+};
 
 function sendResponse () {
     return function sendResponseMiddleware (req, res) {
@@ -630,5 +595,16 @@ function tileError () {
         err.label = 'TILE RENDER';
 
         next(err);
+    };
+}
+
+function incrementSuccessMetrics (statsClient) {
+    return function incrementSuccessMetricsMiddleware (req, res, next) {
+        const formatStat = parseFormat(req.params.format);
+
+        statsClient.increment('windshaft.tiles.success');
+        statsClient.increment(`windshaft.tiles.${formatStat}.success`);
+
+        next();
     };
 }


### PR DESCRIPTION
After solving a lot of conflicts
```
git revert 94d1667d705049a864a536f748d70938ed14b1c5
```

```
git mergetool --tool=kdiff3
```

and fix some syntax issues. The commit in question: 94d1667d705049a864a536f748d70938ed14b1c5