### PR TITLE
Fix some rate limit tests

### DIFF
--- a/test/acceptance/rate-limit.test.js
+++ b/test/acceptance/rate-limit.test.js
@@ -160,7 +160,9 @@ function assertRateLimitRequest (status, limit, remaining, reset, retry, done) {
 describe('rate limit', function() {
     before(function() {
         global.environment.enabledFeatures.rateLimitsEnabled = true;
-        global.environment.enabledFeatures.rateLimitsByEndpoint.anonymous = true;
+        global.environment.enabledFeatures.rateLimitsByEndpoint = {
+            anonymous: true
+        };
 
         redisClient = redis.createClient(global.environment.redis.port);
         testClient = new TestClient(createMapConfig(), 1234);


### PR DESCRIPTION
`rateLimitsByEndpoint` is defined in the test config, but usually
there's no guarantee it is defined in the development config. This makes
the tests more robust.