### PR TITLE
Upgrade camshaft to avoid missing columns when an analysis changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## 6.3.1
 Released 2018-mm-dd
-
+- Upgrades Camshaft to [0.62.2](https://github.com/CartoDB/camshaft/releases/tag/0.61.11):
+  - Build query from node's cache to compute output columns when building analysis
 
 ## 6.3.0
 Released 2018-07-26

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## 6.3.1
 Released 2018-mm-dd
+
 - Upgrades Camshaft to [0.62.2](https://github.com/CartoDB/camshaft/releases/tag/0.61.11):
   - Build query from node's cache to compute output columns when building analysis
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@carto/fqdn-sync": "0.2.2",
     "basic-auth": "2.0.0",
     "body-parser": "1.18.3",
-    "camshaft": "0.62.1",
+    "camshaft": "cartodb/camshaft#calculate-columns-from-cached-query",
     "cartodb-psql": "0.11.0",
     "cartodb-query-tables": "0.3.0",
     "cartodb-redis": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@carto/fqdn-sync": "0.2.2",
     "basic-auth": "2.0.0",
     "body-parser": "1.18.3",
-    "camshaft": "cartodb/camshaft#calculate-columns-from-cached-query",
+    "camshaft": "0.62.2",
     "cartodb-psql": "0.11.0",
     "cartodb-query-tables": "0.3.0",
     "cartodb-redis": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,9 +265,9 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-camshaft@cartodb/camshaft#calculate-columns-from-cached-query:
+camshaft@0.62.2:
   version "0.62.2"
-  resolved "https://codeload.github.com/cartodb/camshaft/tar.gz/8d137ddf242a37c7973be099ad9f290071142824"
+  resolved "https://registry.yarnpkg.com/camshaft/-/camshaft-0.62.2.tgz#1d665b717a5a02ce44db8f7630cf23954929354a"
   dependencies:
     async "^1.5.2"
     bunyan "1.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,9 +265,9 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-camshaft@0.62.1:
-  version "0.62.1"
-  resolved "https://registry.yarnpkg.com/camshaft/-/camshaft-0.62.1.tgz#75f8734c4089aaeae3b9067eb94d3c669cebbcaf"
+camshaft@cartodb/camshaft#calculate-columns-from-cached-query:
+  version "0.62.2"
+  resolved "https://codeload.github.com/cartodb/camshaft/tar.gz/8d137ddf242a37c7973be099ad9f290071142824"
   dependencies:
     async "^1.5.2"
     bunyan "1.8.1"


### PR DESCRIPTION
Upgrade camshaft to avoid missing columns when an analysis changes its schema output