### PR TITLE
Upgrade turbo carto

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@ New features:
   - request: 2.87.0
   - semver: 5.5.0
   - step: 1.0.0
-  - turbo-carto: 0.20.3
+  - turbo-carto: 0.20.4
   - yargs: 11.1.0
 - Update devel deps:
   - istanbul: 0.4.5

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "5.5.0",
     "step": "1.0.0",
     "step-profiler": "0.3.0",
-    "turbo-carto": "0.20.3",
+    "turbo-carto": "0.20.4",
     "underscore": "1.6.0",
     "windshaft": "4.8.1",
     "yargs": "11.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2625,9 +2625,9 @@ turbo-carto@0.19.0:
     postcss "5.0.19"
     postcss-value-parser "3.3.0"
 
-turbo-carto@0.20.3:
-  version "0.20.3"
-  resolved "https://registry.yarnpkg.com/turbo-carto/-/turbo-carto-0.20.3.tgz#ab9ee1357f63a3e3f317a31f92f81adc5ea97475"
+turbo-carto@0.20.4:
+  version "0.20.4"
+  resolved "https://registry.yarnpkg.com/turbo-carto/-/turbo-carto-0.20.4.tgz#788643f2eae749ef97dd321f682ab4f9115b6457"
   dependencies:
     cartocolor "4.0.0"
     colorbrewer "1.0.0"


### PR DESCRIPTION
Upgrade turbo-carto to version 0.20.4
- revert .then() .catch() call order until we upgrade to node8/10 #78

closes temporarily https://github.com/CartoDB/Windshaft-cartodb/issues/1000

More info: https://github.com/CartoDB/turbo-carto/pull/80