### PR TITLE
Update Windshaft, camshaft and cartodb-psql to use cartodb-psql 0.11.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,16 +5,17 @@ Released 2018-mm-dd
 
 New features:
 - CI tests with Ubuntu Xenial + PostgreSQL 10.1 and Ubuntu Precise + PostgreSQL 9.5
-- Upgrades Windshaft to [4.8.0](https://github.com/CartoDB/Windshaft/blob/4.8.0/NEWS.md#version-480) which includes:
+- Upgrades Windshaft to [4.8.1](https://github.com/CartoDB/Windshaft/blob/4.8.1/NEWS.md#version-481) which includes:
   - Update internal deps.
   - A fix in mapnik-vector-tile to avoid grouping together properties with the same value but a different type.
   - Performance improvements in the marker symbolizer (local cache, avoid building the collision matrix when possible).
   - MVT: Disable simplify_distance to avoid multiple simplifications.
   - Fix a bug with zero length lines not being rendered when using the marker symbolizer.
-- Upgrades Camshaft to [0.61.9](https://github.com/CartoDB/camshaft/releases/tag/0.61.9):
+- Upgrades Camshaft to [0.61.10](https://github.com/CartoDB/camshaft/releases/tag/0.61.10):
   - Use Dollar-Quoted String Constants to avoid Syntax Error while running moran analyses.
 - Update other deps:
   - body-parser: 1.18.3
+  - cartodb-psql: 0.11.0
   - dot: 1.1.2
   - express: 4.16.3
   - lru-cache: 4.1.3

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "basic-auth": "2.0.0",
     "body-parser": "1.18.3",
-    "camshaft": "0.61.9",
-    "cartodb-psql": "0.10.2",
+    "camshaft": "0.61.10",
+    "cartodb-psql": "0.11.0",
     "cartodb-query-tables": "0.3.0",
     "cartodb-redis": "1.0.0",
     "debug": "3.1.0",
@@ -48,7 +48,7 @@
     "step-profiler": "0.3.0",
     "turbo-carto": "0.20.2",
     "underscore": "1.6.0",
-    "windshaft": "4.8.0",
+    "windshaft": "4.8.1",
     "yargs": "11.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Related: https://github.com/CartoDB/camshaft/pull/363 and https://github.com/CartoDB/Windshaft/pull/625