### PR TITLE
Unify connection pool config

### DIFF
--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -137,15 +137,7 @@ var config = {
         //If enabled, MVTs will be generated with PostGIS directly, instead of using Mapnik,
         //PostGIS 2.4 is required for this to work
         //If disabled it will use Mapnik MVT generation
-        usePostGIS: false,
-        dbPoolParams: {
-              // maximum number of resources to create at any given time
-              size: 16,
-              // max milliseconds a resource can go unused before it should be destroyed
-              idleTimeout: 3000,
-              // frequency to check for idle resources
-              reapInterval: 1000
-          }
+        usePostGIS: false
       },
       mapnik: {
           // The size of the pool of internal mapnik backend
@@ -261,16 +253,7 @@ var config = {
               src: __dirname + '/../../assets/default-placeholder.png'
           }
       },
-      torque: {
-          dbPoolParams: {
-              // maximum number of resources to create at any given time
-              size: 16,
-              // max milliseconds a resource can go unused before it should be destroyed
-              idleTimeout: 3000,
-              // frequency to check for idle resources
-              reapInterval: 1000
-          }
-      }
+      torque: {}
     }
     // anything analyses related
     ,analysis: {

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -118,7 +118,7 @@ var config = {
         user: "publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 6432
+        port: 5432
     }
     ,mapnik_version: undefined
     ,mapnik_tile_format: 'png8:m=h'

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -118,7 +118,15 @@ var config = {
         user: "publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 5432
+        port: 5432,
+        pool: {
+            // maximum number of resources to create at any given time
+            size: 16,
+            // max milliseconds a resource can go unused before it should be destroyed
+            idleTimeout: 3000,
+            // frequency to check for idle resources
+            reapInterval: 1000
+        }
     }
     ,mapnik_version: undefined
     ,mapnik_tile_format: 'png8:m=h'

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -115,32 +115,10 @@ var config = {
     // Supported labels: 'user_id', 'user_password' (both read from redis)
     ,postgres_auth_pass: '<%= user_password %>'
     ,postgres: {
-        // Parameters to pass to datasource plugin of mapnik
-        // See http://github.com/mapnik/mapnik/wiki/PostGIS
-        type: "postgis",
         user: "publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 5432,
-        extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
-        /* experimental
-        geometry_field: "the_geom",
-        extent: "-180,-90,180,90",
-        srid: 4326,
-        */
-        // max number of rows to return when querying data, 0 means no limit
-        row_limit: 65535,
-        simplify_geometries: true,
-        use_overviews: true, // use overviews to retrieve raster
-        /*
-         * Set persist_connection to false if you want
-         * database connections to be closed on renderer
-         * expiration (1 minute after last use).
-         * Setting to true (the default) would never
-         * close any connection for the server's lifetime
-         */
-        persist_connection: false,
-        max_size: 500
+        port: 6432
     }
     ,mapnik_version: undefined
     ,mapnik_tile_format: 'png8:m=h'
@@ -220,6 +198,29 @@ var config = {
           // Returning the portion of a geometry falling within a rectangle
           // It will only work if snapToGrid is enabled
           clipByBox2d: false, // this requires postgis >=2.2 and geos >=3.5
+
+          postgis: {
+              // Parameters to pass to datasource plugin of mapnik
+              // See http://github.com/mapnik/mapnik/wiki/PostGIS
+              user: "publicuser",
+              password: "public",
+              host: '127.0.0.1',
+              port: 6432,
+              extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
+              // max number of rows to return when querying data, 0 means no limit
+              row_limit: 65535,
+              /*
+               * Set persist_connection to false if you want
+               * database connections to be closed on renderer
+               * expiration (1 minute after last use).
+               * Setting to true (the default) would never
+               * close any connection for the server's lifetime
+               */
+               persist_connection: false,
+               simplify_geometries: true,
+               use_overviews: true, // use overviews to retrieve raster
+               max_size: 500
+          },
 
           limits: {
               // Time in milliseconds a render request can take before it fails, some notes:

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -235,25 +235,6 @@ var config = {
               cacheOnTimeout: true
           },
 
-          geojson: {
-                dbPoolParams: {
-                      // maximum number of resources to create at any given time
-                      size: 16,
-                      // max milliseconds a resource can go unused before it should be destroyed
-                      idleTimeout: 3000,
-                      // frequency to check for idle resources
-                      reapInterval: 1000
-                },
-
-              // SQL queries will be wrapped with ST_ClipByBox2D
-              // Returning the portion of a geometry falling within a rectangle
-              // It will only work if snapToGrid is enabled
-              clipByBox2d: false, // this requires postgis >=2.2 and geos >=3.5
-              // geometries will be simplified using ST_RemoveRepeatedPoints
-              // which cost is no more expensive than snapping and results are
-              // much closer to the original geometry
-              removeRepeatedPoints: false // this requires postgis >=2.2
-          },
           // If enabled Mapnik will reuse the features retrieved from the database
           // instead of requesting them once per style inside a layer
           'cache-features': true,

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -197,7 +197,7 @@ var config = {
               user: "publicuser",
               password: "public",
               host: '127.0.0.1',
-              port: 6432,
+              port: 5432,
               extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
               // max number of rows to return when querying data, 0 means no limit
               row_limit: 65535,

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -115,26 +115,10 @@ var config = {
     // Supported labels: 'user_id', 'user_password' (both read from redis)
     ,postgres_auth_pass: '<%= user_password %>'
     ,postgres: {
-        // Parameters to pass to datasource plugin of mapnik
-        // See http://github.com/mapnik/mapnik/wiki/PostGIS
         user: "publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 6432,
-        extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
-        // max number of rows to return when querying data, 0 means no limit
-        row_limit: 65535,
-        /*
-         * Set persist_connection to false if you want
-         * database connections to be closed on renderer
-         * expiration (1 minute after last use).
-         * Setting to true (the default) would never
-         * close any connection for the server's lifetime
-         */
-        persist_connection: false,
-        simplify_geometries: true,
-        use_overviews: true, // use overviews to retrieve raster
-        max_size: 500
+        port: 6432
     }
     ,mapnik_version: undefined
     ,mapnik_tile_format: 'png8:m=h'
@@ -214,6 +198,29 @@ var config = {
           // Returning the portion of a geometry falling within a rectangle
           // It will only work if snapToGrid is enabled
           clipByBox2d: false, // this requires postgis >=2.2 and geos >=3.5
+
+          postgis: {
+              // Parameters to pass to datasource plugin of mapnik
+              // See http://github.com/mapnik/mapnik/wiki/PostGIS
+              user: "publicuser",
+              password: "public",
+              host: '127.0.0.1',
+              port: 6432,
+              extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
+              // max number of rows to return when querying data, 0 means no limit
+              row_limit: 65535,
+              /*
+               * Set persist_connection to false if you want
+               * database connections to be closed on renderer
+               * expiration (1 minute after last use).
+               * Setting to true (the default) would never
+               * close any connection for the server's lifetime
+               */
+               persist_connection: false,
+               simplify_geometries: true,
+               use_overviews: true, // use overviews to retrieve raster
+               max_size: 500
+          },
 
           limits: {
               // Time in milliseconds a render request can take before it fails, some notes:

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -118,7 +118,15 @@ var config = {
         user: "publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 5432
+        port: 5432,
+        pool: {
+            // maximum number of resources to create at any given time
+            size: 16,
+            // max milliseconds a resource can go unused before it should be destroyed
+            idleTimeout: 3000,
+            // frequency to check for idle resources
+            reapInterval: 1000
+        }
     }
     ,mapnik_version: undefined
     ,mapnik_tile_format: 'png8:m=h'

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -118,7 +118,7 @@ var config = {
         user: "publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 6432
+        port: 5432
     }
     ,mapnik_version: undefined
     ,mapnik_tile_format: 'png8:m=h'
@@ -205,7 +205,7 @@ var config = {
               user: "publicuser",
               password: "public",
               host: '127.0.0.1',
-              port: 6432,
+              port: 5432,
               extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
               // max number of rows to return when querying data, 0 means no limit
               row_limit: 65535,

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -261,16 +261,7 @@ var config = {
               src: __dirname + '/../../assets/default-placeholder.png'
           }
       },
-      torque: {
-          dbPoolParams: {
-              // maximum number of resources to create at any given time
-              size: 16,
-              // max milliseconds a resource can go unused before it should be destroyed
-              idleTimeout: 3000,
-              // frequency to check for idle resources
-              reapInterval: 1000
-          }
-      }
+      torque: {}
     }
     // anything analyses related
     ,analysis: {

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -235,26 +235,6 @@ var config = {
               cacheOnTimeout: true
           },
 
-          geojson: {
-                dbPoolParams: {
-                      // maximum number of resources to create at any given time
-                      size: 16,
-                      // max milliseconds a resource can go unused before it should be destroyed
-                      idleTimeout: 3000,
-                      // frequency to check for idle resources
-                      reapInterval: 1000
-                },
-
-              // SQL queries will be wrapped with ST_ClipByBox2D
-              // Returning the portion of a geometry falling within a rectangle
-              // It will only work if snapToGrid is enabled
-              clipByBox2d: false, // this requires postgis >=2.2 and geos >=3.5
-              // geometries will be simplified using ST_RemoveRepeatedPoints
-              // which cost is no more expensive than snapping and results are
-              // much closer to the original geometry
-              removeRepeatedPoints: false // this requires postgis >=2.2
-          },
-
           // If enabled Mapnik will reuse the features retrieved from the database
           // instead of requesting them once per style inside a layer
           'cache-features': true,

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -137,15 +137,7 @@ var config = {
         //If enabled, MVTs will be generated with PostGIS directly, instead of using Mapnik,
         //PostGIS 2.4 is required for this to work
         //If disabled it will use Mapnik MVT generation
-        usePostGIS: false,
-        dbPoolParams: {
-              // maximum number of resources to create at any given time
-              size: 16,
-              // max milliseconds a resource can go unused before it should be destroyed
-              idleTimeout: 3000,
-              // frequency to check for idle resources
-              reapInterval: 1000
-          }
+        usePostGIS: false
       },
       mapnik: {
           // The size of the pool of internal mapnik backend
@@ -261,16 +253,7 @@ var config = {
               src: __dirname + '/../../assets/default-placeholder.png'
           }
       },
-      torque: {
-          dbPoolParams: {
-              // maximum number of resources to create at any given time
-              size: 16,
-              // max milliseconds a resource can go unused before it should be destroyed
-              idleTimeout: 3000,
-              // frequency to check for idle resources
-              reapInterval: 1000
-          }
-      }
+      torque: {}
     }
     // anything analyses related
     ,analysis: {

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -118,7 +118,15 @@ var config = {
         user: "publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 5432
+        port: 5432,
+        pool: {
+            // maximum number of resources to create at any given time
+            size: 16,
+            // max milliseconds a resource can go unused before it should be destroyed
+            idleTimeout: 3000,
+            // frequency to check for idle resources
+            reapInterval: 1000
+        }
     }
     ,mapnik_version: undefined
     ,mapnik_tile_format: 'png8:m=h'

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -115,26 +115,10 @@ var config = {
     // Supported labels: 'user_id', 'user_password' (both read from redis)
     ,postgres_auth_pass: '<%= user_password %>'
     ,postgres: {
-        // Parameters to pass to datasource plugin of mapnik
-        // See http://github.com/mapnik/mapnik/wiki/PostGIS
         user: "publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 6432,
-        extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
-        // max number of rows to return when querying data, 0 means no limit
-        row_limit: 65535,
-        simplify_geometries: true,
-        use_overviews: true, // use overviews to retrieve raster
-        /*
-         * Set persist_connection to false if you want
-         * database connections to be closed on renderer
-         * expiration (1 minute after last use).
-         * Setting to true (the default) would never
-         * close any connection for the server's lifetime
-         */
-        persist_connection: false,
-        max_size: 500
+        port: 6432
     }
     ,mapnik_version: undefined
     ,mapnik_tile_format: 'png8:m=h'
@@ -214,6 +198,29 @@ var config = {
           // Returning the portion of a geometry falling within a rectangle
           // It will only work if snapToGrid is enabled
           clipByBox2d: false, // this requires postgis >=2.2 and geos >=3.5
+
+          postgis: {
+              // Parameters to pass to datasource plugin of mapnik
+              // See http://github.com/mapnik/mapnik/wiki/PostGIS
+              user: "publicuser",
+              password: "public",
+              host: '127.0.0.1',
+              port: 6432,
+              extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
+              // max number of rows to return when querying data, 0 means no limit
+              row_limit: 65535,
+              /*
+               * Set persist_connection to false if you want
+               * database connections to be closed on renderer
+               * expiration (1 minute after last use).
+               * Setting to true (the default) would never
+               * close any connection for the server's lifetime
+               */
+               persist_connection: false,
+               simplify_geometries: true,
+               use_overviews: true, // use overviews to retrieve raster
+               max_size: 500
+          },
 
           limits: {
               // Time in milliseconds a render request can take before it fails, some notes:

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -235,26 +235,6 @@ var config = {
               cacheOnTimeout: true
           },
 
-          geojson: {
-                dbPoolParams: {
-                      // maximum number of resources to create at any given time
-                      size: 16,
-                      // max milliseconds a resource can go unused before it should be destroyed
-                      idleTimeout: 3000,
-                      // frequency to check for idle resources
-                      reapInterval: 1000
-                },
-
-              // SQL queries will be wrapped with ST_ClipByBox2D
-              // Returning the portion of a geometry falling within a rectangle
-              // It will only work if snapToGrid is enabled
-              clipByBox2d: false, // this requires postgis >=2.2 and geos >=3.5
-              // geometries will be simplified using ST_RemoveRepeatedPoints
-              // which cost is no more expensive than snapping and results are
-              // much closer to the original geometry
-              removeRepeatedPoints: false // this requires postgis >=2.2
-          },
-
           // If enabled Mapnik will reuse the features retrieved from the database
           // instead of requesting them once per style inside a layer
           'cache-features': true,

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -118,7 +118,7 @@ var config = {
         user: "publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 6432
+        port: 5432
     }
     ,mapnik_version: undefined
     ,mapnik_tile_format: 'png8:m=h'
@@ -197,7 +197,7 @@ var config = {
               user: "publicuser",
               password: "public",
               host: '127.0.0.1',
-              port: 6432,
+              port: 5432,
               extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
               // max number of rows to return when querying data, 0 means no limit
               row_limit: 65535,

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -119,21 +119,7 @@ var config = {
         user: "test_windshaft_publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 5432,
-        extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
-        // max number of rows to return when querying data, 0 means no limit
-        row_limit: 65535,
-        simplify_geometries: true,
-        use_overviews: true, // use overviews to retrieve raster
-        /*
-         * Set persist_connection to false if you want
-         * database connections to be closed on renderer
-         * expiration (1 minute after last use).
-         * Setting to true (the default) would never
-         * close any connection for the server's lifetime
-         */
-        persist_connection: false,
-        max_size: 500
+        port: 5432
     }
     ,mapnik_version: ''
     ,mapnik_tile_format: 'png8:m=h'
@@ -213,6 +199,29 @@ var config = {
           // Returning the portion of a geometry falling within a rectangle
           // It will only work if snapToGrid is enabled
           clipByBox2d: false, // this requires postgis >=2.2 and geos >=3.5
+
+          postgis: {
+              // Parameters to pass to datasource plugin of mapnik
+              // See http://github.com/mapnik/mapnik/wiki/PostGIS
+              user: "publicuser",
+              password: "public",
+              host: '127.0.0.1',
+              port: 5432,
+              extent: "-20037508.3,-20037508.3,20037508.3,20037508.3",
+              // max number of rows to return when querying data, 0 means no limit
+              row_limit: 65535,
+              /*
+               * Set persist_connection to false if you want
+               * database connections to be closed on renderer
+               * expiration (1 minute after last use).
+               * Setting to true (the default) would never
+               * close any connection for the server's lifetime
+               */
+               persist_connection: false,
+               simplify_geometries: true,
+               use_overviews: true, // use overviews to retrieve raster
+               max_size: 500
+          },
 
           limits: {
               // Time in milliseconds a render request can take before it fails, some notes:

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -250,16 +250,7 @@ var config = {
               src: __dirname + '/../../assets/default-placeholder.png'
           }
       },
-      torque: {
-          dbPoolParams: {
-              // maximum number of resources to create at any given time
-              size: 16,
-              // max milliseconds a resource can go unused before it should be destroyed
-              idleTimeout: 3000,
-              // frequency to check for idle resources
-              reapInterval: 1000
-          }
-      }
+      torque: {}
     }
     // anything analyses related
     ,analysis: {

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -119,7 +119,15 @@ var config = {
         user: "test_windshaft_publicuser",
         password: "public",
         host: '127.0.0.1',
-        port: 5432
+        port: 5432,
+        pool: {
+            // maximum number of resources to create at any given time
+            size: 16,
+            // max milliseconds a resource can go unused before it should be destroyed
+            idleTimeout: 3000,
+            // frequency to check for idle resources
+            reapInterval: 1000
+        }
     }
     ,mapnik_version: ''
     ,mapnik_tile_format: 'png8:m=h'

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -227,26 +227,6 @@ var config = {
               cacheOnTimeout: true
           },
 
-          geojson: {
-                dbPoolParams: {
-                      // maximum number of resources to create at any given time
-                      size: 16,
-                      // max milliseconds a resource can go unused before it should be destroyed
-                      idleTimeout: 3000,
-                      // frequency to check for idle resources
-                      reapInterval: 1000
-                },
-
-              // SQL queries will be wrapped with ST_ClipByBox2D
-              // Returning the portion of a geometry falling within a rectangle
-              // It will only work if snapToGrid is enabled
-              clipByBox2d: false, // this requires postgis >=2.2 and geos >=3.5
-              // geometries will be simplified using ST_RemoveRepeatedPoints
-              // which cost is no more expensive than snapping and results are
-              // much closer to the original geometry
-              removeRepeatedPoints: false // this requires postgis >=2.2
-          },
-
           // If enabled Mapnik will reuse the features retrieved from the database
           // instead of requesting them once per style inside a layer
           'cache-features': true,

--- a/lib/cartodb/api/api-router.js
+++ b/lib/cartodb/api/api-router.js
@@ -311,7 +311,8 @@ function createRendererFactory ({ redisPool, serverOptions, environmentOptions }
             mapnik: serverOptions.renderer.mapnik
         },
         http: serverOptions.renderer.http,
-        mvt: serverOptions.renderer.mvt
+        mvt: serverOptions.renderer.mvt,
+        torque: serverOptions.renderer.torque
     });
 
 

--- a/lib/cartodb/api/api-router.js
+++ b/lib/cartodb/api/api-router.js
@@ -315,6 +315,5 @@ function createRendererFactory ({ redisPool, serverOptions, environmentOptions }
         torque: serverOptions.renderer.torque
     });
 
-
     return rendererFactory;
 }

--- a/lib/cartodb/server_options.js
+++ b/lib/cartodb/server_options.js
@@ -127,7 +127,7 @@ module.exports = {
             // TODO: allow to specify in configuration
             srid: 3857
         },
-        datasource: rendererConfig.mapnik.postgis,
+        datasource: rendererConfig.mapnik.postgis || global.environment.postgres || {},
         cachedir: global.environment.millstone.cache_basedir,
         use_workers: rendererConfig.mapnik.useCartocssWorkers || false,
         mapnik_version: global.environment.mapnik_version,

--- a/lib/cartodb/server_options.js
+++ b/lib/cartodb/server_options.js
@@ -141,16 +141,7 @@ module.exports = {
     },
     renderer: {
         mvt: rendererConfig.mvt,
-        mapnik: _.defaults(rendererConfig.mapnik, {
-            geojson: {
-                dbPoolParams: {
-                    size: 16,
-                    idleTimeout: 3000,
-                    reapInterval: 1000
-                },
-                clipByBox2d: false
-            }
-        }),
+        mapnik: rendererConfig.mapnik,
         torque: rendererConfig.torque,
         http: rendererConfig.http
     },

--- a/lib/cartodb/server_options.js
+++ b/lib/cartodb/server_options.js
@@ -140,9 +140,9 @@ module.exports = {
         statsInterval: rendererConfig.statsInterval
     },
     renderer: {
-        mvt: rendererConfig.mvt,
+        mvt: Object.assign({ dbPoolParams: global.environment.postgres.pool }, rendererConfig.mvt),
         mapnik: rendererConfig.mapnik,
-        torque: rendererConfig.torque,
+        torque: Object.assign({ dbPoolParams: global.environment.postgres.pool }, rendererConfig.torque),
         http: rendererConfig.http
     },
 

--- a/lib/cartodb/server_options.js
+++ b/lib/cartodb/server_options.js
@@ -16,6 +16,15 @@ var rendererConfig = _.defaults(global.environment.renderer || {}, {
         snapToGrid: false,
         clipByBox2d: false,
         metrics: false,
+        postgis: {
+            simplify_geometries: false,
+            extent: '-20037508.3,-20037508.3,20037508.3,20037508.3',
+            row_limit: 65535,
+            persist_connection: false,
+            use_overviews: true,
+            max_size: 500,
+            twkb_encoding: true
+        },
         limits: {}
     },
     http: {}
@@ -118,7 +127,7 @@ module.exports = {
             // TODO: allow to specify in configuration
             srid: 3857
         },
-        datasource: global.environment.postgres,
+        datasource: rendererConfig.mapnik.postgis,
         cachedir: global.environment.millstone.cache_basedir,
         use_workers: rendererConfig.mapnik.useCartocssWorkers || false,
         mapnik_version: global.environment.mapnik_version,

--- a/test/acceptance/ported/server_gettile.js
+++ b/test/acceptance/ported/server_gettile.js
@@ -39,13 +39,13 @@ describe('server_gettile', function() {
     // --{
     ////////////////////////////////////////////////////////////////////
 
-    it("get'ing a tile with default style should return an expected tile", function(done){
+    it.only("get'ing a tile with default style should return an expected tile", function(done){
       testClient.getTile(testClient.defaultTableMapConfig('test_table'), 13, 4011, 3088,
           imageCompareFn('test_table_13_4011_3088.png', done)
       );
     });
 
-    it("response of get tile can be served by renderer cache",  function(done) {
+    it.only("response of get tile can be served by renderer cache",  function(done) {
         var tileUrl = '/13/4011/3088.png';
         var lastXwc;
         var mapConfig = testClient.defaultTableMapConfig('test_table');
@@ -60,7 +60,7 @@ describe('server_gettile', function() {
                     var xwc = res.headers['x-windshaft-cache'];
                     assert.ok(xwc);
                     assert.ok(xwc > 0);
-                    assert.ok(xwc >= lastXwc);
+                    assert.ok(xwc >= lastXwc, `xwc: ${xwc}, lastXwc: ${lastXwc}`);
 
                     requestTile(tileUrl, { cache_buster: 'wadus' }, function (err, res) {
                         var xwc = res.headers['x-windshaft-cache'];

--- a/test/acceptance/ported/server_gettile.js
+++ b/test/acceptance/ported/server_gettile.js
@@ -39,13 +39,13 @@ describe('server_gettile', function() {
     // --{
     ////////////////////////////////////////////////////////////////////
 
-    it.only("get'ing a tile with default style should return an expected tile", function(done){
+    it("get'ing a tile with default style should return an expected tile", function(done){
       testClient.getTile(testClient.defaultTableMapConfig('test_table'), 13, 4011, 3088,
           imageCompareFn('test_table_13_4011_3088.png', done)
       );
     });
 
-    it.only("response of get tile can be served by renderer cache",  function(done) {
+    it("response of get tile can be served by renderer cache",  function(done) {
         var tileUrl = '/13/4011/3088.png';
         var lastXwc;
         var mapConfig = testClient.defaultTableMapConfig('test_table');

--- a/test/acceptance/ported/server_gettile.js
+++ b/test/acceptance/ported/server_gettile.js
@@ -51,19 +51,19 @@ describe('server_gettile', function() {
         var mapConfig = testClient.defaultTableMapConfig('test_table');
         testClient.withLayergroup(mapConfig, function (err, requestTile, finish) {
             requestTile(tileUrl, function (err, res) {
-                var xwc = res.headers['x-windshaft-cache'];
+                var xwc = parseInt(res.headers['x-windshaft-cache'], 10);
                 assert.ok(xwc);
                 assert.ok(xwc > 0);
                 lastXwc = xwc;
 
                 requestTile(tileUrl, function (err, res) {
-                    var xwc = res.headers['x-windshaft-cache'];
+                    var xwc = parseInt(res.headers['x-windshaft-cache'], 10);
                     assert.ok(xwc);
                     assert.ok(xwc > 0);
-                    assert.ok(xwc >= lastXwc, `xwc: ${xwc}, lastXwc: ${lastXwc}`);
+                    assert.ok(xwc >= lastXwc);
 
                     requestTile(tileUrl, { cache_buster: 'wadus' }, function (err, res) {
-                        var xwc = res.headers['x-windshaft-cache'];
+                        var xwc = parseInt(res.headers['x-windshaft-cache'], 10);
                         assert.ok(!xwc);
 
                         finish(done);
@@ -103,7 +103,7 @@ describe('server_gettile', function() {
 
         testClient.withLayergroup(mapConfig, validateLayergroup, function(err, requestTile, finish) {
             requestTile(tileUrl, function(err, res) {
-                var xwc = res.headers['x-windshaft-cache'];
+                var xwc = parseInt(res.headers['x-windshaft-cache'], 10);
                 assert.ok(!xwc);
 
                 requestTile(tileUrl, function (err, res) {
@@ -111,7 +111,7 @@ describe('server_gettile', function() {
                         res.headers.hasOwnProperty('x-windshaft-cache'),
                         "Did not hit renderer cache on second time"
                     );
-                    assert.ok(res.headers['x-windshaft-cache'] >= 0);
+                    assert.ok(parseInt(res.headers['x-windshaft-cache'], 10) >= 0);
 
                     assert.imageBufferIsSimilarToFile(res.body, imageFixture, IMAGE_EQUALS_TOLERANCE_PER_MIL,
                         function(err) {


### PR DESCRIPTION
 - [x] Create a new general configuration entry for PostgreSQL pool.
 - [x] Move "postgres" attributes inside Mapnik's renderer configuration to make it clear where that belongs.
 - [x] Remove geojson renderer configuration
 - [x] Use same pool configuration to create windshaft's renderers