### PR TITLE
Unify headers middlewares

### DIFF
--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -6,12 +6,20 @@ var queue = require('queue-async');
 
 var LruCache = require("lru-cache");
 
-function NamedMapProviderCache(templateMaps, pgConnection, metadataBackend, userLimitsApi, mapConfigAdapter) {
+function NamedMapProviderCache(
+    templateMaps,
+    pgConnection,
+    metadataBackend,
+    userLimitsApi,
+    mapConfigAdapter,
+    affectedTablesCache
+) {
     this.templateMaps = templateMaps;
     this.pgConnection = pgConnection;
     this.metadataBackend = metadataBackend;
     this.userLimitsApi = userLimitsApi;
     this.mapConfigAdapter = mapConfigAdapter;
+    this.affectedTablesCache = affectedTablesCache;
 
     this.providerCache = new LruCache({ max: 2000 });
 }
@@ -30,6 +38,7 @@ NamedMapProviderCache.prototype.get = function(user, templateId, config, authTok
             this.metadataBackend,
             this.userLimitsApi,
             this.mapConfigAdapter,
+            this.affectedTablesCache,
             user,
             templateId,
             config,

--- a/lib/cartodb/controllers/analyses.js
+++ b/lib/cartodb/controllers/analyses.js
@@ -9,6 +9,7 @@ const authorize = require('../middleware/authorize');
 const dbConnSetup = require('../middleware/db-conn-setup');
 const rateLimit = require('../middleware/rate-limit');
 const { RATE_LIMIT_ENDPOINTS_GROUPS } = rateLimit;
+const cacheControlHeader = require('../middleware/cache-control-header');
 const sendResponse = require('../middleware/send-response');
 
 function AnalysesController(pgConnection, authApi, userLimitsApi) {
@@ -37,7 +38,7 @@ AnalysesController.prototype.register = function (app) {
         getDataFromQuery({ queryTemplate: catalogQueryTpl, key: 'catalog' }),
         getDataFromQuery({ queryTemplate: tablesQueryTpl, key: 'tables' }),
         prepareResponse(),
-        setCacheControlHeader(),
+        cacheControlHeader({ ttl: 10, revalidate: true }),
         sendResponse(),
         unauthorizedError()
     );
@@ -108,13 +109,6 @@ function prepareResponse () {
 
         res.body = { catalog: analysisCatalog };
 
-        next();
-    };
-}
-
-function setCacheControlHeader () {
-    return function setCacheControlHeaderMiddleware (req, res, next) {
-        res.set('Cache-Control', 'public,max-age=10,must-revalidate');
         next();
     };
 }

--- a/lib/cartodb/controllers/layergroup.js
+++ b/lib/cartodb/controllers/layergroup.js
@@ -9,6 +9,7 @@ const dbConnSetup = require('../middleware/db-conn-setup');
 const authorize = require('../middleware/authorize');
 const rateLimit = require('../middleware/rate-limit');
 const { RATE_LIMIT_ENDPOINTS_GROUPS } = rateLimit;
+const cacheControlHeader = require('../middleware/cache-control-header');
 const cacheChannelHeader = require('../middleware/cache-channel-header');
 const surrogateKeyHeader = require('../middleware/surrogate-key-header');
 const lastModifiedHeader = require('../middleware/last-modified-header');
@@ -87,7 +88,7 @@ LayergroupController.prototype.register = function(app) {
             this.layergroupAffectedTablesCache
         ),
         getTile(this.tileBackend, 'map_tile'),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -116,7 +117,7 @@ LayergroupController.prototype.register = function(app) {
             this.layergroupAffectedTablesCache
         ),
         getTile(this.tileBackend, 'map_tile'),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -146,7 +147,7 @@ LayergroupController.prototype.register = function(app) {
             this.layergroupAffectedTablesCache
         ),
         getTile(this.tileBackend, 'maplayer_tile'),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -175,7 +176,7 @@ LayergroupController.prototype.register = function(app) {
             this.layergroupAffectedTablesCache
         ),
         getFeatureAttributes(this.attributesBackend),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -203,7 +204,7 @@ LayergroupController.prototype.register = function(app) {
             forcedFormat
         ),
         getPreviewImageByCenter(this.previewBackend),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -229,7 +230,7 @@ LayergroupController.prototype.register = function(app) {
             forcedFormat
         ),
         getPreviewImageByBoundingBox(this.previewBackend),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -272,7 +273,7 @@ LayergroupController.prototype.register = function(app) {
             this.layergroupAffectedTablesCache
         ),
         getDataview(this.dataviewBackend),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -297,7 +298,7 @@ LayergroupController.prototype.register = function(app) {
             this.layergroupAffectedTablesCache
         ),
         getDataview(this.dataviewBackend),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -322,7 +323,7 @@ LayergroupController.prototype.register = function(app) {
             this.layergroupAffectedTablesCache
         ),
         dataviewSearch(this.dataviewBackend),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -347,7 +348,7 @@ LayergroupController.prototype.register = function(app) {
             this.layergroupAffectedTablesCache
         ),
         dataviewSearch(this.dataviewBackend),
-        setCacheControlHeader(),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
@@ -607,14 +608,6 @@ function getPreviewImageByBoundingBox (previewBackend) {
 
             next();
         });
-    };
-}
-
-function setCacheControlHeader () {
-    return function setCacheControlHeaderMiddleware (req, res, next) {
-        res.set('Cache-Control', 'public,max-age=31536000');
-
-        next();
     };
 }
 

--- a/lib/cartodb/controllers/layergroup.js
+++ b/lib/cartodb/controllers/layergroup.js
@@ -9,11 +9,12 @@ const dbConnSetup = require('../middleware/db-conn-setup');
 const authorize = require('../middleware/authorize');
 const rateLimit = require('../middleware/rate-limit');
 const { RATE_LIMIT_ENDPOINTS_GROUPS } = rateLimit;
+const cacheChannelHeader = require('../middleware/cache-channel-header');
+const surrogateKeyHeader = require('../middleware/surrogate-key-header');
 const sendResponse = require('../middleware/send-response');
 const DataviewBackend = require('../backends/dataview');
 const AnalysisStatusBackend = require('../backends/analysis-status');
 const MapStoreMapConfigProvider = require('../models/mapconfig/provider/map-store-provider');
-const QueryTables = require('cartodb-query-tables');
 const SUPPORTED_FORMATS = {
     grid_json: true,
     json_torque: true,
@@ -44,7 +45,7 @@ function LayergroupController(
     attributesBackend,
     surrogateKeysCache,
     userLimitsApi,
-    layergroupAffectedTables,
+    layergroupAffectedTablesCache,
     analysisBackend,
     authApi
 ) {
@@ -55,7 +56,7 @@ function LayergroupController(
     this.attributesBackend = attributesBackend;
     this.surrogateKeysCache = surrogateKeysCache;
     this.userLimitsApi = userLimitsApi;
-    this.layergroupAffectedTables = layergroupAffectedTables;
+    this.layergroupAffectedTablesCache = layergroupAffectedTablesCache;
 
     this.dataviewBackend = new DataviewBackend(analysisBackend);
     this.analysisStatusBackend = new AnalysisStatusBackend();
@@ -65,10 +66,10 @@ function LayergroupController(
 module.exports = LayergroupController;
 
 LayergroupController.prototype.register = function(app) {
-    const { base_url_mapconfig: mapconfigBasePath } = app;
+    const { base_url_mapconfig: mapConfigBasePath } = app;
 
     app.get(
-        `${mapconfigBasePath}/:token/:z/:x/:y@:scale_factor?x.:format`,
+        `${mapConfigBasePath}/:token/:z/:x/:y@:scale_factor?x.:format`,
         cors(),
         cleanUpQueryParams(),
         locals(),
@@ -78,13 +79,17 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache
+        ),
         getTile(this.tileBackend, 'map_tile'),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         incrementSuccessMetrics(global.statsClient),
         sendResponse(),
         incrementErrorMetrics(global.statsClient),
@@ -93,7 +98,7 @@ LayergroupController.prototype.register = function(app) {
     );
 
     app.get(
-        `${mapconfigBasePath}/:token/:z/:x/:y.:format`,
+        `${mapConfigBasePath}/:token/:z/:x/:y.:format`,
         cors(),
         cleanUpQueryParams(),
         locals(),
@@ -103,13 +108,17 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache
+        ),
         getTile(this.tileBackend, 'map_tile'),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         incrementSuccessMetrics(global.statsClient),
         sendResponse(),
         incrementErrorMetrics(global.statsClient),
@@ -118,7 +127,7 @@ LayergroupController.prototype.register = function(app) {
     );
 
     app.get(
-        `${mapconfigBasePath}/:token/:layer/:z/:x/:y.(:format)`,
+        `${mapConfigBasePath}/:token/:layer/:z/:x/:y.(:format)`,
         distinguishLayergroupFromStaticRoute(),
         cors(),
         cleanUpQueryParams(),
@@ -129,13 +138,17 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache
+        ),
         getTile(this.tileBackend, 'maplayer_tile'),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         incrementSuccessMetrics(global.statsClient),
         sendResponse(),
         incrementErrorMetrics(global.statsClient),
@@ -144,7 +157,7 @@ LayergroupController.prototype.register = function(app) {
     );
 
     app.get(
-        `${mapconfigBasePath}/:token/:layer/attributes/:fid`,
+        `${mapConfigBasePath}/:token/:layer/attributes/:fid`,
         cors(),
         cleanUpQueryParams(),
         locals(),
@@ -154,20 +167,24 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache
+        ),
         getFeatureAttributes(this.attributesBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         sendResponse()
     );
 
     const forcedFormat = 'png';
 
     app.get(
-        `${mapconfigBasePath}/static/center/:token/:z/:lat/:lng/:width/:height.:format`,
+        `${mapConfigBasePath}/static/center/:token/:z/:lat/:lng/:width/:height.:format`,
         cors(),
         cleanUpQueryParams(['layer']),
         locals(),
@@ -177,18 +194,23 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi, forcedFormat),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache,
+            forcedFormat
+        ),
         getPreviewImageByCenter(this.previewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         sendResponse()
     );
 
     app.get(
-        `${mapconfigBasePath}/static/bbox/:token/:west,:south,:east,:north/:width/:height.:format`,
+        `${mapConfigBasePath}/static/bbox/:token/:west,:south,:east,:north/:width/:height.:format`,
         cors(),
         cleanUpQueryParams(['layer']),
         locals(),
@@ -198,13 +220,18 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi, forcedFormat),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache,
+            forcedFormat
+        ),
         getPreviewImageByBoundingBox(this.previewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         sendResponse()
     );
 
@@ -227,7 +254,7 @@ LayergroupController.prototype.register = function(app) {
     ];
 
     app.get(
-        `${mapconfigBasePath}/:token/dataview/:dataviewName`,
+        `${mapConfigBasePath}/:token/dataview/:dataviewName`,
         cors(),
         cleanUpQueryParams(allowedDataviewQueryParams),
         locals(),
@@ -237,18 +264,22 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache
+        ),
         getDataview(this.dataviewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         sendResponse()
     );
 
     app.get(
-        `${mapconfigBasePath}/:token/:layer/widget/:dataviewName`,
+        `${mapConfigBasePath}/:token/:layer/widget/:dataviewName`,
         cors(),
         cleanUpQueryParams(allowedDataviewQueryParams),
         locals(),
@@ -258,18 +289,22 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache
+        ),
         getDataview(this.dataviewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         sendResponse()
     );
 
     app.get(
-        `${mapconfigBasePath}/:token/dataview/:dataviewName/search`,
+        `${mapConfigBasePath}/:token/dataview/:dataviewName/search`,
         cors(),
         cleanUpQueryParams(allowedDataviewQueryParams),
         locals(),
@@ -279,18 +314,22 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache
+        ),
         dataviewSearch(this.dataviewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         sendResponse()
     );
 
     app.get(
-        `${mapconfigBasePath}/:token/:layer/widget/:dataviewName/search`,
+        `${mapConfigBasePath}/:token/:layer/widget/:dataviewName/search`,
         cors(),
         cleanUpQueryParams(allowedDataviewQueryParams),
         locals(),
@@ -300,18 +339,22 @@ LayergroupController.prototype.register = function(app) {
         credentials(),
         authorize(this.authApi),
         dbConnSetup(this.pgConnection),
-        createMapStoreMapConfigProvider(this.mapStore, this.userLimitsApi),
+        createMapStoreMapConfigProvider(
+            this.mapStore,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTablesCache
+        ),
         dataviewSearch(this.dataviewBackend),
         setCacheControlHeader(),
         setLastModifiedHeader(),
-        getAffectedTables(this.layergroupAffectedTables, this.pgConnection, this.mapStore),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         sendResponse()
     );
 
     app.get(
-        `${mapconfigBasePath}/:token/analysis/node/:nodeId`,
+        `${mapConfigBasePath}/:token/analysis/node/:nodeId`,
         cors(),
         cleanUpQueryParams(),
         locals(),
@@ -367,7 +410,13 @@ function getRequestParams(locals) {
     return params;
 }
 
-function createMapStoreMapConfigProvider (mapStore, userLimitsApi, forcedFormat = null) {
+function createMapStoreMapConfigProvider (
+    mapStore,
+    userLimitsApi,
+    pgConnection,
+    affectedTablesCache,
+    forcedFormat = null
+) {
     return function createMapStoreMapConfigProviderMiddleware (req, res, next) {
         const { user } = res.locals;
 
@@ -378,7 +427,14 @@ function createMapStoreMapConfigProvider (mapStore, userLimitsApi, forcedFormat 
             params.layer = params.layer || 'all';
         }
 
-        res.locals.mapConfigProvider = new MapStoreMapConfigProvider(mapStore, user, userLimitsApi, params);
+        res.locals.mapConfigProvider = new MapStoreMapConfigProvider(
+            mapStore,
+            user,
+            userLimitsApi,
+            pgConnection,
+            affectedTablesCache,
+            params
+        );
 
         next();
     };
@@ -570,88 +626,6 @@ function setLastModifiedHeader () {
 function setCacheControlHeader () {
     return function setCacheControlHeaderMiddleware (req, res, next) {
         res.set('Cache-Control', 'public,max-age=31536000');
-
-        next();
-    };
-}
-
-function getAffectedTables (layergroupAffectedTables, pgConnection, mapStore) {
-    return function getAffectedTablesMiddleware (req, res, next) {
-        const { user, dbname, token } = res.locals;
-
-        if (layergroupAffectedTables.hasAffectedTables(dbname, token)) {
-            res.locals.affectedTables = layergroupAffectedTables.get(dbname, token);
-            return next();
-        }
-
-        mapStore.load(token, (err, mapconfig) => {
-            if (err) {
-                global.logger.warn('ERROR generating cache channel:', err);
-                return next();
-            }
-
-            const queries = [];
-            mapconfig.getLayers().forEach(function(layer) {
-                queries.push(layer.options.sql);
-                if (layer.options.affected_tables) {
-                    layer.options.affected_tables.map(function(table) {
-                        queries.push(`SELECT * FROM ${table} LIMIT 0`);
-                    });
-                }
-            });
-
-            const sql = queries.length ? queries.join(';') : null;
-
-            if (!sql) {
-                global.logger.warn('ERROR generating cache channel:' +
-                    ' this request doesn\'t need an X-Cache-Channel generated');
-                return next();
-            }
-
-            pgConnection.getConnection(user, (err, connection) => {
-                if (err) {
-                    global.logger.warn('ERROR generating cache channel:', err);
-                    return next();
-                }
-
-                QueryTables.getAffectedTablesFromQuery(connection, sql, (err, affectedTables) => {
-                    req.profiler.done('getAffectedTablesFromQuery');
-                    if (err) {
-                        global.logger.warn('ERROR generating cache channel: ', err);
-                        return next();
-                    }
-
-                    // feed affected tables cache so it can be reused from, for instance, map controller
-                    layergroupAffectedTables.set(dbname, token, affectedTables);
-
-                    res.locals.affectedTables = affectedTables;
-
-                    next();
-                });
-            });
-        });
-    };
-}
-
-function setCacheChannelHeader () {
-    return function setCacheChannelHeaderMiddleware (req, res, next) {
-        const { affectedTables } = res.locals;
-
-        if (affectedTables) {
-            res.set('X-Cache-Channel', affectedTables.getCacheChannel());
-        }
-
-        next();
-    };
-}
-
-function setSurrogateKeyHeader (surrogateKeysCache) {
-    return function setSurrogateKeyHeaderMiddleware (req, res, next) {
-        const { affectedTables } = res.locals;
-
-        if (affectedTables) {
-            surrogateKeysCache.tag(res, affectedTables);
-        }
 
         next();
     };

--- a/lib/cartodb/controllers/layergroup.js
+++ b/lib/cartodb/controllers/layergroup.js
@@ -11,6 +11,7 @@ const rateLimit = require('../middleware/rate-limit');
 const { RATE_LIMIT_ENDPOINTS_GROUPS } = rateLimit;
 const cacheChannelHeader = require('../middleware/cache-channel-header');
 const surrogateKeyHeader = require('../middleware/surrogate-key-header');
+const lastModifiedHeader = require('../middleware/last-modified-header');
 const sendResponse = require('../middleware/send-response');
 const DataviewBackend = require('../backends/dataview');
 const AnalysisStatusBackend = require('../backends/analysis-status');
@@ -87,9 +88,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         getTile(this.tileBackend, 'map_tile'),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         incrementSuccessMetrics(global.statsClient),
         sendResponse(),
         incrementErrorMetrics(global.statsClient),
@@ -116,9 +117,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         getTile(this.tileBackend, 'map_tile'),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         incrementSuccessMetrics(global.statsClient),
         sendResponse(),
         incrementErrorMetrics(global.statsClient),
@@ -146,9 +147,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         getTile(this.tileBackend, 'maplayer_tile'),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         incrementSuccessMetrics(global.statsClient),
         sendResponse(),
         incrementErrorMetrics(global.statsClient),
@@ -175,9 +176,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         getFeatureAttributes(this.attributesBackend),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         sendResponse()
     );
 
@@ -203,9 +204,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         getPreviewImageByCenter(this.previewBackend),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         sendResponse()
     );
 
@@ -229,9 +230,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         getPreviewImageByBoundingBox(this.previewBackend),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         sendResponse()
     );
 
@@ -272,9 +273,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         getDataview(this.dataviewBackend),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         sendResponse()
     );
 
@@ -297,9 +298,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         getDataview(this.dataviewBackend),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         sendResponse()
     );
 
@@ -322,9 +323,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         dataviewSearch(this.dataviewBackend),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         sendResponse()
     );
 
@@ -347,9 +348,9 @@ LayergroupController.prototype.register = function(app) {
         ),
         dataviewSearch(this.dataviewBackend),
         setCacheControlHeader(),
-        setLastModifiedHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         sendResponse()
     );
 
@@ -606,20 +607,6 @@ function getPreviewImageByBoundingBox (previewBackend) {
 
             next();
         });
-    };
-}
-
-function setLastModifiedHeader () {
-    return function setLastModifiedHeaderMiddleware (req, res, next) {
-        let { cache_buster: cacheBuster } = res.locals;
-
-        cacheBuster = parseInt(cacheBuster, 10);
-
-        const lastUpdated = res.locals.cache_buster ? new Date(cacheBuster) : new Date();
-
-        res.set('Last-Modified', lastUpdated.toUTCString());
-
-        next();
     };
 }
 

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -13,6 +13,7 @@ const dbConnSetup = require('../middleware/db-conn-setup');
 const authorize = require('../middleware/authorize');
 const cacheChannelHeader = require('../middleware/cache-channel-header');
 const surrogateKeyHeader = require('../middleware/surrogate-key-header');
+const lastModifiedHeader = require('../middleware/last-modified-header');
 const sendResponse = require('../middleware/send-response');
 const NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
 const CreateLayergroupMapConfigProvider = require('../models/mapconfig/provider/create-layergroup-provider');
@@ -115,7 +116,7 @@ MapController.prototype.composeCreateMapMiddleware = function (endpointGroup, us
         augmentLayergroupData(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
-        setLastModified(),
+        lastModifiedHeader({ now: true }),
         setLastUpdatedTimeToLayergroup(),
         setCacheControl(),
         setLayerStats(this.pgConnection, this.statsBackend),
@@ -395,16 +396,6 @@ function augmentLayergroupData () {
         // those variables are useful to send to the client information
         // about how to reach this server or information about it
         _.extend(layergroup, global.environment.serverMetadata);
-
-        next();
-    };
-}
-
-function setLastModified () {
-    return function setLastModifiedMiddleware (req, res, next) {
-        if (req.method === 'GET') {
-            res.set('Last-Modified', (new Date()).toUTCString());
-        }
 
         next();
     };

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -2,7 +2,6 @@ const _ = require('underscore');
 const windshaft = require('windshaft');
 const MapConfig = windshaft.model.MapConfig;
 const Datasource = windshaft.model.Datasource;
-const QueryTables = require('cartodb-query-tables');
 const ResourceLocator = require('../models/resource-locator');
 const cors = require('../middleware/cors');
 const user = require('../middleware/user');
@@ -12,8 +11,9 @@ const layergroupToken = require('../middleware/layergroup-token');
 const credentials = require('../middleware/credentials');
 const dbConnSetup = require('../middleware/db-conn-setup');
 const authorize = require('../middleware/authorize');
+const cacheChannelHeader = require('../middleware/cache-channel-header');
+const surrogateKeyHeader = require('../middleware/surrogate-key-header');
 const sendResponse = require('../middleware/send-response');
-const NamedMapsCacheEntry = require('../cache/model/named_maps_entry');
 const NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
 const CreateLayergroupMapConfigProvider = require('../models/mapconfig/provider/create-layergroup-provider');
 const LayergroupMetadata = require('../utils/layergroup-metadata');
@@ -64,15 +64,15 @@ function MapController (
 module.exports = MapController;
 
 MapController.prototype.register = function(app) {
-    const { base_url_mapconfig: mapconfigBasePath, base_url_templated: templateBasePath } = app;
+    const { base_url_mapconfig: mapConfigBasePath, base_url_templated: templateBasePath } = app;
 
     app.get(
-        `${mapconfigBasePath}`,
+        `${mapConfigBasePath}`,
         this.composeCreateMapMiddleware(RATE_LIMIT_ENDPOINTS_GROUPS.ANONYMOUS)
     );
 
     app.post(
-        `${mapconfigBasePath}`,
+        `${mapConfigBasePath}`,
         this.composeCreateMapMiddleware(RATE_LIMIT_ENDPOINTS_GROUPS.ANONYMOUS)
     );
 
@@ -88,7 +88,7 @@ MapController.prototype.register = function(app) {
         this.composeCreateMapMiddleware(RATE_LIMIT_ENDPOINTS_GROUPS.NAMED, useTemplate)
     );
 
-    app.options(app.base_url_mapconfig, cors('Content-Type'));
+    app.options(`${mapConfigBasePath}`, cors('Content-Type'));
 };
 
 MapController.prototype.composeCreateMapMiddleware = function (endpointGroup, useTemplate = false) {
@@ -113,9 +113,8 @@ MapController.prototype.composeCreateMapMiddleware = function (endpointGroup, us
         this.getCreateMapMiddlewares(useTemplate),
         incrementMapViewCount(this.metadataBackend),
         augmentLayergroupData(),
-        getAffectedTables(this.pgConnection, this.layergroupAffectedTables),
-        setCacheChannelHeader(),
-        setSurrogateKeyHeader(this.surrogateKeysCache),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         setLastModified(),
         setLastUpdatedTimeToLayergroup(),
         setCacheControl(),
@@ -140,16 +139,27 @@ MapController.prototype.getCreateMapMiddlewares = function (useTemplate) {
                 this.pgConnection,
                 this.metadataBackend,
                 this.userLimitsApi,
-                this.mapConfigAdapter
+                this.mapConfigAdapter,
+                this.layergroupAffectedTables
             ),
-            instantiateLayergroup(this.mapBackend, this.userLimitsApi)
+            instantiateLayergroup(
+                this.mapBackend,
+                this.userLimitsApi,
+                this.pgConnection,
+                this.layergroupAffectedTables
+            )
         ];
     }
 
     return [
         checkCreateLayergroup(),
         prepareAdapterMapConfig(this.mapConfigAdapter),
-        createLayergroup (this.mapBackend, this.userLimitsApi)
+        createLayergroup (
+            this.mapBackend,
+            this.userLimitsApi,
+            this.pgConnection,
+            this.layergroupAffectedTables
+        )
     ];
 };
 
@@ -220,17 +230,25 @@ function checkCreateLayergroup () {
     };
 }
 
-function getTemplate (templateMaps, pgConnection, metadataBackend, userLimitsApi, mapConfigAdapter) {
+function getTemplate (
+    templateMaps,
+    pgConnection,
+    metadataBackend,
+    userLimitsApi,
+    mapConfigAdapter,
+    affectedTablesCache
+) {
     return function getTemplateMiddleware (req, res, next) {
         const templateParams = req.body;
         const { user } = res.locals;
 
-        const mapconfigProvider = new NamedMapMapConfigProvider(
+        const mapConfigProvider = new NamedMapMapConfigProvider(
             templateMaps,
             pgConnection,
             metadataBackend,
             userLimitsApi,
             mapConfigAdapter,
+            affectedTablesCache,
             user,
             req.params.template_id,
             templateParams,
@@ -238,15 +256,15 @@ function getTemplate (templateMaps, pgConnection, metadataBackend, userLimitsApi
             res.locals
         );
 
-        mapconfigProvider.getMapConfig((err, mapconfig, rendererParams) => {
+        mapConfigProvider.getMapConfig((err, mapConfig, rendererParams) => {
             req.profiler.done('named.getMapConfig');
             if (err) {
                 return next(err);
             }
 
-            res.locals.mapconfig = mapconfig;
+            res.locals.mapConfig = mapConfig;
             res.locals.rendererParams = rendererParams;
-            res.locals.mapconfigProvider = mapconfigProvider;
+            res.locals.mapConfigProvider = mapConfigProvider;
 
             next();
         });
@@ -289,38 +307,51 @@ function prepareAdapterMapConfig (mapConfigAdapter) {
     };
 }
 
-function createLayergroup (mapBackend, userLimitsApi) {
+function createLayergroup (mapBackend, userLimitsApi, pgConnection, affectedTablesCache) {
     return function createLayergroupMiddleware (req, res, next) {
         const requestMapConfig = req.body;
         const { context, user } = res.locals;
         const datasource = context.datasource || Datasource.EmptyDatasource();
-        const mapconfig = new MapConfig(requestMapConfig, datasource);
-        const mapconfigProvider =
-            new CreateLayergroupMapConfigProvider(mapconfig, user, userLimitsApi, res.locals);
+        const mapConfig = new MapConfig(requestMapConfig, datasource);
+        const mapConfigProvider = new CreateLayergroupMapConfigProvider(
+            mapConfig,
+            user,
+            userLimitsApi,
+            pgConnection,
+            affectedTablesCache,
+            res.locals
+        );
 
-        res.locals.mapconfig = mapconfig;
+        res.locals.mapConfig = mapConfig;
         res.locals.analysesResults = context.analysesResults;
 
-        mapBackend.createLayergroup(mapconfig, res.locals, mapconfigProvider, (err, layergroup) => {
+        mapBackend.createLayergroup(mapConfig, res.locals, mapConfigProvider, (err, layergroup) => {
             req.profiler.done('createLayergroup');
             if (err) {
                 return next(err);
             }
 
             res.body = layergroup;
+            res.locals.mapConfigProvider = mapConfigProvider;
 
             next();
         });
     };
 }
 
-function instantiateLayergroup (mapBackend, userLimitsApi) {
+function instantiateLayergroup (mapBackend, userLimitsApi, pgConnection, affectedTablesCache) {
     return function instantiateLayergroupMiddleware (req, res, next) {
-        const { user, mapconfig, rendererParams } = res.locals;
-        const mapconfigProvider =
-            new CreateLayergroupMapConfigProvider(mapconfig, user, userLimitsApi, rendererParams);
+        const { user, mapConfig, rendererParams } = res.locals;
+        const mapConfigProvider = new CreateLayergroupMapConfigProvider(
+            mapConfig,
+            user,
+            userLimitsApi,
+            pgConnection,
+            affectedTablesCache,
+            rendererParams
+        );
 
-        mapBackend.createLayergroup(mapconfig, rendererParams, mapconfigProvider, (err, layergroup) => {
+        mapBackend.createLayergroup(mapConfig, rendererParams, mapConfigProvider, (err, layergroup) => {
             req.profiler.done('createLayergroup');
             if (err) {
                 return next(err);
@@ -328,12 +359,11 @@ function instantiateLayergroup (mapBackend, userLimitsApi) {
 
             res.body = layergroup;
 
-            const { mapconfigProvider } = res.locals;
+            const { mapConfigProvider } = res.locals;
 
-            res.locals.analysesResults = mapconfigProvider.analysesResults;
-            res.locals.template = mapconfigProvider.template;
-            res.locals.templateName = mapconfigProvider.getTemplateName();
-            res.locals.context = mapconfigProvider.context;
+            res.locals.analysesResults = mapConfigProvider.analysesResults;
+            res.locals.template = mapConfigProvider.template;
+            res.locals.context = mapConfigProvider.context;
 
             next();
         });
@@ -342,10 +372,10 @@ function instantiateLayergroup (mapBackend, userLimitsApi) {
 
 function incrementMapViewCount (metadataBackend) {
     return function incrementMapViewCountMiddleware(req, res, next) {
-        const { mapconfig, user } = res.locals;
+        const { mapConfig, user } = res.locals;
 
         // Error won't blow up, just be logged.
-        metadataBackend.incMapviewCount(user, mapconfig.obj().stat_tag, (err) => {
+        metadataBackend.incMapviewCount(user, mapConfig.obj().stat_tag, (err) => {
             req.profiler.done('incMapviewCount');
 
             if (err) {
@@ -370,71 +400,6 @@ function augmentLayergroupData () {
     };
 }
 
-function getAffectedTables (pgConnection, layergroupAffectedTables) {
-    return function getAffectedTablesMiddleware (req, res, next) {
-        const { dbname, user, mapconfig } = res.locals;
-        const layergroup = res.body;
-
-        pgConnection.getConnection(user, (err, connection) => {
-            if (err) {
-                return next(err);
-            }
-
-            const sql = [];
-            mapconfig.getLayers().forEach(function(layer) {
-                sql.push(layer.options.sql);
-                if (layer.options.affected_tables) {
-                    layer.options.affected_tables.map(function(table) {
-                        sql.push('SELECT * FROM ' + table + ' LIMIT 0');
-                    });
-                }
-            });
-
-            QueryTables.getAffectedTablesFromQuery(connection, sql.join(';'), (err, affectedTables) => {
-                req.profiler.done('getAffectedTablesFromQuery');
-                if (err) {
-                    return next(err);
-                }
-
-                // feed affected tables cache so it can be reused from, for instance, layergroup controller
-                layergroupAffectedTables.set(dbname, layergroup.layergroupId, affectedTables);
-
-                res.locals.affectedTables = affectedTables;
-
-                next();
-            });
-        });
-    };
-}
-
-function setCacheChannelHeader () {
-    return function setCacheChannelHeaderMiddleware (req, res, next) {
-        const { affectedTables } = res.locals;
-
-        if (req.method === 'GET') {
-            res.set('X-Cache-Channel', affectedTables.getCacheChannel());
-        }
-
-        next();
-    };
-}
-
-function setSurrogateKeyHeader (surrogateKeysCache) {
-    return function setSurrogateKeyHeaderMiddleware(req, res, next) {
-        const { affectedTables, user, templateName } = res.locals;
-
-        if (req.method === 'GET' && affectedTables.tables && affectedTables.tables.length > 0) {
-            surrogateKeysCache.tag(res, affectedTables);
-        }
-
-        if (templateName) {
-            surrogateKeysCache.tag(res, new NamedMapsCacheEntry(user, templateName));
-        }
-
-        next();
-    };
-}
-
 function setLastModified () {
     return function setLastModifiedMiddleware (req, res, next) {
         if (req.method === 'GET') {
@@ -447,18 +412,28 @@ function setLastModified () {
 
 function setLastUpdatedTimeToLayergroup () {
     return function setLastUpdatedTimeToLayergroupMiddleware (req, res, next) {
-        const { affectedTables, analysesResults } = res.locals;
+        const { mapConfigProvider, analysesResults } = res.locals;
         const layergroup = res.body;
 
-        var lastUpdateTime = affectedTables.getLastUpdatedAt();
+        mapConfigProvider.getAffectedTables((err, affectedTables) => {
+            if (err) {
+                return next(err);
+            }
 
-        lastUpdateTime = getLastUpdatedTime(analysesResults, lastUpdateTime) || lastUpdateTime;
+            if (!affectedTables) {
+                return next();
+            }
 
-        // last update for layergroup cache buster
-        layergroup.layergroupid = layergroup.layergroupid + ':' + lastUpdateTime;
-        layergroup.last_updated = new Date(lastUpdateTime).toISOString();
+            var lastUpdateTime = affectedTables.getLastUpdatedAt();
 
-        next();
+            lastUpdateTime = getLastUpdatedTime(analysesResults, lastUpdateTime) || lastUpdateTime;
+
+            // last update for layergroup cache buster
+            layergroup.layergroupid = layergroup.layergroupid + ':' + lastUpdateTime;
+            layergroup.last_updated = new Date(lastUpdateTime).toISOString();
+
+            next();
+        });
     };
 }
 
@@ -488,7 +463,7 @@ function setCacheControl () {
 
 function setLayerStats (pgConnection, statsBackend) {
     return function setLayerStatsMiddleware(req, res, next) {
-        const { user, mapconfig } = res.locals;
+        const { user, mapConfig } = res.locals;
         const layergroup = res.body;
 
         pgConnection.getConnection(user, (err, connection) => {
@@ -496,7 +471,7 @@ function setLayerStats (pgConnection, statsBackend) {
                 return next(err);
             }
 
-            statsBackend.getStats(mapconfig, connection, function(err, layersStats) {
+            statsBackend.getStats(mapConfig, connection, function(err, layersStats) {
                 if (err) {
                     return next(err);
                 }
@@ -531,10 +506,10 @@ function setLayergroupIdHeader (templateMaps, useTemplateHash) {
 
 function setDataviewsAndWidgetsUrlsToLayergroupMetadata (layergroupMetadata) {
     return function setDataviewsAndWidgetsUrlsToLayergroupMetadataMiddleware (req, res, next) {
-        const { user, mapconfig } = res.locals;
+        const { user, mapConfig } = res.locals;
         const layergroup = res.body;
 
-        layergroupMetadata.addDataviewsAndWidgetsUrls(user, layergroup, mapconfig.obj());
+        layergroupMetadata.addDataviewsAndWidgetsUrls(user, layergroup, mapConfig.obj());
 
         next();
     };
@@ -553,10 +528,10 @@ function setAnalysesMetadataToLayergroup (layergroupMetadata, includeQuery) {
 
 function setTurboCartoMetadataToLayergroup (layergroupMetadata) {
     return function setTurboCartoMetadataToLayergroupMiddleware (req, res, next) {
-        const { mapconfig, context } = res.locals;
+        const { mapConfig, context } = res.locals;
         const layergroup = res.body;
 
-        layergroupMetadata.addTurboCartoContextMetadata(layergroup, mapconfig.obj(), context);
+        layergroupMetadata.addTurboCartoContextMetadata(layergroup, mapConfig.obj(), context);
 
         next();
     };
@@ -564,10 +539,10 @@ function setTurboCartoMetadataToLayergroup (layergroupMetadata) {
 
 function setAggregationMetadataToLayergroup (layergroupMetadata) {
     return function setAggregationMetadataToLayergroupMiddleware (req, res, next) {
-        const { mapconfig, context } = res.locals;
+        const { mapConfig, context } = res.locals;
         const layergroup = res.body;
 
-        layergroupMetadata.addAggregationContextMetadata(layergroup, mapconfig.obj(), context);
+        layergroupMetadata.addAggregationContextMetadata(layergroup, mapConfig.obj(), context);
 
         next();
     };
@@ -575,10 +550,10 @@ function setAggregationMetadataToLayergroup (layergroupMetadata) {
 
 function setTilejsonMetadataToLayergroup (layergroupMetadata) {
     return function augmentLayergroupTilejsonMiddleware (req, res, next) {
-        const { user, mapconfig } = res.locals;
+        const { user, mapConfig } = res.locals;
         const layergroup = res.body;
 
-        layergroupMetadata.addTileJsonMetadata(layergroup, user, mapconfig);
+        layergroupMetadata.addTileJsonMetadata(layergroup, user, mapConfig);
 
         next();
     };
@@ -589,10 +564,10 @@ function augmentError (options) {
 
     return function augmentErrorMiddleware (err, req, res, next) {
         req.profiler.done('error');
-        const { mapconfig } = res.locals;
+        const { mapConfig } = res.locals;
 
         if (addContext) {
-            err = Number.isFinite(err.layerIndex) ? populateError(err, mapconfig) : err;
+            err = Number.isFinite(err.layerIndex) ? populateError(err, mapConfig) : err;
         }
 
         err.label = label;

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -442,17 +442,6 @@ function getLastUpdatedTime(analysesResults, lastUpdateTime) {
     }, lastUpdateTime);
 }
 
-function setCacheControl () {
-    return function setCacheControlMiddleware (req, res, next) {
-        if (req.method === 'GET') {
-            var ttl = global.environment.varnish.layergroupTtl || 86400;
-            res.set('Cache-Control', 'public,max-age='+ttl+',must-revalidate');
-        }
-
-        next();
-    };
-}
-
 function setLayerStats (pgConnection, statsBackend) {
     return function setLayerStatsMiddleware(req, res, next) {
         const { user, mapConfig } = res.locals;

--- a/lib/cartodb/controllers/map.js
+++ b/lib/cartodb/controllers/map.js
@@ -11,6 +11,7 @@ const layergroupToken = require('../middleware/layergroup-token');
 const credentials = require('../middleware/credentials');
 const dbConnSetup = require('../middleware/db-conn-setup');
 const authorize = require('../middleware/authorize');
+const cacheControlHeader = require('../middleware/cache-control-header');
 const cacheChannelHeader = require('../middleware/cache-channel-header');
 const surrogateKeyHeader = require('../middleware/surrogate-key-header');
 const lastModifiedHeader = require('../middleware/last-modified-header');
@@ -114,11 +115,11 @@ MapController.prototype.composeCreateMapMiddleware = function (endpointGroup, us
         this.getCreateMapMiddlewares(useTemplate),
         incrementMapViewCount(this.metadataBackend),
         augmentLayergroupData(),
+        cacheControlHeader({ ttl: global.environment.varnish.layergroupTtl || 86400, revalidate: true }),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader({ now: true }),
         setLastUpdatedTimeToLayergroup(),
-        setCacheControl(),
         setLayerStats(this.pgConnection, this.statsBackend),
         setLayergroupIdHeader(this.templateMaps ,useTemplateHash),
         setDataviewsAndWidgetsUrlsToLayergroupMetadata(this.layergroupMetadata),

--- a/lib/cartodb/controllers/named_maps.js
+++ b/lib/cartodb/controllers/named_maps.js
@@ -1,4 +1,3 @@
-const NamedMapsCacheEntry = require('../cache/model/named_maps_entry');
 const cors = require('../middleware/cors');
 const user = require('../middleware/user');
 const locals = require('../middleware/locals');
@@ -7,6 +6,9 @@ const layergroupToken = require('../middleware/layergroup-token');
 const credentials = require('../middleware/credentials');
 const dbConnSetup = require('../middleware/db-conn-setup');
 const authorize = require('../middleware/authorize');
+const cacheChannelHeader = require('../middleware/cache-channel-header');
+const surrogateKeyHeader = require('../middleware/surrogate-key-header');
+const lastModifiedHeader = require('../middleware/last-modified-header');
 const sendResponse = require('../middleware/send-response');
 const vectorError = require('../middleware/vector-error');
 const rateLimit = require('../middleware/rate-limit');
@@ -28,8 +30,8 @@ function getRequestParams(locals) {
     const params = Object.assign({}, locals);
 
     delete params.template;
-    delete params.affectedTablesAndLastUpdate;
-    delete params.namedMapProvider;
+    delete params.affectedTables;
+    delete params.mapConfigProvider;
     delete params.allowedQueryParams;
 
     return params;
@@ -77,14 +79,13 @@ NamedMapsController.prototype.register = function(app) {
             namedMapProviderCache: this.namedMapProviderCache,
             label: 'NAMED_MAP_TILE'
         }),
-        getAffectedTables(),
         getTile({
             tileBackend: this.tileBackend,
             label: 'NAMED_MAP_TILE'
         }),
-        setSurrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
-        setCacheChannelHeader(),
-        setLastModifiedHeader(),
+        cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        lastModifiedHeader(),
         setCacheControlHeader(),
         setContentTypeHeader(),
         sendResponse(),
@@ -106,7 +107,6 @@ NamedMapsController.prototype.register = function(app) {
             namedMapProviderCache: this.namedMapProviderCache,
             label: 'STATIC_VIZ_MAP', forcedFormat: 'png'
         }),
-        getAffectedTables(),
         getTemplate({ label: 'STATIC_VIZ_MAP' }),
         prepareLayerFilterFromPreviewLayers({
             namedMapProviderCache: this.namedMapProviderCache,
@@ -115,9 +115,9 @@ NamedMapsController.prototype.register = function(app) {
         getStaticImageOptions({ tablesExtentApi: this.tablesExtentApi }),
         getImage({ previewBackend: this.previewBackend, label: 'STATIC_VIZ_MAP' }),
         incrementMapViews({ metadataBackend: this.metadataBackend }),
-        setSurrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
-        setCacheChannelHeader(),
-        setLastModifiedHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        cacheChannelHeader(),
+        lastModifiedHeader(),
         setCacheControlHeader(),
         setContentTypeHeader(),
         sendResponse()
@@ -143,25 +143,7 @@ function getNamedMapProvider ({ namedMapProviderCache, label, forcedFormat = nul
                 return next(err);
             }
 
-            res.locals.namedMapProvider = namedMapProvider;
-
-            next();
-        });
-    };
-}
-
-function getAffectedTables () {
-    return function getAffectedTables (req, res, next) {
-        const { namedMapProvider } = res.locals;
-
-        namedMapProvider.getAffectedTablesAndLastUpdatedTime((err, affectedTablesAndLastUpdate) => {
-            req.profiler.done('affectedTables');
-
-            if (err) {
-                return next(err);
-            }
-
-            res.locals.affectedTablesAndLastUpdate = affectedTablesAndLastUpdate;
+            res.locals.mapConfigProvider = namedMapProvider;
 
             next();
         });
@@ -170,9 +152,9 @@ function getAffectedTables () {
 
 function getTemplate ({ label }) {
     return function getTemplateMiddleware (req, res, next) {
-        const { namedMapProvider } = res.locals;
+        const { mapConfigProvider } = res.locals;
 
-        namedMapProvider.getTemplate((err, template) => {
+        mapConfigProvider.getTemplate((err, template) => {
             if (err) {
                 err.label = label;
                 return next(err);
@@ -220,7 +202,7 @@ function prepareLayerFilterFromPreviewLayers ({ namedMapProviderCache, label }) 
                 return next(err);
             }
 
-            res.locals.namedMapProvider = provider;
+            res.locals.mapConfigProvider = provider;
 
             next();
         });
@@ -229,9 +211,9 @@ function prepareLayerFilterFromPreviewLayers ({ namedMapProviderCache, label }) 
 
 function getTile ({ tileBackend, label }) {
     return function getTileMiddleware (req, res, next) {
-        const { namedMapProvider, format } = res.locals;
+        const { mapConfigProvider, format } = res.locals;
 
-        tileBackend.getTile(namedMapProvider, req.params, (err, tile, headers, stats) => {
+        tileBackend.getTile(mapConfigProvider, req.params, (err, tile, headers, stats) => {
             req.profiler.add(stats);
             req.profiler.done('render-' + format);
 
@@ -253,7 +235,7 @@ function getTile ({ tileBackend, label }) {
 
 function getStaticImageOptions ({ tablesExtentApi }) {
     return function getStaticImageOptionsMiddleware(req, res, next) {
-        const { user, namedMapProvider, template } = res.locals;
+        const { user, mapConfigProvider, template } = res.locals;
 
         const imageOpts = getImageOptions(res.locals, template);
 
@@ -264,18 +246,18 @@ function getStaticImageOptions ({ tablesExtentApi }) {
 
         res.locals.imageOpts = DEFAULT_ZOOM_CENTER;
 
-        namedMapProvider.getAffectedTablesAndLastUpdatedTime((err, affectedTablesAndLastUpdate) => {
+        mapConfigProvider.getAffectedTables((err, affectedTables) => {
             if (err) {
                 return next();
             }
 
-            var affectedTables = affectedTablesAndLastUpdate.tables || [];
+            var tables = affectedTables.tables || [];
 
-            if (affectedTables.length === 0) {
+            if (tables.length === 0) {
                 return next();
             }
 
-            tablesExtentApi.getBounds(user, affectedTables, (err, bounds) => {
+            tablesExtentApi.getBounds(user, tables, (err, bounds) => {
                 if (err) {
                     return next();
                 }
@@ -355,7 +337,7 @@ function getImageOptionsFromBoundingBox (bbox = '') {
 
 function getImage({ previewBackend, label }) {
     return function getImageMiddleware (req, res, next) {
-        const { imageOpts, namedMapProvider } = res.locals;
+        const { imageOpts, mapConfigProvider } = res.locals;
         const { zoom, center, bounds } = imageOpts;
 
         let { width, height } = req.params;
@@ -366,7 +348,7 @@ function getImage({ previewBackend, label }) {
         const format = req.params.format === 'jpg' ? 'jpeg' : 'png';
 
         if (zoom !== undefined && center) {
-            return previewBackend.getImage(namedMapProvider, format, width, height, zoom, center,
+            return previewBackend.getImage(mapConfigProvider, format, width, height, zoom, center,
                 (err, image, headers, stats) => {
                 req.profiler.add(stats);
 
@@ -385,7 +367,7 @@ function getImage({ previewBackend, label }) {
             });
         }
 
-        previewBackend.getImage(namedMapProvider, format, width, height, bounds, (err, image, headers, stats) => {
+        previewBackend.getImage(mapConfigProvider, format, width, height, bounds, (err, image, headers, stats) => {
             req.profiler.add(stats);
             req.profiler.done('render-' + format);
 
@@ -411,9 +393,9 @@ function incrementMapViewsError (ctx) {
 
 function incrementMapViews ({ metadataBackend }) {
     return function incrementMapViewsMiddleware(req, res, next) {
-        const { user, namedMapProvider } = res.locals;
+        const { user, mapConfigProvider } = res.locals;
 
-        namedMapProvider.getMapConfig((err, mapConfig) => {
+        mapConfigProvider.getMapConfig((err, mapConfig) => {
             if (err) {
                 global.logger.log(incrementMapViewsError({ user, err }));
                 return next();
@@ -462,59 +444,13 @@ function templateBounds(view) {
     return false;
 }
 
-function setSurrogateKeyHeader ({ surrogateKeysCache }) {
-    return function setSurrogateKeyHeaderMiddleware(req, res, next) {
-        const { user, namedMapProvider, affectedTablesAndLastUpdate } = res.locals;
-
-        surrogateKeysCache.tag(res, new NamedMapsCacheEntry(user, namedMapProvider.getTemplateName()));
-        if (!affectedTablesAndLastUpdate || !!affectedTablesAndLastUpdate.tables) {
-            if (affectedTablesAndLastUpdate.tables.length > 0) {
-                surrogateKeysCache.tag(res, affectedTablesAndLastUpdate);
-            }
-        }
-
-        next();
-    };
-}
-
-function setCacheChannelHeader () {
-    return function setCacheChannelHeaderMiddleware (req, res, next) {
-        const { affectedTablesAndLastUpdate } = res.locals;
-
-        if (!affectedTablesAndLastUpdate || !!affectedTablesAndLastUpdate.tables) {
-            res.set('X-Cache-Channel', affectedTablesAndLastUpdate.getCacheChannel());
-        }
-
-        next();
-    };
-}
-
-function setLastModifiedHeader () {
-    return function setLastModifiedHeaderMiddleware(req, res, next) {
-        const { affectedTablesAndLastUpdate } = res.locals;
-
-        if (!affectedTablesAndLastUpdate || !!affectedTablesAndLastUpdate.tables) {
-            var lastModifiedDate;
-            if (Number.isFinite(affectedTablesAndLastUpdate.lastUpdatedTime)) {
-                lastModifiedDate = new Date(affectedTablesAndLastUpdate.getLastUpdatedAt());
-            } else {
-                lastModifiedDate = new Date();
-            }
-
-            res.set('Last-Modified', lastModifiedDate.toUTCString());
-        }
-
-        next();
-    };
- }
-
 function setCacheControlHeader () {
     return function setCacheControlHeaderMiddleware(req, res, next) {
-        const { affectedTablesAndLastUpdate } = res.locals;
+        const { affectedTables } = res.locals;
 
         res.set('Cache-Control', 'public,max-age=7200,must-revalidate');
 
-        if (!affectedTablesAndLastUpdate || !!affectedTablesAndLastUpdate.tables) {
+        if (!affectedTables || !!affectedTables.tables) {
             // we increase cache control as we can invalidate it
             res.set('Cache-Control', 'public,max-age=31536000');
         }

--- a/lib/cartodb/controllers/named_maps.js
+++ b/lib/cartodb/controllers/named_maps.js
@@ -84,11 +84,11 @@ NamedMapsController.prototype.register = function(app) {
             tileBackend: this.tileBackend,
             label: 'NAMED_MAP_TILE'
         }),
+        setContentTypeHeader(),
         cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
-        setContentTypeHeader(),
         sendResponse(),
         vectorError()
     );
@@ -115,12 +115,12 @@ NamedMapsController.prototype.register = function(app) {
         }),
         getStaticImageOptions({ tablesExtentApi: this.tablesExtentApi }),
         getImage({ previewBackend: this.previewBackend, label: 'STATIC_VIZ_MAP' }),
+        setContentTypeHeader(),
         incrementMapViews({ metadataBackend: this.metadataBackend }),
         cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
-        setContentTypeHeader(),
         sendResponse()
     );
 };
@@ -388,6 +388,14 @@ function getImage({ previewBackend, label }) {
     };
 }
 
+function setContentTypeHeader () {
+    return function setContentTypeHeaderMiddleware(req, res, next) {
+        res.set('Content-Type', res.get('content-type') || res.get('Content-Type') || 'image/png');
+
+        next();
+    };
+}
+
 function incrementMapViewsError (ctx) {
     return `ERROR: failed to increment mapview count for user '${ctx.user}': ${ctx.err}`;
 }
@@ -443,12 +451,4 @@ function templateBounds(view) {
         }
     }
     return false;
-}
-
-function setContentTypeHeader () {
-    return function setContentTypeHeaderMiddleware(req, res, next) {
-        res.set('Content-Type', res.get('content-type') || res.get('Content-Type') || 'image/png');
-
-        next();
-    };
 }

--- a/lib/cartodb/controllers/named_maps.js
+++ b/lib/cartodb/controllers/named_maps.js
@@ -6,6 +6,7 @@ const layergroupToken = require('../middleware/layergroup-token');
 const credentials = require('../middleware/credentials');
 const dbConnSetup = require('../middleware/db-conn-setup');
 const authorize = require('../middleware/authorize');
+const cacheControlHeader = require('../middleware/cache-control-header');
 const cacheChannelHeader = require('../middleware/cache-channel-header');
 const surrogateKeyHeader = require('../middleware/surrogate-key-header');
 const lastModifiedHeader = require('../middleware/last-modified-header');
@@ -83,10 +84,10 @@ NamedMapsController.prototype.register = function(app) {
             tileBackend: this.tileBackend,
             label: 'NAMED_MAP_TILE'
         }),
+        cacheControlHeader(),
         cacheChannelHeader(),
         surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
-        setCacheControlHeader(),
         setContentTypeHeader(),
         sendResponse(),
         vectorError()
@@ -115,10 +116,10 @@ NamedMapsController.prototype.register = function(app) {
         getStaticImageOptions({ tablesExtentApi: this.tablesExtentApi }),
         getImage({ previewBackend: this.previewBackend, label: 'STATIC_VIZ_MAP' }),
         incrementMapViews({ metadataBackend: this.metadataBackend }),
-        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
+        cacheControlHeader(),
         cacheChannelHeader(),
+        surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
         lastModifiedHeader(),
-        setCacheControlHeader(),
         setContentTypeHeader(),
         sendResponse()
     );
@@ -444,24 +445,8 @@ function templateBounds(view) {
     return false;
 }
 
-function setCacheControlHeader () {
-    return function setCacheControlHeaderMiddleware(req, res, next) {
-        const { affectedTables } = res.locals;
-
-        res.set('Cache-Control', 'public,max-age=7200,must-revalidate');
-
-        if (!affectedTables || !!affectedTables.tables) {
-            // we increase cache control as we can invalidate it
-            res.set('Cache-Control', 'public,max-age=31536000');
-        }
-
-        next();
-    };
- }
-
 function setContentTypeHeader () {
     return function setContentTypeHeaderMiddleware(req, res, next) {
-
         res.set('Content-Type', res.get('content-type') || res.get('Content-Type') || 'image/png');
 
         next();

--- a/lib/cartodb/middleware/cache-channel-header.js
+++ b/lib/cartodb/middleware/cache-channel-header.js
@@ -1,0 +1,24 @@
+module.exports = function setCacheChannelHeader () {
+    return function setCacheChannelHeaderMiddleware (req, res, next) {
+        if (req.method !== 'GET') {
+            return next();
+        }
+
+        const { mapConfigProvider } = res.locals;
+
+        mapConfigProvider.getAffectedTables((err, affectedTables) => {
+            if (err) {
+                global.logger.warn('ERROR generating Cache Channel Header:', err);
+                return next();
+            }
+
+            if (!affectedTables) {
+                return next();
+            }
+
+            res.set('X-Cache-Channel', affectedTables.getCacheChannel());
+
+            next();
+        });
+    };
+};

--- a/lib/cartodb/middleware/cache-control-header.js
+++ b/lib/cartodb/middleware/cache-control-header.js
@@ -14,4 +14,4 @@ module.exports = function setCacheControlHeader ({ ttl = 31536000, revalidate = 
 
         next();
     };
-}
+};

--- a/lib/cartodb/middleware/cache-control-header.js
+++ b/lib/cartodb/middleware/cache-control-header.js
@@ -1,4 +1,6 @@
-module.exports = function setCacheControlHeader ({ ttl = 31536000, revalidate = false } = {}) {
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
+module.exports = function setCacheControlHeader ({ ttl = ONE_YEAR_IN_SECONDS, revalidate = false } = {}) {
     return function setCacheControlHeaderMiddleware (req, res, next) {
         if (req.method !== 'GET') {
             return next();

--- a/lib/cartodb/middleware/cache-control-header.js
+++ b/lib/cartodb/middleware/cache-control-header.js
@@ -1,0 +1,17 @@
+module.exports = function setCacheControlHeader ({ ttl = 31536000, revalidate = false } = {}) {
+    return function setCacheControlHeaderMiddleware (req, res, next) {
+        if (req.method !== 'GET') {
+            return next();
+        }
+
+        const directives = [ 'public', `max-age=${ttl}` ];
+
+        if (revalidate) {
+            directives.push('must-revalidate');
+        }
+
+        res.set('Cache-Control', directives.join(','));
+
+        next();
+    };
+}

--- a/lib/cartodb/middleware/last-modified-header.js
+++ b/lib/cartodb/middleware/last-modified-header.js
@@ -1,0 +1,40 @@
+module.exports = function setLastModifiedHeader () {
+    return function setLastModifiedHeaderMiddleware(req, res, next) {
+        if (req.method !== 'GET') {
+            return next();
+        }
+
+        const { mapConfigProvider, cache_buster } = res.locals;
+
+        if (cache_buster) {
+            const cacheBuster = parseInt(cache_buster, 10);
+
+            if (Number.isFinite(cacheBuster)) {
+                res.set('Last-Modified',  new Date(cacheBuster).toUTCString());
+            }
+
+            return next();
+        }
+
+        mapConfigProvider.getAffectedTables((err, affectedTables) => {
+            if (err) {
+                global.logger.warn('ERROR generating Last Modified Header:', err);
+                return next();
+            }
+
+            if (!affectedTables) {
+                return next();
+            }
+
+            const lastUpdatedAt = affectedTables.getLastUpdatedAt();
+
+            const lastModifiedDate = Number.isFinite(lastUpdatedAt) ?
+                new Date(lastUpdatedAt) :
+                new Date();
+
+            res.set('Last-Modified', lastModifiedDate.toUTCString());
+
+            next();
+        });
+    };
+};

--- a/lib/cartodb/middleware/last-modified-header.js
+++ b/lib/cartodb/middleware/last-modified-header.js
@@ -1,4 +1,4 @@
-module.exports = function setLastModifiedHeader () {
+module.exports = function setLastModifiedHeader ({ now = false } = {}) {
     return function setLastModifiedHeaderMiddleware(req, res, next) {
         if (req.method !== 'GET') {
             return next();
@@ -8,10 +8,16 @@ module.exports = function setLastModifiedHeader () {
 
         if (cache_buster) {
             const cacheBuster = parseInt(cache_buster, 10);
+            const lastModifiedDate = Number.isFinite(cacheBuster) ? new Date(cacheBuster) : new Date();
 
-            if (Number.isFinite(cacheBuster)) {
-                res.set('Last-Modified',  new Date(cacheBuster).toUTCString());
-            }
+            res.set('Last-Modified', lastModifiedDate.toUTCString());
+
+            return next();
+        }
+
+        // REVIEW: to keep 100% compatibility with maps controller
+        if (now) {
+            res.set('Last-Modified', new Date().toUTCString());
 
             return next();
         }
@@ -23,14 +29,13 @@ module.exports = function setLastModifiedHeader () {
             }
 
             if (!affectedTables) {
+                res.set('Last-Modified', new Date().toUTCString());
+
                 return next();
             }
 
             const lastUpdatedAt = affectedTables.getLastUpdatedAt();
-
-            const lastModifiedDate = Number.isFinite(lastUpdatedAt) ?
-                new Date(lastUpdatedAt) :
-                new Date();
+            const lastModifiedDate = Number.isFinite(lastUpdatedAt) ? new Date(lastUpdatedAt) : new Date();
 
             res.set('Last-Modified', lastModifiedDate.toUTCString());
 

--- a/lib/cartodb/middleware/surrogate-key-header.js
+++ b/lib/cartodb/middleware/surrogate-key-header.js
@@ -1,0 +1,31 @@
+const NamedMapsCacheEntry = require('../cache/model/named_maps_entry');
+const NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
+
+module.exports = function setSurrogateKeyHeader ({ surrogateKeysCache }) {
+    return function setSurrogateKeyHeaderMiddleware(req, res, next) {
+        const { user, mapConfigProvider } = res.locals;
+
+        if (mapConfigProvider instanceof NamedMapMapConfigProvider) {
+            surrogateKeysCache.tag(res, new NamedMapsCacheEntry(user, mapConfigProvider.getTemplateName()));
+        }
+
+        if (req.method !== 'GET') {
+            return next();
+        }
+
+        mapConfigProvider.getAffectedTables((err, affectedTables) => {
+            if (err) {
+                global.logger.warn('ERROR generating Surrogate Key Header:', err);
+                return next();
+            }
+
+            if (!affectedTables || !affectedTables.tables || affectedTables.tables.length === 0) {
+                return next();
+            }
+
+            surrogateKeysCache.tag(res, affectedTables);
+
+            next();
+        });
+    };
+};

--- a/lib/cartodb/models/mapconfig/provider/create-layergroup-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/create-layergroup-provider.js
@@ -27,7 +27,13 @@ module.exports = CreateLayergroupMapConfigProvider;
 
 CreateLayergroupMapConfigProvider.prototype.getMapConfig = function(callback) {
     var self = this;
+
+    if (this.mapConfig && this.params && this.context) {
+        return callback(null, this.mapConfig, this.params, this.context);
+    }
+
     var context = {};
+
     step(
         function prepareContextLimits() {
             self.userLimitsApi.getRenderLimits(self.user, self.params.api_key, this);
@@ -35,6 +41,7 @@ CreateLayergroupMapConfigProvider.prototype.getMapConfig = function(callback) {
         function handleRenderLimits(err, renderLimits) {
             assert.ifError(err);
             context.limits = renderLimits;
+            self.context = context;
             return null;
         },
         function finish(err) {
@@ -52,59 +59,50 @@ CreateLayergroupMapConfigProvider.prototype.filter = MapStoreMapConfigProvider.p
 CreateLayergroupMapConfigProvider.prototype.createKey = MapStoreMapConfigProvider.prototype.createKey;
 
 CreateLayergroupMapConfigProvider.prototype.getAffectedTables = function (callback) {
-    var self = this;
+    this.getMapConfig((err, mapConfig) => {
+        if (err) {
+            return callback(err);
+        }
 
-    const { dbname } = self.params;
-    const token = self.mapConfig.id();
+        const { dbname } = this.params;
+        const token = mapConfig.id();
 
-    if (self.affectedTablesCache.hasAffectedTables(dbname, token)) {
-        const affectedTables = self.affectedTablesCache.get(dbname, token);
-        return callback(null, affectedTables);
-    }
+        if (this.affectedTablesCache.hasAffectedTables(dbname, token)) {
+            const affectedTables = this.affectedTablesCache.get(dbname, token);
+            return callback(null, affectedTables);
+        }
 
-    step(
-        function getSql() {
-            const queries = [];
+        const queries = [];
 
-            self.mapConfig.getLayers().forEach(function(layer) {
-                queries.push(layer.options.sql);
-                if (layer.options.affected_tables) {
-                    layer.options.affected_tables.map(table => {
-                        queries.push(`SELECT * FROM ${table} LIMIT 0`);
-                    });
-                }
-            });
-
-            const sql = queries.length ? queries.join(';') : null;
-
-            if (!sql) {
-                return callback();
+        this.mapConfig.getLayers().forEach(function(layer) {
+            queries.push(layer.options.sql);
+            if (layer.options.affected_tables) {
+                layer.options.affected_tables.map(table => {
+                    queries.push(`SELECT * FROM ${table} LIMIT 0`);
+                });
             }
+        });
 
-            return sql;
-        },
-        function getAffectedTables(err, sql) {
-            assert.ifError(err);
+        const sql = queries.length ? queries.join(';') : null;
 
-            step(
-                function getConnection() {
-                    self.pgConnection.getConnection(self.user, this);
-                },
-                function getAffectedTables(err, connection) {
-                    assert.ifError(err);
-                    QueryTables.getAffectedTablesFromQuery(connection, sql, this);
-                },
-                this
-            );
-        },
-        function finish(err, affectedTables) {
+        if (!sql) {
+            return callback();
+        }
+
+        this.pgConnection.getConnection(this.user, (err, connection) => {
             if (err) {
                 return callback(err);
             }
 
-            self.affectedTablesCache.set(dbname, token, affectedTables);
+            QueryTables.getAffectedTablesFromQuery(connection, sql, (err, affectedTables) => {
+                if (err) {
+                    return callback(err);
+                }
 
-            return callback(null, affectedTables);
-        }
-    );
+                this.affectedTablesCache.set(dbname, token, affectedTables);
+
+                callback(null, affectedTables);
+            });
+        });
+    });
 };

--- a/lib/cartodb/models/mapconfig/provider/create-layergroup-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/create-layergroup-provider.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var step = require('step');
 
 var MapStoreMapConfigProvider = require('./map-store-provider');
+const QueryTables = require('cartodb-query-tables');
 
 /**
  * @param {MapConfig} mapConfig
@@ -11,10 +12,13 @@ var MapStoreMapConfigProvider = require('./map-store-provider');
  * @constructor
  * @type {CreateLayergroupMapConfigProvider}
  */
-function CreateLayergroupMapConfigProvider(mapConfig, user, userLimitsApi, params) {
+
+function CreateLayergroupMapConfigProvider(mapConfig, user, userLimitsApi, pgConnection, affectedTablesCache, params) {
     this.mapConfig = mapConfig;
     this.user = user;
     this.userLimitsApi = userLimitsApi;
+    this.pgConnection = pgConnection;
+    this.affectedTablesCache = affectedTablesCache;
     this.params = params;
     this.cacheBuster = params.cache_buster || 0;
 }
@@ -46,3 +50,61 @@ CreateLayergroupMapConfigProvider.prototype.getCacheBuster = MapStoreMapConfigPr
 CreateLayergroupMapConfigProvider.prototype.filter = MapStoreMapConfigProvider.prototype.filter;
 
 CreateLayergroupMapConfigProvider.prototype.createKey = MapStoreMapConfigProvider.prototype.createKey;
+
+CreateLayergroupMapConfigProvider.prototype.getAffectedTables = function (callback) {
+    var self = this;
+
+    const { dbname } = self.params;
+    const token = self.mapConfig.id();
+
+    if (self.affectedTablesCache.hasAffectedTables(dbname, token)) {
+        const affectedTables = self.affectedTablesCache.get(dbname, token);
+        return callback(null, affectedTables);
+    }
+
+    step(
+        function getSql() {
+            const queries = [];
+
+            self.mapConfig.getLayers().forEach(function(layer) {
+                queries.push(layer.options.sql);
+                if (layer.options.affected_tables) {
+                    layer.options.affected_tables.map(table => {
+                        queries.push(`SELECT * FROM ${table} LIMIT 0`);
+                    });
+                }
+            });
+
+            const sql = queries.length ? queries.join(';') : null;
+
+            if (!sql) {
+                return callback();
+            }
+
+            return sql;
+        },
+        function getAffectedTables(err, sql) {
+            assert.ifError(err);
+
+            step(
+                function getConnection() {
+                    self.pgConnection.getConnection(self.user, this);
+                },
+                function getAffectedTables(err, connection) {
+                    assert.ifError(err);
+                    QueryTables.getAffectedTablesFromQuery(connection, sql, this);
+                },
+                this
+            );
+        },
+        function finish(err, affectedTables) {
+            if (err) {
+                return callback(err);
+            }
+
+            self.affectedTablesCache.set(dbname, token, affectedTables);
+
+            return callback(null, affectedTables);
+        }
+    );
+};

--- a/lib/cartodb/models/mapconfig/provider/create-layergroup-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/create-layergroup-provider.js
@@ -74,7 +74,7 @@ CreateLayergroupMapConfigProvider.prototype.getAffectedTables = function (callba
 
         const queries = [];
 
-        this.mapConfig.getLayers().forEach(function(layer) {
+        this.mapConfig.getLayers().forEach(layer => {
             queries.push(layer.options.sql);
             if (layer.options.affected_tables) {
                 layer.options.affected_tables.map(table => {

--- a/lib/cartodb/models/mapconfig/provider/map-store-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/map-store-provider.js
@@ -106,7 +106,7 @@ MapStoreMapConfigProvider.prototype.getAffectedTables = function(callback) {
 
         const queries = [];
 
-        mapConfig.getLayers().forEach(function(layer) {
+        mapConfig.getLayers().forEach(layer => {
             queries.push(layer.options.sql);
             if (layer.options.affected_tables) {
                 layer.options.affected_tables.map(table => {

--- a/lib/cartodb/models/mapconfig/provider/map-store-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/map-store-provider.js
@@ -90,64 +90,51 @@ MapStoreMapConfigProvider.prototype.createKey = function(base) {
 };
 
 MapStoreMapConfigProvider.prototype.getAffectedTables = function(callback) {
-    var self = this;
+    this.getMapConfig((err, mapConfig) => {
+        if (err) {
+            return callback(err);
+        }
 
-    const { dbname, token } = self.params;
+        const { dbname } = this.params;
+        const token = mapConfig.id();
 
-    if (self.affectedTablesCache.hasAffectedTables(dbname, token)) {
-        const affectedTables = self.affectedTablesCache.get(dbname, token);
+        if (this.affectedTablesCache.hasAffectedTables(dbname, token)) {
+            const affectedTables = this.affectedTablesCache.get(dbname, token);
 
-        return callback(null, affectedTables);
-    }
+            return callback(null, affectedTables);
+        }
 
-    step(
-        function getMapConfig() {
-            self.getMapConfig(this);
-        },
-        function getSql(err, mapConfig) {
-            assert.ifError(err);
+        const queries = [];
 
-            const queries = [];
-
-            mapConfig.getLayers().forEach(function(layer) {
-                queries.push(layer.options.sql);
-                if (layer.options.affected_tables) {
-                    layer.options.affected_tables.map(table => {
-                        queries.push(`SELECT * FROM ${table} LIMIT 0`);
-                    });
-                }
-            });
-
-            const sql = queries.length ? queries.join(';') : null;
-
-            if (!sql) {
-                return callback();
+        mapConfig.getLayers().forEach(function(layer) {
+            queries.push(layer.options.sql);
+            if (layer.options.affected_tables) {
+                layer.options.affected_tables.map(table => {
+                    queries.push(`SELECT * FROM ${table} LIMIT 0`);
+                });
             }
+        });
 
-            return sql;
-        },
-        function getAffectedTables(err, sql) {
-            assert.ifError(err);
+        const sql = queries.length ? queries.join(';') : null;
 
-            step(
-                function getConnection() {
-                    self.pgConnection.getConnection(self.user, this);
-                },
-                function getAffectedTables(err, connection) {
-                    assert.ifError(err);
-                    QueryTables.getAffectedTablesFromQuery(connection, sql, this);
-                },
-                this
-            );
-        },
-        function finish(err, affectedTables) {
+        if (!sql) {
+            return callback();
+        }
+
+        this.pgConnection.getConnection(this.user, (err, connection) => {
             if (err) {
                 return callback(err);
             }
 
-            self.affectedTablesCache.set(dbname, token, affectedTables);
+            QueryTables.getAffectedTablesFromQuery(connection, sql, (err, affectedTables) => {
+                if (err) {
+                    return callback(err);
+                }
 
-            return callback(err, affectedTables);
-        }
-    );
+                this.affectedTablesCache.set(dbname, token, affectedTables);
+
+                callback(err, affectedTables);
+            });
+        });
+    });
 };

--- a/lib/cartodb/models/mapconfig/provider/map-store-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/map-store-provider.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var assert = require('assert');
 var dot = require('dot');
 var step = require('step');
+const QueryTables = require('cartodb-query-tables');
 
 /**
  * @param {MapStore} mapStore
@@ -11,20 +12,30 @@ var step = require('step');
  * @constructor
  * @type {MapStoreMapConfigProvider}
  */
-function MapStoreMapConfigProvider(mapStore, user, userLimitsApi, params) {
+function MapStoreMapConfigProvider(mapStore, user, userLimitsApi, pgConnection, affectedTablesCache, params) {
     this.mapStore = mapStore;
     this.user = user;
     this.userLimitsApi = userLimitsApi;
-    this.params = params;
+    this.pgConnection = pgConnection;
+    this.affectedTablesCache = affectedTablesCache;
     this.token = params.token;
     this.cacheBuster = params.cache_buster || 0;
+    this.mapConfig = null;
+    this.params = params;
+    this.context = null;
 }
 
 module.exports = MapStoreMapConfigProvider;
 
 MapStoreMapConfigProvider.prototype.getMapConfig = function(callback) {
     var self = this;
+
+    if (this.mapConfig !== null) {
+        return callback(null, this.mapConfig, this.params, this.context);
+    }
+
     var context = {};
+
     step(
         function prepareContextLimits() {
             self.userLimitsApi.getRenderLimits(self.user, self.params.api_key, this);
@@ -39,6 +50,8 @@ MapStoreMapConfigProvider.prototype.getMapConfig = function(callback) {
             self.mapStore.load(self.token, this);
         },
         function finish(err, mapConfig) {
+            self.mapConfig = mapConfig;
+            self.context = context;
             return callback(err, mapConfig, self.params, context);
         }
     );
@@ -74,4 +87,67 @@ MapStoreMapConfigProvider.prototype.createKey = function(base) {
         scale_factor: 1
     });
     return (base) ? baseKeyTpl(tplValues) : rendererKeyTpl(tplValues);
+};
+
+MapStoreMapConfigProvider.prototype.getAffectedTables = function(callback) {
+    var self = this;
+
+    const { dbname, token } = self.params;
+
+    if (self.affectedTablesCache.hasAffectedTables(dbname, token)) {
+        const affectedTables = self.affectedTablesCache.get(dbname, token);
+
+        return callback(null, affectedTables);
+    }
+
+    step(
+        function getMapConfig() {
+            self.getMapConfig(this);
+        },
+        function getSql(err, mapConfig) {
+            assert.ifError(err);
+
+            const queries = [];
+
+            mapConfig.getLayers().forEach(function(layer) {
+                queries.push(layer.options.sql);
+                if (layer.options.affected_tables) {
+                    layer.options.affected_tables.map(table => {
+                        queries.push(`SELECT * FROM ${table} LIMIT 0`);
+                    });
+                }
+            });
+
+            const sql = queries.length ? queries.join(';') : null;
+
+            if (!sql) {
+                return callback();
+            }
+
+            return sql;
+        },
+        function getAffectedTables(err, sql) {
+            assert.ifError(err);
+
+            step(
+                function getConnection() {
+                    self.pgConnection.getConnection(self.user, this);
+                },
+                function getAffectedTables(err, connection) {
+                    assert.ifError(err);
+                    QueryTables.getAffectedTablesFromQuery(connection, sql, this);
+                },
+                this
+            );
+        },
+        function finish(err, affectedTables) {
+            if (err) {
+                return callback(err);
+            }
+
+            self.affectedTablesCache.set(dbname, token, affectedTables);
+
+            return callback(err, affectedTables);
+        }
+    );
 };

--- a/lib/cartodb/models/mapconfig/provider/named-map-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/named-map-provider.js
@@ -11,8 +11,19 @@ var QueryTables = require('cartodb-query-tables');
  * @constructor
  * @type {NamedMapMapConfigProvider}
  */
-function NamedMapMapConfigProvider(templateMaps, pgConnection, metadataBackend, userLimitsApi, mapConfigAdapter,
-                                   owner, templateId, config, authToken, params) {
+function NamedMapMapConfigProvider(
+    templateMaps,
+    pgConnection,
+    metadataBackend,
+    userLimitsApi,
+    mapConfigAdapter,
+    affectedTablesCache,
+    owner,
+    templateId,
+    config,
+    authToken,
+    params
+) {
     this.templateMaps = templateMaps;
     this.pgConnection = pgConnection;
     this.metadataBackend = metadataBackend;
@@ -30,7 +41,7 @@ function NamedMapMapConfigProvider(templateMaps, pgConnection, metadataBackend, 
     // use template after call to mapConfig
     this.template = null;
 
-    this.affectedTablesAndLastUpdate = null;
+    this.affectedTablesCache = affectedTablesCache;
 
     // providing
     this.err = null;
@@ -189,7 +200,7 @@ NamedMapMapConfigProvider.prototype.getCacheBuster = function() {
 NamedMapMapConfigProvider.prototype.reset = function() {
     this.template = null;
 
-    this.affectedTablesAndLastUpdate = null;
+    this.affectedTables = null;
 
     this.err = null;
     this.mapConfig = null;
@@ -251,12 +262,11 @@ NamedMapMapConfigProvider.prototype.getTemplateName = function() {
     return this.templateName;
 };
 
-NamedMapMapConfigProvider.prototype.getAffectedTablesAndLastUpdatedTime = function(callback) {
+NamedMapMapConfigProvider.prototype.getAffectedTables = function(callback) {
     var self = this;
 
-    if (this.affectedTablesAndLastUpdate !== null) {
-        return callback(null, this.affectedTablesAndLastUpdate);
-    }
+    let dbname = null;
+    let token = null;
 
     step(
         function getMapConfig() {
@@ -264,9 +274,33 @@ NamedMapMapConfigProvider.prototype.getAffectedTablesAndLastUpdatedTime = functi
         },
         function getSql(err, mapConfig) {
             assert.ifError(err);
-            return mapConfig.getLayers().map(function(layer) {
-                return layer.options.sql;
-            }).join(';');
+
+            dbname = self.rendererParams;
+            token = mapConfig.id();
+
+            if (self.affectedTablesCache.hasAffectedTables(dbname, token)) {
+                const affectedTables = self.affectedTablesCache.get(dbname, token);
+                return callback(null, affectedTables);
+            }
+
+            const queries = [];
+
+            mapConfig.getLayers().forEach(layer => {
+                queries.push(layer.options.sql);
+                if (layer.options.affected_tables) {
+                    layer.options.affected_tables.map(table => {
+                        queries.push(`SELECT * FROM ${table} LIMIT 0`);
+                    });
+                }
+            });
+
+            const sql = queries.length ? queries.join(';') : null;
+
+            if (!sql) {
+                return callback();
+            }
+
+            return sql;
         },
         function getAffectedTables(err, sql) {
             assert.ifError(err);
@@ -281,9 +315,14 @@ NamedMapMapConfigProvider.prototype.getAffectedTablesAndLastUpdatedTime = functi
                 this
             );
         },
-        function finish(err, result) {
-            self.affectedTablesAndLastUpdate = result;
-            return callback(err, result);
+        function finish(err, affectedTables) {
+            if (err) {
+                return callback(err);
+            }
+
+            self.affectedTablesCache.set(dbname, token, affectedTables);
+
+            return callback(err, affectedTables);
         }
     );
 };

--- a/lib/cartodb/models/mapconfig/provider/named-map-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/named-map-provider.js
@@ -263,66 +263,50 @@ NamedMapMapConfigProvider.prototype.getTemplateName = function() {
 };
 
 NamedMapMapConfigProvider.prototype.getAffectedTables = function(callback) {
-    var self = this;
+    this.getMapConfig((err, mapConfig) => {
+        if (err) {
+            return callback(err);
+        }
 
-    let dbname = null;
-    let token = null;
+        const { dbname } = this.rendererParams;
+        const token = mapConfig.id();
 
-    step(
-        function getMapConfig() {
-            self.getMapConfig(this);
-        },
-        function getSql(err, mapConfig) {
-            assert.ifError(err);
+        if (this.affectedTablesCache.hasAffectedTables(dbname, token)) {
+            const affectedTables = this.affectedTablesCache.get(dbname, token);
+            return callback(null, affectedTables);
+        }
 
-            dbname = self.rendererParams;
-            token = mapConfig.id();
+        const queries = [];
 
-            if (self.affectedTablesCache.hasAffectedTables(dbname, token)) {
-                const affectedTables = self.affectedTablesCache.get(dbname, token);
-                return callback(null, affectedTables);
+        mapConfig.getLayers().forEach(layer => {
+            queries.push(layer.options.sql);
+            if (layer.options.affected_tables) {
+                layer.options.affected_tables.map(table => {
+                    queries.push(`SELECT * FROM ${table} LIMIT 0`);
+                });
             }
+        });
 
-            const queries = [];
+        const sql = queries.length ? queries.join(';') : null;
 
-            mapConfig.getLayers().forEach(layer => {
-                queries.push(layer.options.sql);
-                if (layer.options.affected_tables) {
-                    layer.options.affected_tables.map(table => {
-                        queries.push(`SELECT * FROM ${table} LIMIT 0`);
-                    });
-                }
-            });
+        if (!sql) {
+            return callback();
+        }
 
-            const sql = queries.length ? queries.join(';') : null;
-
-            if (!sql) {
-                return callback();
-            }
-
-            return sql;
-        },
-        function getAffectedTables(err, sql) {
-            assert.ifError(err);
-            step(
-                function getConnection() {
-                    self.pgConnection.getConnection(self.owner, this);
-                },
-                function getAffectedTables(err, connection) {
-                    assert.ifError(err);
-                    QueryTables.getAffectedTablesFromQuery(connection, sql, this);
-                },
-                this
-            );
-        },
-        function finish(err, affectedTables) {
+        this.pgConnection.getConnection(this.owner, (err, connection) => {
             if (err) {
                 return callback(err);
             }
 
-            self.affectedTablesCache.set(dbname, token, affectedTables);
+            QueryTables.getAffectedTablesFromQuery(connection, sql, (err, affectedTables) => {
+                if (err) {
+                    return callback(err);
+                }
 
-            return callback(err, affectedTables);
-        }
-    );
+                this.affectedTablesCache.set(dbname, token, affectedTables);
+
+                callback(err, affectedTables);
+            });
+        });
+    });
 };

--- a/lib/cartodb/server.js
+++ b/lib/cartodb/server.js
@@ -200,7 +200,8 @@ module.exports = function(serverOptions) {
         pgConnection,
         metadataBackend,
         userLimitsApi,
-        mapConfigAdapter
+        mapConfigAdapter,
+        layergroupAffectedTablesCache
     );
 
     ['update', 'delete'].forEach(function(eventType) {

--- a/test/acceptance/multilayer.js
+++ b/test/acceptance/multilayer.js
@@ -1272,6 +1272,8 @@ describe(suiteName, function() {
     it("cache control for layergroup default value", function(done) {
         global.environment.varnish.layergroupTtl = null;
 
+        var server = new CartodbWindshaft(serverOptions);
+
         assert.response(server, layergroupTtlRequest, layergroupTtlResponseExpectation,
             function(res) {
                 assert.equal(res.headers['cache-control'], 'public,max-age=86400,must-revalidate');
@@ -1286,6 +1288,8 @@ describe(suiteName, function() {
     it("cache control for layergroup uses configuration for max-age", function(done) {
         var layergroupTtl = 300;
         global.environment.varnish.layergroupTtl = layergroupTtl;
+
+        var server = new CartodbWindshaft(serverOptions);
 
         assert.response(server, layergroupTtlRequest, layergroupTtlResponseExpectation,
             function(res) {


### PR DESCRIPTION
Make generic middlewares to calculate surrogate key, cache channel, last modified, and cache control headers:

 - In controllers: all reference to map config are now `camelized`, for instance: mapconfig -> mapConfig or mapconfigProvider -> mapConfigProvider
 - In controllers: all map config providers created in req/res cycle are saved into `res.locals` and `mapConfigProvider` as key.
 - In map-config-providers: all of them implement `.getAffectedTables()`, in order to calculate the tables involved for a given map-config. For that, `pgConnection` and `affectedTablesCache` are injected as a constructor argument.
 - Named Map Provider: rename references from `affectedTablesAndLastUpdate` to `affectedTables`.
 - Named Map Provider Cache: In order to create a new named map provider, needs affectedTablesCache.
 - Extract locals middlewares (surrogate-key and cache-channel) from controllers and create a unified version of them.
 - Extract last-modified middleware fro, controllers.
 - Extract cache control header middleware