### PR TITLE
Tests: Use "UNION ALL" instead of "UNION" to improve performance

### DIFF
--- a/test/acceptance/ported/torque.js
+++ b/test/acceptance/ported/torque.js
@@ -164,7 +164,7 @@ describe('torque', function() {
         version: '1.1.0',
         layers: [
            { type: 'torque', options: {
-               sql: "select 1 as id, '1970-01-02'::date as d, 'POINT(0 0)'::geometry as the_geom UNION select 2, " +
+               sql: "select 1 as id, '1970-01-02'::date as d, 'POINT(0 0)'::geometry as the_geom UNION ALL select 2, " +
                    "'1970-01-01'::date, 'POINT(1 1)'::geometry",
                geom_column: 'the_geom',
                cartocss: 'Map { -torque-frame-count:2; -torque-resolution:3; -torque-time-attribute:d; ' +
@@ -359,7 +359,7 @@ describe('torque', function() {
         version: '1.1.0',
         layers: [
            { type: 'torque', options: {
-               sql: "select 1 as id, '1970-01-03'::date as d, 'POINT(0 0)'::geometry as the_geom UNION select 2, " +
+               sql: "select 1 as id, '1970-01-03'::date as d, 'POINT(0 0)'::geometry as the_geom UNION ALL select 2, " +
                    "'1970-01-01'::date, 'POINT(1 1)'::geometry",
                geom_column: 'the_geom',
                cartocss: 'Map { -torque-frame-count:2; -torque-resolution:3; -torque-time-attribute:d; ' +

--- a/test/acceptance/turbo-carto/anonymous-maps.js
+++ b/test/acceptance/turbo-carto/anonymous-maps.js
@@ -21,13 +21,13 @@ function makeMapconfig(cartocss) {
                     "sql": [
                         'SELECT test_table.*, _prices.price FROM test_table JOIN (' +
                         '  SELECT 1 AS cartodb_id, 10.00 AS price',
-                        '  UNION',
+                        '  UNION ALL',
                         '  SELECT 2, 10.50',
-                        '  UNION',
+                        '  UNION ALL',
                         '  SELECT 3, 11.00',
-                        '  UNION',
+                        '  UNION ALL',
                         '  SELECT 4, 12.00',
-                        '  UNION',
+                        '  UNION ALL',
                         '  SELECT 5, 21.00',
                         ') _prices ON _prices.cartodb_id = test_table.cartodb_id'
                     ].join('\n'),

--- a/test/acceptance/turbo-carto/named-maps.js
+++ b/test/acceptance/turbo-carto/named-maps.js
@@ -45,13 +45,13 @@ describe('turbo-carto for named maps', function() {
                             sql: [
                                 'SELECT ' + table + '.*, _prices.price FROM ' + table + ' JOIN (' +
                                 '  SELECT 1 AS cartodb_id, 10.00 AS price',
-                                '  UNION',
+                                '  UNION ALL',
                                 '  SELECT 2, 10.50',
-                                '  UNION',
+                                '  UNION ALL',
                                 '  SELECT 3, 11.00',
-                                '  UNION',
+                                '  UNION ALL',
                                 '  SELECT 4, 12.00',
-                                '  UNION',
+                                '  UNION ALL',
                                 '  SELECT 5, 21.00',
                                 ') _prices ON _prices.cartodb_id = ' + table + '.cartodb_id'
                             ].join('\n'),

--- a/test/acceptance/widgets/regressions.js
+++ b/test/acceptance/widgets/regressions.js
@@ -265,12 +265,12 @@ describe('widgets-regressions', function() {
                     ST_TRANSFORM(ST_SETSRID(ST_GeomFromGeoJSON(
                         '${JSON.stringify(notIntersectingLeftTriangle)}'
                     ), 4326), 3857) AS the_geom_webmercator, 1 AS cartodb_id, 'notIntersectingLeftTriangle' AS name
-                UNION
+                UNION ALL
                 SELECT
                     ST_TRANSFORM(ST_SETSRID(ST_GeomFromGeoJSON(
                         '${JSON.stringify(notIntersectingRightTriangle)}'
                     ), 4326), 3857), 2, 'notIntersectingRightTriangle'
-                UNION
+                UNION ALL
                 SELECT
                     ST_TRANSFORM(ST_SETSRID(ST_GeomFromGeoJSON(
                         '${JSON.stringify(intersectingTriangle)}'


### PR DESCRIPTION
While investigating https://github.com/CartoDB/Windshaft-cartodb/pull/1002 with @jgoizueta I noticed that when combining queries using `UNION` a query would take ~60ms as it was generating a plan expecting both sides of the union being 1 million rows in size.

On the other hand, using `UNION ALL` would take ~1 ms, using a different plan as it doesn't require to remove duplicates from the combination. @jgoizueta tested with PG 9.6 and it varied (60ms the first time, and ~1ms the rest) and in production (PG 10.1) where it was always 1ms. My installation (PG11) always went to the 60 ms plan.

As in these cases there is no need to remove duplicates, UNION ALL is more efficient.