### PR TITLE
Do not log analysis results to stdout when log filename is not provided

### DIFF
--- a/lib/cartodb/backends/analysis.js
+++ b/lib/cartodb/backends/analysis.js
@@ -48,9 +48,11 @@ AnalysisBackend.prototype.create = function(analysisConfiguration, analysisDefin
     analysisConfiguration.batch.inlineExecution = this.batchConfig.inlineExecution;
     analysisConfiguration.batch.hostHeaderTemplate = this.batchConfig.hostHeaderTemplate;
 
-    analysisConfiguration.logger = {
-        stream: this.stream ? this.stream : process.stdout
-    };
+    if (this.stream) {
+        analysisConfiguration.logger = {
+            stream: this.stream
+        };
+    }
 
     this.getAnalysesLimits(analysisConfiguration.user, function(err, limits) {
         analysisConfiguration.limits = limits || {};


### PR DESCRIPTION
To remove the noise that analysis logger produces when running test: do not log analysis results to stdout when log filename is not provided