### PR TITLE
Fix numeric histogram bounds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@ Bug Fixes:
 - Static maps fails for unsupported formats
 - Handling errors extracting the column type on dataviews
 - Fix `meta.stats.estimatedFeatureCount` for aggregations and queries with tokens
+- Fix numeric histogram bounds when `start` and `end` are specified (#991)
 - Static maps filters correctly if `layer` option is passed in the url.
 
 Announcements:

--- a/lib/cartodb/models/dataview/histograms/numeric-histogram.js
+++ b/lib/cartodb/models/dataview/histograms/numeric-histogram.js
@@ -99,6 +99,7 @@ module.exports = class NumericHistogram extends BaseHistogram {
         var extra_tables = ``;
         var extra_queries = ``;
         var extra_groupby = ``;
+        var extra_filter = ``;
 
         if (ctx.start >= ctx.end) {
             ctx.end = `__cdb_basics.__cdb_max_val`;
@@ -106,6 +107,8 @@ module.exports = class NumericHistogram extends BaseHistogram {
             extra_groupby = `, __cdb_basics.__cdb_max_val, __cdb_basics.__cdb_min_val`;
             extra_tables = `, __cdb_basics`;
             extra_queries = `WITH ${irqQueryTpl(ctx)}`;
+        } else {
+            extra_filter = `WHERE ${ctx.column} >= ${ctx.start} AND ${ctx.column} <= ${ctx.end}`;
         }
 
         if (ctx.bins <= 0) {
@@ -135,7 +138,7 @@ SELECT
     END AS bin
 FROM
 (
-    SELECT * FROM (${ctx.query}) __ctx_query WHERE ${ctx.column} >= ${ctx.start} AND  ${ctx.column} <= ${ctx.end}
+    SELECT * FROM (${ctx.query}) __ctx_query${extra_tables} ${extra_filter}
 ) __cdb_filtered_source_query${extra_tables}
 GROUP BY 10${extra_groupby}
 ORDER BY 10;`;

--- a/lib/cartodb/models/dataview/histograms/numeric-histogram.js
+++ b/lib/cartodb/models/dataview/histograms/numeric-histogram.js
@@ -135,7 +135,7 @@ SELECT
     END AS bin
 FROM
 (
-    ${ctx.query}
+    SELECT * FROM (${ctx.query}) __ctx_query WHERE ${ctx.column} >= ${ctx.start} AND  ${ctx.column} <= ${ctx.end}
 ) __cdb_filtered_source_query${extra_tables}
 GROUP BY 10${extra_groupby}
 ORDER BY 10;`;

--- a/lib/cartodb/models/dataview/histograms/numeric-histogram.js
+++ b/lib/cartodb/models/dataview/histograms/numeric-histogram.js
@@ -101,14 +101,17 @@ module.exports = class NumericHistogram extends BaseHistogram {
         var extra_groupby = ``;
         var extra_filter = ``;
 
-        if (ctx.start >= ctx.end) {
+        if (ctx.start < ctx.end) {
+            extra_filter = `
+              WHERE __ctx_query.${ctx.column} >= ${ctx.start}
+                AND __ctx_query.${ctx.column} <= ${ctx.end}
+            `;
+        } else {
             ctx.end = `__cdb_basics.__cdb_max_val`;
             ctx.start = `__cdb_basics.__cdb_min_val`;
             extra_groupby = `, __cdb_basics.__cdb_max_val, __cdb_basics.__cdb_min_val`;
             extra_tables = `, __cdb_basics`;
             extra_queries = `WITH ${irqQueryTpl(ctx)}`;
-        } else {
-            extra_filter = `WHERE ${ctx.column} >= ${ctx.start} AND ${ctx.column} <= ${ctx.end}`;
         }
 
         if (ctx.bins <= 0) {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 OPT_CREATE_REDIS=yes # create the redis test environment
 OPT_CREATE_PGSQL=yes # create the PostgreSQL test environment

--- a/test/acceptance/dataviews/histogram.js
+++ b/test/acceptance/dataviews/histogram.js
@@ -67,6 +67,27 @@ describe('histogram-dataview', function() {
         ]
     );
 
+    it('should get bins with min >= start and max <= end', function(done) {
+        var params = {
+            bins: 3,
+            start: 50,
+            end: 500
+        };
+
+        this.testClient = new TestClient(mapConfig, 1234);
+        this.testClient.getDataview('pop_max_histogram', params, function(err, dataview) {
+            assert.ok(!err, err);
+
+            assert.ok(3 === dataview.bins_count, 'Unexpected bin count: ' + dataview.bins_count);
+            assert.ok(3 === dataview.bins.length, 'Unexpected number of bins: ' + dataview.bins.length);
+            dataview.bins.forEach(function(bin) {
+                assert.ok(bin.min >= params.start, 'bin min < start: ' + JSON.stringify(bin));
+                assert.ok(bin.max <= params.end, 'bin max > end: ' + JSON.stringify(bin));
+            });
+            done();
+        });
+    });
+
     it('should get bin_width right when max > min in filter', function(done) {
         var params = {
             bins: 10,


### PR DESCRIPTION
This fixes https://github.com/CartoDB/Windshaft/issues/634

Asking for a review to get early feedback.

Note that I leave the case "`start` is defined and `end` is not" (and the reverse) as undefined behavior.