### PR TITLE
Accept `layer` option in static map url request

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@ Bug Fixes:
 - Static maps fails for unsupported formats
 - Handling errors extracting the column type on dataviews
 - Fix `meta.stats.estimatedFeatureCount` for aggregations and queries with tokens
+- Static maps filters correctly if `layer` option is passed in the url.
 
 ## 6.1.0
 Released 2018-04-16

--- a/docs/static_maps_api.md
+++ b/docs/static_maps_api.md
@@ -11,7 +11,7 @@ Begin by instantiating either a Named or Anonymous Map using the `layergroupid t
 #### Definition
 
 ```bash
-GET /api/v1/map/static/center/{token}/{z}/{lat}/{lng}/{width}/{height}.{format}
+GET /api/v1/map/static/center/{token}/{z}/{lat}/{lng}/{width}/{height}.{format}{{?}extra_options}
 ```
 
 #### Params
@@ -57,6 +57,9 @@ Note: you can see this endpoint as
 ```bash
 GET /api/v1/map/static/bbox/{token}/{west},{south},{east},{north}/{width}/{height}.{format}`
 ```
+
+#### Extra options
+ * Layer: List of layers to be shown in the image (by default `all`), for example `?layer=0,1`.
 
 ### Named Map
 

--- a/lib/cartodb/api/middlewares/map-store-map-config-provider.js
+++ b/lib/cartodb/api/middlewares/map-store-map-config-provider.js
@@ -10,12 +10,13 @@ module.exports = function createMapStoreMapConfigProvider (
     return function createMapStoreMapConfigProviderMiddleware (req, res, next) {
         const { user, token, cache_buster, api_key } = res.locals;
         const { dbuser, dbname, dbpassword, dbhost, dbport } = res.locals;
-        const { layer, z, x, y, scale_factor, format } = req.params;
+        const { layer: layerFromParams, z, x, y, scale_factor, format } = req.params;
+        const { layer: layerFromQuery } = req.query;
 
         const params = {
             user, token, cache_buster, api_key,
             dbuser, dbname, dbpassword, dbhost, dbport,
-            layer, z, x, y, scale_factor, format
+            layer: (layerFromQuery || layerFromParams), z, x, y, scale_factor, format
         };
 
         if (forcedFormat) {

--- a/test/acceptance/analysis/named-maps.js
+++ b/test/acceptance/analysis/named-maps.js
@@ -261,6 +261,27 @@ describe('named-maps analysis', function() {
             );
         });
 
+        it('should fail to retrieve static map preview via layergroup ' +
+           'when filtering by invalid layers', function(done) {
+            assert.response(
+                server,
+                {
+                    url: '/api/v1/map/static/center/' + layergroupid + '/4/42/-3/320/240.png?layer=1',
+                    method: 'GET',
+                    encoding: 'binary',
+                    headers: {
+                        host: username
+                    }
+                },
+                {
+                    status: 400
+                },
+                function(res, err) {
+                    done(err);
+                }
+            );
+        });
+
         it('should return and an error requesting unsupported image format', function(done) {
             assert.response(
                 server,

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -1268,15 +1268,15 @@ TestClient.prototype.setUserDatabaseTimeoutLimit = function (timeoutLimit, callb
     const dbuser = _.template(global.environment.postgres_auth_user, { user_id: 1 });
     const publicuser = global.environment.postgres.user;
 
-    // we need to guarantee all new connections have the new settings
-    helper.cleanPGPoolConnections();
-
     const psql = new PSQL({
         user: 'postgres',
         dbname: dbname,
         host: global.environment.postgres.host,
         port: global.environment.postgres.port
     });
+
+    // we need to guarantee all new connections have the new settings
+    psql.end();
 
     step(
         function configureTimeouts () {

--- a/test/support/test_helper.js
+++ b/test/support/test_helper.js
@@ -13,7 +13,6 @@ var lzmaWorker = new LZMA();
 
 var redis = require('redis');
 var log4js = require('log4js');
-var pg = require('pg');
 const setICUEnvVariable = require('../../lib/cartodb/utils/icu_data_env_setter');
 
 // set environment specific variables
@@ -148,11 +147,6 @@ afterEach(function(done) {
     });
 });
 
-function cleanPGPoolConnections () {
-    // TODO: this method will be replaced by psql.end
-    pg.end();
-}
-
 function deleteRedisKeys(keysToDelete, callback) {
 
     if (Object.keys(keysToDelete).length === 0) {
@@ -215,6 +209,5 @@ module.exports = {
   checkSurrogateKey: checkSurrogateKey,
   checkCache: checkCache,
   rmdirRecursiveSync: rmdirRecursiveSync,
-  configureMetadata,
-  cleanPGPoolConnections
+  configureMetadata
 };


### PR DESCRIPTION
- Fixes https://github.com/CartoDB/cartodb/issues/13865 by accepting the `layer` in the url as done for the named maps.
- Increases the threshold for the static map image test.
- Removes direct usage of `node-postgres` in the tests and uses `cartodb-psql` instead. For me this fixes some failures the torque timeout tests.