### PR TITLE
Rate limits final details

### DIFF
--- a/lib/cartodb/middleware/rate-limit.js
+++ b/lib/cartodb/middleware/rate-limit.js
@@ -39,11 +39,13 @@ function rateLimit(userLimitsApi, endpointGroup = null) {
             res.set({
                 'Carto-Rate-Limit-Limit': limit,
                 'Carto-Rate-Limit-Remaining': remaining,
-                'Retry-After': retry,
                 'Carto-Rate-Limit-Reset': reset
             });
 
             if (isBlocked) {
+                // retry is floor rounded in seconds by redis-cell
+                res.set('Retry-After', retry + 1);
+
                 const rateLimitError = new Error('You are over the limits.');
                 rateLimitError.http_status = 429;
                 rateLimitError.type = 'limit';

--- a/lib/cartodb/middleware/rate-limit.js
+++ b/lib/cartodb/middleware/rate-limit.js
@@ -46,7 +46,9 @@ function rateLimit(userLimitsApi, endpointGroup = null) {
                 // retry is floor rounded in seconds by redis-cell
                 res.set('Retry-After', retry + 1);
 
-                const rateLimitError = new Error('You are over the limits.');
+                let rateLimitError = new Error(
+                    'You are over platform\'s limits. Please contact us to know more details'
+                );
                 rateLimitError.http_status = 429;
                 rateLimitError.type = 'limit';
                 rateLimitError.subtype = 'rate-limit';

--- a/lib/cartodb/middleware/vector-error.js
+++ b/lib/cartodb/middleware/vector-error.js
@@ -5,7 +5,7 @@ module.exports = function vectorError() {
     return function vectorErrorMiddleware(err, req, res, next) {
         if(req.params.format === 'mvt') {
 
-            if (isTimeoutError(err)) {
+            if (isTimeoutError(err) || isRateLimitError(err)) {
                 res.set('Content-Type', 'application/x-protobuf');
                 return res.status(429).send(timeoutErrorVectorTile);
             }
@@ -26,4 +26,8 @@ function isDatasourceTimeoutError (err) {
 
 function isTimeoutError (err) {
     return isRenderTimeoutError(err) || isDatasourceTimeoutError(err);
+}
+
+function isRateLimitError (err) {
+    return err.type === 'limit' && err.subtype === 'rate-limit';
 }

--- a/test/acceptance/rate-limit.test.js
+++ b/test/acceptance/rate-limit.test.js
@@ -337,18 +337,23 @@ describe('rate limit and vector tiles', function () {
         testClient.getTile(0, 0, 0, tileParams(204, '1', '0', '1'), (err) => {
             assert.ifError(err);
     
-            testClient.getTile(0, 0, 0, tileParams(429, '1', '0', '0', '1', 'application/x-protobuf'), (err, res, tile) => {
-                assert.ifError(err);
+            testClient.getTile(
+                0, 
+                0, 
+                0, 
+                tileParams(429, '1', '0', '0', '1', 'application/x-protobuf'), 
+                (err, res, tile) => {
+                    assert.ifError(err);
 
-                var tileJSON = tile.toJSON();
-                assert.equal(Array.isArray(tileJSON), true);
-                assert.equal(tileJSON.length, 2);
-                assert.equal(tileJSON[0].name, 'errorTileSquareLayer');
-                assert.equal(tileJSON[1].name, 'errorTileStripesLayer');
-        
-                done();
-            });
+                    var tileJSON = tile.toJSON();
+                    assert.equal(Array.isArray(tileJSON), true);
+                    assert.equal(tileJSON.length, 2);
+                    assert.equal(tileJSON[0].name, 'errorTileSquareLayer');
+                    assert.equal(tileJSON[1].name, 'errorTileStripesLayer');
             
+                    done();
+                }
+            );    
         });
     
     });

--- a/test/acceptance/rate-limit.test.js
+++ b/test/acceptance/rate-limit.test.js
@@ -143,7 +143,7 @@ function assertRateLimitRequest (status, limit, remaining, reset, retry, done) {
             assert.ifError(err);
         } else {
             assert.ok(err);
-            assert.equal(err.message, 'You are over the limits.');
+            assert.equal(err.message, 'You are over platform\'s limits. Please contact us to know more details');
             assert.equal(err.http_status, 429);
             assert.equal(err.type, 'limit');
             assert.equal(err.subtype, 'rate-limit');


### PR DESCRIPTION
- Remove Rety-after HTTP header when you are not rate limited (now we are returning -1)
- Vector tile error
- Unify error message with the timeout limit message