### PR TITLE
PG11: Modify regex match to accept pg11 errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ New features:
  - Upgrades camshaft to 0.61.8
  - Upgrades cartodb-redis to 1.0.0
  - Rate limit feature (disabled by default)
+ - Fixes for tests with PG11
 
 ## 5.4.0
 Released 2018-03-15

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -1336,7 +1336,7 @@ describe(suiteName, function() {
                 status: 403
             },
             function(res) {
-                assert.ok(res.body.match(/permission denied for relation test_table_private_1/));
+                assert.ok(res.body.match(/permission denied for .+?test_table_private_1/));
                 done();
             }
         );

--- a/test/acceptance/named_layers.js
+++ b/test/acceptance/named_layers.js
@@ -659,7 +659,7 @@ describe('named_layers', function() {
                 }
 
                 var parsedBody = JSON.parse(response.body);
-                assert.ok(parsedBody.errors[0].match(/permission denied for relation test_table_private_1/));
+                assert.ok(parsedBody.errors[0].match(/permission denied for .+?test_table_private_1/));
 
                 return null;
             },

--- a/test/acceptance/turbo-carto/regressions.js
+++ b/test/acceptance/turbo-carto/regressions.js
@@ -88,7 +88,7 @@ describe('turbo-carto regressions', function() {
             var turboCartoError = layergroup.errors_with_context[0];
             assert.ok(turboCartoError);
             assert.equal(turboCartoError.type, 'layer');
-            assert.ok(turboCartoError.message.match(/permission\sdenied\sfor\srelation\stest_table_private_1/));
+            assert.ok(turboCartoError.message.match(/permission\sdenied\sfor\s.+?test_table_private_1/));
 
             done();
         });


### PR DESCRIPTION
Basically `relation` has become `table` so the exact error is different.