### PR TITLE
Express Routers: Activate mergeParams option

### DIFF
--- a/lib/cartodb/api/api-router.js
+++ b/lib/cartodb/api/api-router.js
@@ -191,7 +191,7 @@ module.exports = class ApiRouter {
         Object.keys(this.serverOptions.routes).forEach(apiVersion => {
             const routes = this.serverOptions.routes[apiVersion];
 
-            const apiRouter = router();
+            const apiRouter = router({ mergeParams: true });
 
             apiRouter.use(logger(this.serverOptions));
             apiRouter.use(initializeStatusCode());

--- a/lib/cartodb/api/map/map-router.js
+++ b/lib/cartodb/api/map/map-router.js
@@ -113,7 +113,7 @@ module.exports = class MapRouter {
     }
 
     register (apiRouter, mapPaths) {
-        const mapRouter = router();
+        const mapRouter = router({ mergeParams: true });
 
         this.analysisLayergroupController.register(mapRouter);
         this.attributesLayergroupController.register(mapRouter);

--- a/lib/cartodb/api/template/template-router.js
+++ b/lib/cartodb/api/template/template-router.js
@@ -53,7 +53,7 @@ module.exports = class TemplateRouter {
     }
 
     register (apiRouter, templatePaths) {
-        const templateRouter = router();
+        const templateRouter = router({ mergeParams: true });
 
         this.namedMapController.register(templateRouter);
         this.tileTemplateController.register(templateRouter);


### PR DESCRIPTION
In order to extract common middlewares between routers and controllers we need to activate `mergeParams` option to preserve the `req.params` from the parent router