### PR TITLE
Use new version of turbo-carto 0.20.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ New features:
   - request: 2.87.0
   - semver: 5.5.0
   - step: 1.0.0
+  - turbo-carto: 0.20.3
   - yargs: 11.1.0
 - Update devel deps:
   - istanbul: 0.4.5

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "5.5.0",
     "step": "1.0.0",
     "step-profiler": "0.3.0",
-    "turbo-carto": "github:cartodb/turbo-carto#buckets-calc",
+    "turbo-carto": "0.2.30",
     "underscore": "1.6.0",
     "windshaft": "4.8.1",
     "yargs": "11.1.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "5.5.0",
     "step": "1.0.0",
     "step-profiler": "0.3.0",
-    "turbo-carto": "0.20.2",
+    "turbo-carto": "github:cartodb/turbo-carto#buckets-calc",
     "underscore": "1.6.0",
     "windshaft": "4.8.1",
     "yargs": "11.1.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "5.5.0",
     "step": "1.0.0",
     "step-profiler": "0.3.0",
-    "turbo-carto": "0.2.30",
+    "turbo-carto": "0.20.3",
     "underscore": "1.6.0",
     "windshaft": "4.8.1",
     "yargs": "11.1.0"

--- a/test/acceptance/turbo-carto/regressions.js
+++ b/test/acceptance/turbo-carto/regressions.js
@@ -380,4 +380,123 @@ describe('turbo-carto regressions', function() {
         });
     });
 
+    describe.only('Buckets calculation', function () {
+        afterEach(function (done) {
+            if (this.testClient) {
+                this.testClient.drain(done);
+            } else {
+                done();
+            }
+        });
+
+        const scenarios = [
+            {
+                numBuckets: 1,
+                bucketResponse: [
+                    {
+                        filter: {
+                            type: 'range',
+                            start: 0,
+                            end: 8
+                        },
+                        value: 1
+                    }
+                ],
+            },
+            {
+                numBuckets: 2,
+                bucketResponse: [
+                    {
+                        filter: {
+                            type: 'range',
+                            start: 0,
+                            end: 3
+                        },
+                        value: 1
+                    },
+                    {
+                        filter: {
+                            type: 'range',
+                            start: 3,
+                            end: 8
+                        },
+                        value: 20
+                    }
+                ],
+            },
+            {
+                numBuckets: 3,
+                bucketResponse: [
+                    {
+                        filter: {
+                            type: 'range',
+                            start: 0,
+                            end: 2
+                        },
+                        value: 1
+                    },
+                    {
+                        filter: {
+                            type: 'range',
+                            start: 2,
+                            end: 5
+                        },
+                        value: 10.5
+                    },
+                    {
+                        filter: {
+                            type: 'range',
+                            start: 5,
+                            end: 8
+                        },
+                        value: 20
+                    }
+                ],
+            },
+        ];
+
+        scenarios.forEach(function (scenario) {
+            it('Buckets: ' + scenario.numBuckets, function (done) {
+                const bucketsMapConfig = makeMapconfig({ numQuantiles: scenario.numBuckets });
+
+                this.testClient = new TestClient(bucketsMapConfig);
+                this.testClient.getLayergroup({ response: OK_RESPONSE }, function (err, layergroup) {
+                    const rule = layergroup.metadata.layers[0].meta.cartocss_meta.rules[0];
+
+                    assert.ok(!err, err);
+                    assert.equal(rule.buckets.length, scenario.numBuckets);
+                    assert.deepEqual(rule.buckets, scenario.bucketResponse);
+
+                    done();
+                });
+            });
+        });        
+
+        function makeMapconfig({numQuantiles = 1}) {
+            return {
+                "version": "1.4.0",
+                "layers": [
+                    {
+                        "type": 'mapnik',
+                        "options": {
+                            "cartocss_version": '2.3.0',
+                            "sql": 'SELECT * FROM populated_places_simple_reduced',
+                            "cartocss": `#layer {\n  
+                                        marker-width: ramp([labelrank], range(1, 20), quantiles(${numQuantiles}));\n  
+                                        marker-fill: #EE4D5A;\n  marker-fill-opacity: 0.9;\n  
+                                        marker-allow-overlap: true;\n  marker-line-width: 1;\n  
+                                        marker-line-color: #FFFFFF;\n  marker-line-opacity: 1;\n}`,
+                        }
+                    }
+                ]
+            };
+        }
+
+        const OK_RESPONSE = {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8'
+            }
+        };
+    });
 });

--- a/test/acceptance/turbo-carto/regressions.js
+++ b/test/acceptance/turbo-carto/regressions.js
@@ -380,7 +380,7 @@ describe('turbo-carto regressions', function() {
         });
     });
 
-    describe.only('Buckets calculation', function () {
+    describe('Buckets calculation', function () {
         afterEach(function (done) {
             if (this.testClient) {
                 this.testClient.drain(done);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     node-pre-gyp "0.10.0"
     protozero "1.5.1"
 
-"@carto/tilelive-bridge@github:cartodb/tilelive-bridge#2.5.1-cdb9":
+"@carto/tilelive-bridge@cartodb/tilelive-bridge#2.5.1-cdb9":
   version "2.5.1-cdb9"
   resolved "https://codeload.github.com/cartodb/tilelive-bridge/tar.gz/5129e43223cb55daed31373c7a36c98eb6178fc1"
   dependencies:
@@ -27,7 +27,7 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz#70237b9774095ed1cfdbcea7a8fd1fc82b2691f2"
 
-"abaculus@github:cartodb/abaculus#2.0.3-cdb10":
+abaculus@cartodb/abaculus#2.0.3-cdb10:
   version "2.0.3-cdb10"
   resolved "https://codeload.github.com/cartodb/abaculus/tar.gz/90d537028bb8af8a35e7a40c46493066dd8a76b3"
   dependencies:
@@ -35,11 +35,7 @@
     d3-queue "^2.0.2"
     sphericalmercator "1.0.x"
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-
-abbrev@1.0.x:
+abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
@@ -280,7 +276,7 @@ camshaft@0.61.11:
     dot "^1.0.3"
     request "2.85.0"
 
-"canvas@github:cartodb/node-canvas#1.6.2-cdb2":
+canvas@cartodb/node-canvas#1.6.2-cdb2:
   version "1.6.2-cdb2"
   resolved "https://codeload.github.com/cartodb/node-canvas/tar.gz/8acf04557005c633f9e68524488a2657c04f3766"
   dependencies:
@@ -298,7 +294,7 @@ carto@0.16.3:
     semver "^5.1.0"
     yargs "^4.2.0"
 
-"carto@github:cartodb/carto#0.15.1-cdb3":
+carto@cartodb/carto#0.15.1-cdb3:
   version "0.15.1-cdb3"
   resolved "https://codeload.github.com/cartodb/carto/tar.gz/945f5efb74fd1af1f5e1f69f409f9567f94fb5a7"
   dependencies:
@@ -306,7 +302,7 @@ carto@0.16.3:
     optimist "~0.6.0"
     underscore "1.8.3"
 
-"carto@github:cartodb/carto#master":
+carto@cartodb/carto#master:
   version "0.15.1"
   resolved "https://codeload.github.com/cartodb/carto/tar.gz/31abb8bee02df605521247b0223d508320f7d4c8"
   dependencies:
@@ -757,13 +753,9 @@ extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-extsprintf@1.3.0:
+extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-
-extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
@@ -1437,7 +1429,7 @@ mapnik-reference@~8.5.3:
   dependencies:
     semver "^5.1.0"
 
-"mapnik-vector-tile@github:cartodb/mapnik-vector-tile#v1.6.1-carto.1":
+mapnik-vector-tile@cartodb/mapnik-vector-tile#v1.6.1-carto.1:
   version "1.6.1-carto.1"
   resolved "https://codeload.github.com/cartodb/mapnik-vector-tile/tar.gz/0111f7117946179d62ec7a6eba2f4e9fb355d05e"
 
@@ -1506,17 +1498,13 @@ mimic-fn@^1.0.0:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 minimist@~0.2.0:
   version "0.2.0"
@@ -1558,13 +1546,9 @@ mocha@3.5.3:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
-moment@2.22.1:
+moment@2.22.1, moment@^2.10.6:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
-
-moment@^2.10.6:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 ms@0.7.1:
   version "0.7.1"
@@ -1895,7 +1879,7 @@ pg-types@1.*:
     postgres-date "~1.0.0"
     postgres-interval "^1.1.0"
 
-"pg@github:CartoDB/node-postgres#6.4.2-cdb1":
+pg@CartoDB/node-postgres#6.4.2-cdb1:
   version "6.4.2"
   resolved "https://codeload.github.com/CartoDB/node-postgres/tar.gz/449fac1d6da711ffcc6694ae3c89f85244f48bdc"
   dependencies:
@@ -2084,7 +2068,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@1.1:
+readable-stream@1.1, readable-stream@~1.1.9:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"
   dependencies:
@@ -2108,15 +2092,6 @@ readable-stream@^2.0.6, readable-stream@^2.1.4:
 readable-stream@~1.0.2:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -2261,11 +2236,11 @@ rimraf@~2.4.0:
   dependencies:
     glob "^6.0.1"
 
-safe-buffer@5.1.1:
+safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -2458,11 +2433,7 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
-
-statuses@~1.4.0:
+"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2", statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
@@ -2603,7 +2574,7 @@ through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-"tilelive-mapnik@github:cartodb/tilelive-mapnik#0.6.18-cdb14":
+tilelive-mapnik@cartodb/tilelive-mapnik#0.6.18-cdb14:
   version "0.6.18-cdb14"
   resolved "https://codeload.github.com/cartodb/tilelive-mapnik/tar.gz/6d06f728833d3e34d1adcd05567b3f4379f547bb"
   dependencies:
@@ -2654,9 +2625,9 @@ turbo-carto@0.19.0:
     postcss "5.0.19"
     postcss-value-parser "3.3.0"
 
-turbo-carto@0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/turbo-carto/-/turbo-carto-0.20.2.tgz#2b737597a65c2918432f70ea414f12fbec2b6a6f"
+turbo-carto@CartoDB/turbo-carto#buckets-calc:
+  version "0.20.3"
+  resolved "https://codeload.github.com/CartoDB/turbo-carto/tar.gz/c7800628361f3c9bacf27296ebd4cfe283979d79"
   dependencies:
     cartocolor "4.0.0"
     colorbrewer "1.0.0"


### PR DESCRIPTION
In order to fix _Bubble legends with 2 buckets are wrongly rendered_ (https://github.com/CartoDB/cartodb/issues/14075) we need to use the new version of `turbo-carto` 0.20.3 (https://github.com/CartoDB/turbo-carto/pull/79#discussion_r200592129)