### PR TITLE
Adapt tests for more accurate PROJ

### DIFF
--- a/test/acceptance/aggregation.js
+++ b/test/acceptance/aggregation.js
@@ -113,9 +113,9 @@ describe('aggregation', function () {
     -- Generate pairs of near points
     select
         x + 7 as cartodb_id,
-        st_setsrid(st_makepoint(Floor(x/2)*10 + 9E-3*(x % 2), Floor(x/2)*10 + 9E-3*(x % 2)), 4326) as the_geom,
+        st_setsrid(st_makepoint(Floor(x/2)*10 + 9E-3*(x % 2 + 1), Floor(x/2)*10 + 9E-3*(x % 2 + 1)), 4326) as the_geom,
         st_transform(
-            st_setsrid(st_makepoint(Floor(x/2)*10 + 9E-3*(x % 2), Floor(x/2)*10 + 9E-3*(x % 2)),4326),
+            st_setsrid(st_makepoint(Floor(x/2)*10 + 9E-3*(x % 2 + 1), Floor(x/2)*10 + 9E-3*(x % 2 + 1)),4326),
             3857) as the_geom_webmercator,
         x as value
     from generate_series(-6, 6) x
@@ -2384,7 +2384,7 @@ describe('aggregation', function () {
                         assert.equal(typeof body.metadata, 'object');
                         assert.ok(Array.isArray(body.metadata.layers));
                         assert.ok(body.metadata.layers[0].meta.aggregation.mvt);
-                        assert.equal(body.metadata.layers[0].meta.stats.aggrFeatureCount, 9);
+                        assert.equal(body.metadata.layers[0].meta.stats.aggrFeatureCount, 8);
 
                         done();
                     });

--- a/test/acceptance/aggregation.js
+++ b/test/acceptance/aggregation.js
@@ -113,10 +113,23 @@ describe('aggregation', function () {
     -- Generate pairs of near points
     select
         x + 1 as cartodb_id,
-        st_setsrid(st_makepoint(Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1), Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1)), 4326) as the_geom,
+        st_setsrid(
+            st_makepoint(
+                Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1),
+                Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1)
+            ),
+            4326
+        ) as the_geom,
         st_transform(
-            st_setsrid(st_makepoint(Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1), Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1)),4326),
-            3857) as the_geom_webmercator,
+            st_setsrid(
+                st_makepoint(
+                    Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1),
+                    Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1)
+                ),
+                4326
+            ),
+            3857
+        ) as the_geom_webmercator,
         x as value
     from generate_series(0, 13) x
     `;
@@ -2425,7 +2438,7 @@ describe('aggregation', function () {
                         assert.equal(typeof body.metadata, 'object');
                         assert.ok(Array.isArray(body.metadata.layers));
                         assert.ok(body.metadata.layers[0].meta.aggregation.mvt);
-                        assert.equal(body.metadata.layers[0].meta.stats.featureCount, 13);
+                        assert.equal(body.metadata.layers[0].meta.stats.featureCount, 14);
 
                         done();
                     });

--- a/test/acceptance/aggregation.js
+++ b/test/acceptance/aggregation.js
@@ -2139,138 +2139,134 @@ describe('aggregation', function () {
             });
 
             ['default', 'centroid', 'point-sample', 'point-grid'].forEach(placement => {
-                // describe('without points between tiles', function () {
-                    it(`aggregated ids are unique for ${placement} aggregation`, function (done) {
-                        this.mapConfig = {
-                            version: '1.6.0',
-                            buffersize: { 'mvt': 0 },
-                            layers: [
-                                {
-                                    type: 'cartodb',
+                it(`for ${placement} and no points between tiles has unique ids`, function (done) {
+                    this.mapConfig = {
+                        version: '1.6.0',
+                        buffersize: { 'mvt': 0 },
+                        layers: [
+                            {
+                                type: 'cartodb',
 
-                                    options: {
-                                        sql: POINTS_SQL_0,
-                                        resolution: 1,
-                                        aggregation: {
-                                            threshold: 1
-                                        }
+                                options: {
+                                    sql: POINTS_SQL_0,
+                                    resolution: 1,
+                                    aggregation: {
+                                        threshold: 1
                                     }
                                 }
-                            ]
-                        };
-                        if (placement !== 'default') {
-                            this.mapConfig.layers[0].options.aggregation.placement = placement;
+                            }
+                        ]
+                    };
+                    if (placement !== 'default') {
+                        this.mapConfig.layers[0].options.aggregation.placement = placement;
+                    }
+
+                    this.testClient = new TestClient(this.mapConfig);
+
+                    this.testClient.getTile(1, 0, 1, { format: 'mvt' },  (err, res, mvt) => {
+                        if (err) {
+                            return done(err);
                         }
 
-                        this.testClient = new TestClient(this.mapConfig);
+                        const tile1 = JSON.parse(mvt.toGeoJSONSync(0));
 
-                        this.testClient.getTile(1, 0, 1, { format: 'mvt' },  (err, res, mvt) => {
+                        assert.ok(Array.isArray(tile1.features));
+                        assert.ok(tile1.features.length > 0);
+
+                        this.testClient.getTile(1, 1, 0, { format: 'mvt' }, (err, res, mvt) =>  {
                             if (err) {
                                 return done(err);
                             }
 
-                            const tile1 = JSON.parse(mvt.toGeoJSONSync(0));
+                            const tile2 = JSON.parse(mvt.toGeoJSONSync(0));
 
-                            assert.ok(Array.isArray(tile1.features));
-                            assert.ok(tile1.features.length > 0);
+                            assert.ok(Array.isArray(tile2.features));
+                            assert.ok(tile2.features.length > 0);
 
-                            this.testClient.getTile(1, 1, 0, { format: 'mvt' }, (err, res, mvt) =>  {
-                                if (err) {
-                                    return done(err);
-                                }
+                            const tile1Ids = tile1.features.map(f => f.properties.cartodb_id);
+                            const tile2Ids = tile2.features.map(f => f.properties.cartodb_id);
+                            const repeatedIds = tile1Ids.filter(id => tile2Ids.includes(id));
 
-                                const tile2 = JSON.parse(mvt.toGeoJSONSync(0));
+                            assert.equal(repeatedIds.length, 0);
 
-                                assert.ok(Array.isArray(tile2.features));
-                                assert.ok(tile2.features.length > 0);
-
-                                const tile1Ids = tile1.features.map(f => f.properties.cartodb_id);
-                                const tile2Ids = tile2.features.map(f => f.properties.cartodb_id);
-                                const repeatedIds = tile1Ids.filter(id => tile2Ids.includes(id));
-
-                                assert.equal(repeatedIds.length, 0);
-
-                                done();
-                            });
-
+                            done();
                         });
-                    });
-                // });
-                // describe('with points between tiles', function () {
-                    it(`aggregated ids are unique for ${placement} aggregation save for points between tiles`, function (done) {
-                        this.mapConfig = {
-                            version: '1.6.0',
-                            buffersize: { 'mvt': 0 },
-                            layers: [
-                                {
-                                    type: 'cartodb',
 
-                                    options: {
-                                        sql: POINTS_SQL_1,
-                                        resolution: 1,
-                                        aggregation: {
-                                            threshold: 1
-                                        }
+                    });
+                });
+                it(`for ${placement} has unique ids save between tiles`, function (done) {
+                    this.mapConfig = {
+                        version: '1.6.0',
+                        buffersize: { 'mvt': 0 },
+                        layers: [
+                            {
+                                type: 'cartodb',
+
+                                options: {
+                                    sql: POINTS_SQL_1,
+                                    resolution: 1,
+                                    aggregation: {
+                                        threshold: 1
                                     }
                                 }
-                            ]
-                        };
-                        if (placement !== 'default') {
-                            this.mapConfig.layers[0].options.aggregation.placement = placement;
+                            }
+                        ]
+                    };
+                    if (placement !== 'default') {
+                        this.mapConfig.layers[0].options.aggregation.placement = placement;
+                    }
+
+                    this.testClient = new TestClient(this.mapConfig);
+
+                    this.testClient.getTile(1, 0, 1, { format: 'mvt' },  (err, res, mvt) => {
+                        if (err) {
+                            return done(err);
                         }
 
-                        this.testClient = new TestClient(this.mapConfig);
+                        const tile1 = JSON.parse(mvt.toGeoJSONSync(0));
 
-                        this.testClient.getTile(1, 0, 1, { format: 'mvt' },  (err, res, mvt) => {
+                        assert.ok(Array.isArray(tile1.features));
+                        assert.ok(tile1.features.length > 0);
+
+                        this.testClient.getTile(1, 1, 0, { format: 'mvt' }, (err, res, mvt) =>  {
                             if (err) {
                                 return done(err);
                             }
 
-                            const tile1 = JSON.parse(mvt.toGeoJSONSync(0));
+                            const tile2 = JSON.parse(mvt.toGeoJSONSync(0));
 
-                            assert.ok(Array.isArray(tile1.features));
-                            assert.ok(tile1.features.length > 0);
+                            assert.ok(Array.isArray(tile2.features));
+                            assert.ok(tile2.features.length > 0);
 
-                            this.testClient.getTile(1, 1, 0, { format: 'mvt' }, (err, res, mvt) =>  {
-                                if (err) {
-                                    return done(err);
-                                }
+                            const tile1Ids = tile1.features.map(f => f.properties.cartodb_id);
+                            const tile2Ids = tile2.features.map(f => f.properties.cartodb_id);
+                            const repeatedIds = tile1Ids.filter(id => tile2Ids.includes(id));
 
-                                const tile2 = JSON.parse(mvt.toGeoJSONSync(0));
-
-                                assert.ok(Array.isArray(tile2.features));
-                                assert.ok(tile2.features.length > 0);
-
-                                const tile1Ids = tile1.features.map(f => f.properties.cartodb_id);
-                                const tile2Ids = tile2.features.map(f => f.properties.cartodb_id);
-                                const repeatedIds = tile1Ids.filter(id => tile2Ids.includes(id));
-
-                                // It is not guaranteed that features appear in a single tile:
-                                // features on the border of tiles can appear in multiple tiles
-                                if (repeatedIds.length > 0) {
-                                    repeatedIds.forEach(id => {
-                                        const tile1Features = tile1.features.filter(f => f.properties.cartodb_id === id);
-                                        const tile2Features = tile2.features.filter(f => f.properties.cartodb_id === id);
-                                        // repetitions cannot occur inside a tile
-                                        assert.equal(tile1Features.length, 1);
-                                        assert.equal(tile2Features.length, 1);
-                                        const feature1 = tile1Features[0];
-                                        const feature2 = tile2Features[0];
-                                        // features should be identical (geometry and properties)
-                                        assert.deepEqual(feature1.properties, feature2.properties);
-                                        assert.deepEqual(feature1.geometry, feature2.geometry);
-                                        // and geometry should be on the border;
-                                        // for the dataset and zoom 1, only point with cartodb_id=4 (0,0)
-                                        assert.equal(feature1.properties.cartodb_id, 4);
-                                        assert.equal(feature2.properties.cartodb_id, 4);
-                                    });
-                                }
-                                done();
-                            });
-
+                            // It is not guaranteed that features appear in a single tile:
+                            // features on the border of tiles can appear in multiple tiles
+                            if (repeatedIds.length > 0) {
+                                repeatedIds.forEach(id => {
+                                    const tile1Features = tile1.features.filter(f => f.properties.cartodb_id === id);
+                                    const tile2Features = tile2.features.filter(f => f.properties.cartodb_id === id);
+                                    // repetitions cannot occur inside a tile
+                                    assert.equal(tile1Features.length, 1);
+                                    assert.equal(tile2Features.length, 1);
+                                    const feature1 = tile1Features[0];
+                                    const feature2 = tile2Features[0];
+                                    // features should be identical (geometry and properties)
+                                    assert.deepEqual(feature1.properties, feature2.properties);
+                                    assert.deepEqual(feature1.geometry, feature2.geometry);
+                                    // and geometry should be on the border;
+                                    // for the dataset and zoom 1, only point with cartodb_id=4 (0,0)
+                                    assert.equal(feature1.properties.cartodb_id, 4);
+                                    assert.equal(feature2.properties.cartodb_id, 4);
+                                });
+                            }
+                            done();
                         });
+
                     });
-                // });
+                });
             });
 
             ['default', 'centroid', 'point-sample', 'point-grid'].forEach(placement => {

--- a/test/acceptance/aggregation.js
+++ b/test/acceptance/aggregation.js
@@ -112,13 +112,13 @@ describe('aggregation', function () {
     const POINTS_SQL_PAIRS = `
     -- Generate pairs of near points
     select
-        x + 7 as cartodb_id,
-        st_setsrid(st_makepoint(Floor(x/2)*10 + 9E-3*(x % 2 + 1), Floor(x/2)*10 + 9E-3*(x % 2 + 1)), 4326) as the_geom,
+        x + 1 as cartodb_id,
+        st_setsrid(st_makepoint(Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1), Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1)), 4326) as the_geom,
         st_transform(
-            st_setsrid(st_makepoint(Floor(x/2)*10 + 9E-3*(x % 2 + 1), Floor(x/2)*10 + 9E-3*(x % 2 + 1)),4326),
+            st_setsrid(st_makepoint(Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1), Floor((x-6)/2)*10 + 9E-3*(x % 2 + 1)),4326),
             3857) as the_geom_webmercator,
         x as value
-    from generate_series(-6, 6) x
+    from generate_series(0, 13) x
     `;
 
     function createVectorMapConfig (layers = [
@@ -2384,7 +2384,7 @@ describe('aggregation', function () {
                         assert.equal(typeof body.metadata, 'object');
                         assert.ok(Array.isArray(body.metadata.layers));
                         assert.ok(body.metadata.layers[0].meta.aggregation.mvt);
-                        assert.equal(body.metadata.layers[0].meta.stats.aggrFeatureCount, 8);
+                        assert.equal(body.metadata.layers[0].meta.stats.aggrFeatureCount, 7);
 
                         done();
                     });

--- a/test/acceptance/aggregation.js
+++ b/test/acceptance/aggregation.js
@@ -112,10 +112,10 @@ describe('aggregation', function () {
     const POINTS_SQL_PAIRS = `
     -- Generate pairs of near points
     select
-        x + 4 as cartodb_id,
-        st_setsrid(st_makepoint(Floor(x/2)*10 + x/1000.0, Floor(x/2)*10 + x/1000.0), 4326) as the_geom,
+        x + 7 as cartodb_id,
+        st_setsrid(st_makepoint(Floor(x/2)*10 + 9E-3*(x % 2), Floor(x/2)*10 + 9E-3*(x % 2)), 4326) as the_geom,
         st_transform(
-            st_setsrid(st_makepoint(Floor(x/2)*10 + x/1000.0, Floor(x/2)*10 + x/1000.0),4326),
+            st_setsrid(st_makepoint(Floor(x/2)*10 + 9E-3*(x % 2), Floor(x/2)*10 + 9E-3*(x % 2)),4326),
             3857) as the_geom_webmercator,
         x as value
     from generate_series(-6, 6) x

--- a/test/acceptance/stats/mapnik_stats_layergroup.js
+++ b/test/acceptance/stats/mapnik_stats_layergroup.js
@@ -56,6 +56,17 @@ describe('Create mapnik layergroup', function() {
         }
     };
 
+    var mapnikLayer100 = {
+        type: 'mapnik',
+        options: {
+            sql: [
+                'SELECT * FROM test_table_100'
+            ].join(''),
+            cartocss_version: cartocssVersion,
+            cartocss: cartocss
+        }
+    };
+
     var httpLayer = {
         type: 'http',
         options: {
@@ -512,8 +523,8 @@ describe('Create mapnik layergroup', function() {
         var testClient = new TestClient({
             version: '1.4.0',
             layers: [
-                layerWithMetadata(mapnikLayer4, {
-                    sample: { num_rows: 3 }
+                layerWithMetadata(mapnikLayer100, {
+                    sample: { num_rows: 30 }
                 })
             ]
         });
@@ -521,9 +532,9 @@ describe('Create mapnik layergroup', function() {
         testClient.getLayergroup(function(err, layergroup) {
             assert.ifError(err);
             assert.equal(layergroup.metadata.layers[0].id, mapnikBasicLayerId(0));
-            assert.equal(layergroup.metadata.layers[0].meta.stats.estimatedFeatureCount, 5);
+            assert.equal(layergroup.metadata.layers[0].meta.stats.estimatedFeatureCount, 100);
             assert(layergroup.metadata.layers[0].meta.stats.sample.length > 0);
-            const expectedCols = [ 'cartodb_id', 'address', 'the_geom', 'the_geom_webmercator' ].sort();
+            const expectedCols = [ 'cartodb_id', 'value', 'the_geom', 'the_geom_webmercator' ].sort();
             assert.deepEqual(Object.keys(layergroup.metadata.layers[0].meta.stats.sample[0]).sort(), expectedCols);
             testClient.drain(done);
         });
@@ -533,10 +544,10 @@ describe('Create mapnik layergroup', function() {
         var testClient = new TestClient({
             version: '1.4.0',
             layers: [
-                layerWithMetadata(mapnikLayer4, {
+                layerWithMetadata(mapnikLayer100, {
                     sample: {
-                        num_rows: 3,
-                        include_columns:  [ 'cartodb_id', 'address', 'the_geom' ]
+                        num_rows: 30,
+                        include_columns:  [ 'cartodb_id', 'the_geom' ]
                     }
                 })
             ]
@@ -545,9 +556,9 @@ describe('Create mapnik layergroup', function() {
         testClient.getLayergroup(function(err, layergroup) {
             assert.ifError(err);
             assert.equal(layergroup.metadata.layers[0].id, mapnikBasicLayerId(0));
-            assert.equal(layergroup.metadata.layers[0].meta.stats.estimatedFeatureCount, 5);
+            assert.equal(layergroup.metadata.layers[0].meta.stats.estimatedFeatureCount, 100);
             assert(layergroup.metadata.layers[0].meta.stats.sample.length > 0);
-            const expectedCols = [ 'cartodb_id', 'address', 'the_geom' ].sort();
+            const expectedCols = [ 'cartodb_id', 'the_geom' ].sort();
             assert.deepEqual(Object.keys(layergroup.metadata.layers[0].meta.stats.sample[0]).sort(), expectedCols);
             testClient.drain(done);
         });


### PR DESCRIPTION
This fixes #994

Tests are adapted so that points that lie on the border of tiles can appear in multiple aggregated tiles.

I tried to add some nested `describe` blocks to separate tests without duplicated points, but I got into trouble because of [this](https://github.com/mochajs/mocha/issues/2914)

I'm considering avoiding the duplicated points between tiles as proposed in #889, but for the time being here are the tests adjusted.