### PR TITLE
Upgrades Camshaft to 0.61.11

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,9 @@ New features:
   - Performance improvements in the marker symbolizer (local cache, avoid building the collision matrix when possible).
   - MVT: Disable simplify_distance to avoid multiple simplifications.
   - Fix a bug with zero length lines not being rendered when using the marker symbolizer.
-- Upgrades Camshaft to [0.61.10](https://github.com/CartoDB/camshaft/releases/tag/0.61.10):
-  - Use Dollar-Quoted String Constants to avoid Syntax Error while running moran analyses.
+- Upgrades Camshaft to [0.61.11](https://github.com/CartoDB/camshaft/releases/tag/0.61.11):
+  - Use Dollar-Quoted String Constants to avoid Syntax Error while running moran analyses. [0.61.10](https://github.com/CartoDB/camshaft/releases/tag/0.61.10)
+  - Quote name columns when performing trade area analysis to avoid Syntax Errors. [0.61.11](https://github.com/CartoDB/camshaft/releases/tag/0.61.11) 
 - Update other deps:
   - body-parser: 1.18.3
   - cartodb-psql: 0.11.0

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@carto/fqdn-sync": "0.2.2",
     "basic-auth": "2.0.0",
     "body-parser": "1.18.3",
-    "camshaft": "0.61.10",
+    "camshaft": "0.61.11",
     "cartodb-psql": "0.11.0",
     "cartodb-query-tables": "0.3.0",
     "cartodb-redis": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,9 +265,9 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-camshaft@0.61.10:
-  version "0.61.10"
-  resolved "https://registry.yarnpkg.com/camshaft/-/camshaft-0.61.10.tgz#9055bbc577dbd87d38a0e712bf6157afd7704dca"
+camshaft@0.61.11:
+  version "0.61.11"
+  resolved "https://registry.yarnpkg.com/camshaft/-/camshaft-0.61.11.tgz#e6a5dd54b6c69c8933b133bfe8ef3ed6f090b1d0"
   dependencies:
     async "^1.5.2"
     bunyan "1.8.1"


### PR DESCRIPTION
Upgrades Camshaft to 0.61.11 to avoid Syntax Errors when performing trade area analysis with columns named with postgres reserved words