### PR TITLE
Multiple test fixes

### DIFF
--- a/test/acceptance/ported/torque_zero_zero.js
+++ b/test/acceptance/ported/torque_zero_zero.js
@@ -19,13 +19,15 @@ describe('torque tiles at 0,0 point', function() {
             what: 'tl',
             x: 3,
             y: 3,
-            expects: []
+            expects: [],
+            expects_fixed: [{"x__uint8":1,"y__uint8":0,"vals__uint8":[1],"dates__uint16":[0]}]
         },
         {
             what: 'tr',
             x: 4,
             y: 3,
-            expects: []
+            expects: [],
+            expects_fixed: [{"x__uint8":0,"y__uint8":0,"vals__uint8":[1],"dates__uint16":[0]}]
         },
         {
             what: 'bl',
@@ -74,7 +76,13 @@ describe('torque tiles at 0,0 point', function() {
             };
 
             testClient.getTorque(mapConfig, 0, 3, tile.x, tile.y, function(err, res) {
-                assert.deepEqual(JSON.parse(res.body), tile.expects);
+                assert.ok(!err, err);
+                try {
+                    assert.deepEqual(JSON.parse(res.body), tile.expects);
+                } catch (ex) {
+                    // With Proj 5.1 this bug has been fixed and the point appears in all tiles
+                    assert.deepEqual(JSON.parse(res.body), tile.expects_fixed);
+                }
                 done();
             });
         });

--- a/test/acceptance/regressions.js
+++ b/test/acceptance/regressions.js
@@ -188,6 +188,7 @@ describe('regressions', function() {
         };
 
         const testClient = new TestClient(template, apikeyToken);
+        testClient.keysToDelete['map_tpl|localhost'] = 0;
 
         const params = {
             own_filter: 1,

--- a/test/support/prepare_db.sh
+++ b/test/support/prepare_db.sh
@@ -16,13 +16,14 @@ DOWNLOAD_SQL_FILES=yes
 PG_PARALLEL=$(pg_config --version | (awk '{$2*=1000; if ($2 >= 9600) print 1; else print 0;}' 2> /dev/null || echo 0))
 
 while [ -n "$1" ]; do
-  if test "$1" = "--skip-pg"; then
+  OPTION=$(echo "$1" | tr -d '[:space:]')
+  if [[ "$OPTION" == "--skip-pg" ]]; then
     PREPARE_PGSQL=no
     shift; continue
-  elif test "$1" = "--skip-redis"; then
+  elif [[ "$OPTION" == "--skip-redis" ]]; then
     PREPARE_REDIS=no
     shift; continue
-  elif test "$1" = "--no-sql-download"; then
+  elif [[ "$OPTION" == "--no-sql-download" ]]; then
     DOWNLOAD_SQL_FILES=no
     shift; continue
   else
@@ -95,12 +96,12 @@ if test x"$PREPARE_PGSQL" = xyes; then
   LOCAL_SQL_SCRIPTS='analysis_catalog windshaft.test gadm4 countries_null_values ported/populated_places_simple_reduced cdb_analysis_check cdb_invalidate_varnish'
   REMOTE_SQL_SCRIPTS='CDB_QueryStatements CDB_QueryTables CDB_CartodbfyTable CDB_TableMetadata CDB_ForeignTable CDB_UserTables CDB_ColumnNames CDB_ZoomFromScale CDB_OverviewsSupport CDB_Overviews CDB_QuantileBins CDB_JenksBins CDB_HeadsTailsBins CDB_EqualIntervalBins CDB_Hexagon CDB_XYZ CDB_EstimateRowCount CDB_RectangleGrid'
 
-  CURL_ARGS=""
-  for i in ${REMOTE_SQL_SCRIPTS}
-  do
-    CURL_ARGS="${CURL_ARGS}\"https://github.com/CartoDB/cartodb-postgresql/raw/master/scripts-available/$i.sql\" -o sql/$i.sql "
-  done
   if test x"$DOWNLOAD_SQL_FILES" = xyes; then
+    CURL_ARGS=""
+    for i in ${REMOTE_SQL_SCRIPTS}
+    do
+        CURL_ARGS="${CURL_ARGS}\"https://github.com/CartoDB/cartodb-postgresql/raw/master/scripts-available/$i.sql\" -o sql/$i.sql "
+    done
     echo "Downloading and updating: ${REMOTE_SQL_SCRIPTS}"
     echo ${CURL_ARGS} | xargs curl -L -s
   fi


### PR DESCRIPTION
- Fixes the DB flags that I broke (:cry:) in  #976 (Needs to remove the spaces before the options to compare).
- Brings a similar fix to the torque_zero_zero.js as done for Windshaft (https://github.com/CartoDB/Windshaft/pull/630)
- `test/acceptance/regressions.js`: Remove trailing redis key so that the `named map` test clean after itself and can be executed repeatedly without further cleanup.

Partially related to #994