### PR TITLE
984 limits error messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,9 @@ Bug Fixes:
 - Fix `meta.stats.estimatedFeatureCount` for aggregations and queries with tokens
 - Static maps filters correctly if `layer` option is passed in the url.
 
+Announcements:
+  * Improve error message when the DB query is over the user's limits
+
 ## 6.1.0
 Released 2018-04-16
 

--- a/lib/cartodb/api/middlewares/error-middleware.js
+++ b/lib/cartodb/api/middlewares/error-middleware.js
@@ -46,28 +46,37 @@ function isDatasourceTimeoutError (err) {
     return err.message && err.message.match(/canceling statement due to statement timeout/i);
 }
 
-function isTimeoutError (err) {
-    return isRenderTimeoutError(err) || isDatasourceTimeoutError(err);
+function isTimeoutError (errorTypes) {
+    return errorTypes.renderTimeoutError || errorTypes.datasourceTimeoutError;
+}
+
+function getErrorTypes(error) {
+    return {
+        renderTimeoutError: isRenderTimeoutError(error),
+        datasourceTimeoutError: isDatasourceTimeoutError(error),
+    };
 }
 
 function populateTimeoutErrors (errors) {
     return errors.map(function (error) {
-        if (isRenderTimeoutError(error)) {
-            error.subtype = 'render';
-        }
+        const errorTypes = getErrorTypes(error);
 
-        const IS_DATASOURCE_TIMEOUT_ERROR = isDatasourceTimeoutError(error);
-
-        if (isTimeoutError(error)) {
+        if (isTimeoutError(errorTypes)) {
             error.message = 'You are over platform\'s limits. Please contact us to know more details';
             error.type = 'limit';
             error.http_status = 429;
         }
 
-        if (IS_DATASOURCE_TIMEOUT_ERROR) {
+        if (errorTypes.datasourceTimeoutError) {
             error.subtype = 'datasource';
             error.message = 'You are over platform\'s limits: SQL query timeout error.' +
                 ' Refactor your query before running again or contact CARTO support for more details.';
+        }
+
+        if (errorTypes.renderTimeoutError) {
+            error.subtype = 'render';
+            error.message = 'You are over platform\'s limits: Render timeout error.' +
+                ' Contact CARTO support for more details.';
         }
 
         return error;

--- a/lib/cartodb/api/middlewares/error-middleware.js
+++ b/lib/cartodb/api/middlewares/error-middleware.js
@@ -56,14 +56,16 @@ function populateTimeoutErrors (errors) {
             error.subtype = 'render';
         }
 
-        if (isDatasourceTimeoutError(error)) {
-            error.subtype = 'datasource';
-        }
-
         if (isTimeoutError(error)) {
             error.message = 'You are over platform\'s limits. Please contact us to know more details';
             error.type = 'limit';
             error.http_status = 429;
+        }
+
+        if (isDatasourceTimeoutError(error)) {
+            error.subtype = 'datasource';
+            error.message = 'You are over platform\'s limits: SQL query timeout error.' +
+                ' Refactor your query before running again or contact CARTO support for more details.';
         }
 
         return error;

--- a/lib/cartodb/api/middlewares/error-middleware.js
+++ b/lib/cartodb/api/middlewares/error-middleware.js
@@ -56,13 +56,15 @@ function populateTimeoutErrors (errors) {
             error.subtype = 'render';
         }
 
+        const IS_DATASOURCE_TIMEOUT_ERROR = isDatasourceTimeoutError(error);
+
         if (isTimeoutError(error)) {
             error.message = 'You are over platform\'s limits. Please contact us to know more details';
             error.type = 'limit';
             error.http_status = 429;
         }
 
-        if (isDatasourceTimeoutError(error)) {
+        if (IS_DATASOURCE_TIMEOUT_ERROR) {
             error.subtype = 'datasource';
             error.message = 'You are over platform\'s limits: SQL query timeout error.' +
                 ' Refactor your query before running again or contact CARTO support for more details.';

--- a/lib/cartodb/api/middlewares/rate-limit.js
+++ b/lib/cartodb/api/middlewares/rate-limit.js
@@ -47,7 +47,8 @@ function rateLimit(userLimitsBackend, endpointGroup = null) {
                 res.set('Retry-After', retry + 1);
 
                 let rateLimitError = new Error(
-                    'You are over platform\'s limits: too many requests. Please contact us to know more details'
+                    'You are over platform\'s limits: too many requests.' +
+                    ' Please contact us to know more details'
                 );
                 rateLimitError.http_status = 429;
                 rateLimitError.type = 'limit';

--- a/lib/cartodb/api/middlewares/rate-limit.js
+++ b/lib/cartodb/api/middlewares/rate-limit.js
@@ -47,7 +47,7 @@ function rateLimit(userLimitsBackend, endpointGroup = null) {
                 res.set('Retry-After', retry + 1);
 
                 let rateLimitError = new Error(
-                    'You are over platform\'s limits. Please contact us to know more details'
+                    'You are over platform\'s limits: too many requests. Please contact us to know more details'
                 );
                 rateLimitError.http_status = 429;
                 rateLimitError.type = 'limit';

--- a/test/acceptance/rate-limit.test.js
+++ b/test/acceptance/rate-limit.test.js
@@ -144,7 +144,7 @@ function assertRateLimitRequest (status, limit, remaining, reset, retry, done) {
             assert.ifError(err);
         } else {
             assert.ok(err);
-            assert.equal(err.message, 'You are over platform\'s limits. Please contact us to know more details');
+            assert.equal(err.message, 'You are over platform\'s limits: too many requests. Please contact us to know more details');
             assert.equal(err.http_status, 429);
             assert.equal(err.type, 'limit');
             assert.equal(err.subtype, 'rate-limit');

--- a/test/acceptance/rate-limit.test.js
+++ b/test/acceptance/rate-limit.test.js
@@ -144,7 +144,8 @@ function assertRateLimitRequest (status, limit, remaining, reset, retry, done) {
             assert.ifError(err);
         } else {
             assert.ok(err);
-            assert.equal(err.message, 'You are over platform\'s limits: too many requests. Please contact us to know more details');
+            assert.equal(err.message, 'You are over platform\'s limits: too many requests.' +
+                                      ' Please contact us to know more details');
             assert.equal(err.http_status, 429);
             assert.equal(err.type, 'limit');
             assert.equal(err.subtype, 'rate-limit');

--- a/test/acceptance/user-database-timeout-limit.js
+++ b/test/acceptance/user-database-timeout-limit.js
@@ -80,7 +80,7 @@ const DATASOURCE_TIMEOUT_ERROR = {
     }]
 };
 
-describe.only('user database timeout limit', function () {
+describe('user database timeout limit', function () {
     describe('dataview', function () {
         beforeEach(function (done) {
             const mapconfig = createMapConfig();

--- a/test/acceptance/user-database-timeout-limit.js
+++ b/test/acceptance/user-database-timeout-limit.js
@@ -68,16 +68,19 @@ const createMapConfig = ({
     }
 });
 
+const db_limit_error_message = 'You are over platform\'s limits: SQL query timeout error.' +
+    ' Refactor your query before running again or contact CARTO support for more details.';
+
 const DATASOURCE_TIMEOUT_ERROR = {
-    errors: ['You are over platform\'s limits. Please contact us to know more details'],
+    errors: [db_limit_error_message],
     errors_with_context: [{
         type: 'limit',
         subtype: 'datasource',
-        message: 'You are over platform\'s limits. Please contact us to know more details'
+        message: db_limit_error_message
     }]
 };
 
-describe('user database timeout limit', function () {
+describe.only('user database timeout limit', function () {
     describe('dataview', function () {
         beforeEach(function (done) {
             const mapconfig = createMapConfig();
@@ -141,11 +144,11 @@ describe('user database timeout limit', function () {
 
                 this.testClient.getLayergroup({ response: expectedResponse }, (err, timeoutError) => {
                     assert.deepEqual(timeoutError, {
-                        errors: [ 'You are over platform\'s limits. Please contact us to know more details' ],
+                        errors: [db_limit_error_message ],
                         errors_with_context: [{
                             type: 'limit',
                             subtype: 'datasource',
-                            message: 'You are over platform\'s limits. Please contact us to know more details',
+                            message: db_limit_error_message,
                             layer: { id: 'layer0', index: 0, type: 'mapnik' }
                         }]
                     });
@@ -363,11 +366,11 @@ describe('user database timeout limit', function () {
 
                 this.testClient.getLayergroup({ response: expectedResponse }, (err, timeoutError) => {
                     assert.deepEqual(timeoutError, {
-                        errors: [ 'You are over platform\'s limits. Please contact us to know more details' ],
+                        errors: [ db_limit_error_message ],
                         errors_with_context: [{
                             type: 'limit',
                             subtype: 'datasource',
-                            message: 'You are over platform\'s limits. Please contact us to know more details',
+                            message: db_limit_error_message,
                             layer: { id: 'layer0', index: 0, type: 'mapnik' }
                         }]
                     });
@@ -541,11 +544,11 @@ describe('user database timeout limit', function () {
 
                 this.testClient.getLayergroup({ response: expectedResponse }, (err, timeoutError) => {
                     assert.deepEqual(timeoutError, {
-                        errors: [ 'You are over platform\'s limits. Please contact us to know more details' ],
+                        errors: [ db_limit_error_message ],
                         errors_with_context: [{
                             type: 'limit',
                             subtype: 'datasource',
-                            message: 'You are over platform\'s limits. Please contact us to know more details',
+                            message: db_limit_error_message,
                             layer: { id: 'layer0', index: 0, type: 'mapnik' }
                         }]
                     });
@@ -645,11 +648,11 @@ describe('user database timeout limit', function () {
 
                 this.testClient.getLayergroup({ response: expectedResponse }, (err, timeoutError) => {
                     assert.deepEqual(timeoutError, {
-                        errors: [ 'You are over platform\'s limits. Please contact us to know more details' ],
+                        errors: [db_limit_error_message],
                         errors_with_context: [{
                             type: 'limit',
                             subtype: 'datasource',
-                            message: 'You are over platform\'s limits. Please contact us to know more details',
+                            message: db_limit_error_message,
                             layer: { id: 'torque-layer0', index: 0, type: 'torque' }
                         }]
                     });
@@ -776,11 +779,11 @@ describe('user database timeout limit', function () {
 
                 this.testClient.getLayergroup({ response: expectedResponse }, (err, timeoutError) => {
                     assert.deepEqual(timeoutError, {
-                        errors: [ 'You are over platform\'s limits. Please contact us to know more details' ],
+                        errors: [db_limit_error_message],
                         errors_with_context: [{
                             type: 'limit',
                             subtype: 'datasource',
-                            message: 'You are over platform\'s limits. Please contact us to know more details',
+                            message: db_limit_error_message,
                             layer: {
                                 id: 'layer0',
                                 index: 0,

--- a/test/acceptance/user-render-timeout-limit.js
+++ b/test/acceptance/user-render-timeout-limit.js
@@ -23,6 +23,9 @@ const validationPointSleepSql = `
         2 val
 `;
 
+const renderTimeoutErrorMessage = 'You are over platform\'s limits: Render timeout error.' +
+    ' Contact CARTO support for more details.';
+
 const createMapConfig = ({
     version = '1.6.0',
     type = 'cartodb',
@@ -96,11 +99,11 @@ describe('user render timeout limit', function () {
                 assert.ifError(err);
 
                 assert.deepEqual(timeoutError, {
-                    errors: ["You are over platform\'s limits. Please contact us to know more details"],
+                    errors: [renderTimeoutErrorMessage],
                     errors_with_context: [{
                         type: 'limit',
                         subtype: 'render',
-                        message: "You are over platform\'s limits. Please contact us to know more details",
+                        message: renderTimeoutErrorMessage,
                         layer: {
                             id: "layer0",
                             index: 0,
@@ -188,11 +191,11 @@ describe('user render timeout limit', function () {
                     assert.ifError(err);
 
                     assert.deepEqual(timeoutError, {
-                        errors: ["You are over platform\'s limits. Please contact us to know more details"],
+                        errors: [renderTimeoutErrorMessage],
                         errors_with_context: [{
                             type: 'limit',
                             subtype: 'render',
-                            message: "You are over platform\'s limits. Please contact us to know more details"
+                            message: renderTimeoutErrorMessage
                         }]
                     });
 
@@ -282,11 +285,11 @@ describe('user render timeout limit', function () {
                 assert.ifError(err);
 
                 assert.deepEqual(tile, {
-                    errors: ['You are over platform\'s limits. Please contact us to know more details'],
+                    errors: [renderTimeoutErrorMessage],
                     errors_with_context: [{
                         type: 'limit',
                         subtype: 'render',
-                        message: 'You are over platform\'s limits. Please contact us to know more details'
+                        message: renderTimeoutErrorMessage
                     }]
                 });
 
@@ -384,11 +387,11 @@ describe('user render timeout limit', function () {
                     assert.ifError(err);
 
                     assert.deepEqual(timeoutError, {
-                        errors: ["You are over platform\'s limits. Please contact us to know more details"],
+                        errors: [renderTimeoutErrorMessage],
                         errors_with_context: [{
                             type: 'limit',
                             subtype: 'render',
-                            message: "You are over platform\'s limits. Please contact us to know more details"
+                            message: renderTimeoutErrorMessage
                         }]
                     });
 


### PR DESCRIPTION
closes #984

When a DB timeout error arises caused by our `limits system`, the user should be aware of the actual error reason. Currently, the API responses with a cryptic 429 http error:

```json
{
    "error": [
        "You are over platform's limits. Please contact us to know more details."
    ],
    "context": "limit",
    "detail": "datasource"
}
```

This PR rephrases the error message, taking care not to break `carto.js` error handling.

```json
{
    "error": [
        "You are over platform's limits: SQL query timeout error. Refactor your query before running again or contact CARTO support for more details."
    ],
    "type": "limit",
    "subtype": "datasource"
}
```
