### PR TITLE
Log overviews usage during map instantiation

### DIFF
--- a/lib/cartodb/api/map/anonymous-map-controller.js
+++ b/lib/cartodb/api/map/anonymous-map-controller.js
@@ -152,8 +152,10 @@ function prepareAdapterMapConfig (mapConfigAdapter) {
             }
         };
 
-        mapConfigAdapter.getMapConfig(user, requestMapConfig, params, context, (err, requestMapConfig) => {
+        mapConfigAdapter.getMapConfig(user, requestMapConfig, params, context, (err, requestMapConfig, stats = { overviewsUsed : false}) => {
             req.profiler.done('anonymous.getMapConfig');
+            req.profiler.add(stats);
+                      
             if (err) {
                 return next(err);
             }

--- a/lib/cartodb/api/map/anonymous-map-controller.js
+++ b/lib/cartodb/api/map/anonymous-map-controller.js
@@ -158,7 +158,10 @@ function prepareAdapterMapConfig (mapConfigAdapter) {
                                       context, 
                                       (err, requestMapConfig, stats = { overviewsUsed : false }) => {
             req.profiler.done('anonymous.getMapConfig');
+            
+            stats.mapType = 'anonymous';
             req.profiler.add(stats);
+
                       
             if (err) {
                 return next(err);

--- a/lib/cartodb/api/map/anonymous-map-controller.js
+++ b/lib/cartodb/api/map/anonymous-map-controller.js
@@ -152,7 +152,11 @@ function prepareAdapterMapConfig (mapConfigAdapter) {
             }
         };
 
-        mapConfigAdapter.getMapConfig(user, requestMapConfig, params, context, (err, requestMapConfig, stats = { overviewsUsed : false}) => {
+        mapConfigAdapter.getMapConfig(user, 
+                                      requestMapConfig, 
+                                      params, 
+                                      context, 
+                                      (err, requestMapConfig, stats = { overviewsUsed : false }) => {
             req.profiler.done('anonymous.getMapConfig');
             req.profiler.add(stats);
                       

--- a/lib/cartodb/api/template/named-template-controller.js
+++ b/lib/cartodb/api/template/named-template-controller.js
@@ -165,8 +165,12 @@ function getTemplate (
             params
         );
 
-        mapConfigProvider.getMapConfig((err, mapConfig, rendererParams) => {
+        mapConfigProvider.getMapConfig((err, mapConfig, rendererParams, context, stats = {}) => {
             req.profiler.done('named.getMapConfig');
+
+            stats.mapType = 'named';
+            req.profiler.add(stats);
+
             if (err) {
                 return next(err);
             }

--- a/lib/cartodb/models/mapconfig/adapter/index.js
+++ b/lib/cartodb/models/mapconfig/adapter/index.js
@@ -11,16 +11,21 @@ MapConfigAdapter.prototype.getMapConfig = function(user, requestMapConfig, param
     var i = 0;
     var tasksLeft = this.adapters.length;
 
-    function next(err, _requestMapConfig) {
+    let mapConfigStats = {};
+
+    function next(err, _requestMapConfig, adapterStats = {}) {
         if (err) {
             return callback(err);
         }
+
+        mapConfigStats = Object.assign(mapConfigStats, adapterStats);
+
         if (tasksLeft-- === 0) {
-            return callback(null, _requestMapConfig);
+            return callback(null, _requestMapConfig, mapConfigStats);
         }
         var nextAdapter = self.adapters[i++];
         nextAdapter.getMapConfig(user, _requestMapConfig, params, context, next);
     }
 
-    next(null, requestMapConfig);
+    next(null, requestMapConfig, mapConfigStats);
 };

--- a/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
@@ -28,8 +28,7 @@ MapConfigOverviewsAdapter.prototype.getMapConfig = function (user, requestMapCon
         const layers = results.map(result => result.layer);
         const overviewsAddedToMapconfig = results
                                .map(result => result.overviewsAddedToMapconfig)
-                               .reduce((overviewsInMapconfig,overviewsInLayer)=>overviewsInMapconfig||overviewsInLayer,
-                                        false);
+                               .some(overviewsInLayer => overviewsInLayer);
 
         if (!layers || layers.length === 0) {
             return callback(new Error('Missing layers array from layergroup config'));

--- a/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
@@ -37,8 +37,7 @@ MapConfigOverviewsAdapter.prototype.getMapConfig = function (user, requestMapCon
 
         requestMapConfig.layers = layers;
 
-        const stats = { overviewsAddedToMapconfig,
-                        mapType: 'anonymous' };
+        const stats = { overviewsAddedToMapconfig };
 
         return callback(null, requestMapConfig, stats);
     });

--- a/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
@@ -20,10 +20,16 @@ MapConfigOverviewsAdapter.prototype.getMapConfig = function (user, requestMapCon
 
     layers.forEach(layer => augmentLayersQueue.defer(this._augmentLayer.bind(this), user, layer, analysesResults));
 
-    augmentLayersQueue.awaitAll(function layersAugmentQueueFinish (err, layers) {
+    augmentLayersQueue.awaitAll(function layersAugmentQueueFinish (err, results) {
         if (err) {
             return callback(err);
         }
+
+        const layers = results.map(result => result.layer);
+        const overviewsAddedToMapconfig = results
+                               .map(result => result.overviewsAddedToMapconfig)
+                               .reduce((overviewsInMapconfig,overviewsInLayer)=>overviewsInMapconfig||overviewsInLayer,
+                                        false);
 
         if (!layers || layers.length === 0) {
             return callback(new Error('Missing layers array from layergroup config'));
@@ -31,39 +37,45 @@ MapConfigOverviewsAdapter.prototype.getMapConfig = function (user, requestMapCon
 
         requestMapConfig.layers = layers;
 
-        return callback(null, requestMapConfig);
+        const stats = { overviewsAddedToMapconfig,
+                        mapType: 'anonymous' };
+
+        return callback(null, requestMapConfig, stats);
     });
 };
 
 MapConfigOverviewsAdapter.prototype._augmentLayer = function (user, layer, analysesResults, callback) {
+    let overviewsAddedToMapconfig = false;
     if (layer.type !== 'mapnik' && layer.type !== 'cartodb') {
-        return callback(null, layer);
+        return callback(null, { layer, overviewsAddedToMapconfig });
     }
 
     this.overviewsMetadataBackend.getOverviewsMetadata(user, layer.options.sql, (err, metadata) => {
         if (err) {
-            return callback(err, layer);
+            return callback(err, { layer, overviewsAddedToMapconfig });
         }
 
         if (_.isEmpty(metadata)) {
-            return callback(null, layer);
+            return callback(null, { layer, overviewsAddedToMapconfig });
         }
 
         var filters = getFilters(analysesResults, layer);
+
+        overviewsAddedToMapconfig = true;
 
         if (!filters) {
             layer.options = Object.assign({}, layer.options, getQueryRewriteData(layer, analysesResults, {
                 overviews: metadata
             }));
 
-            return callback(null, layer);
+            return callback(null, { layer, overviewsAddedToMapconfig });
         }
 
         var unfilteredQuery = getUnfilteredQuery(analysesResults, layer);
 
         this.filterStatsBackend.getFilterStats(user, unfilteredQuery, filters, function (err, stats) {
             if (err) {
-                return callback(null, layer);
+                return callback(null, { layer, overviewsAddedToMapconfig });
             }
 
             layer.options = Object.assign({}, layer.options, getQueryRewriteData(layer, analysesResults, {
@@ -71,7 +83,7 @@ MapConfigOverviewsAdapter.prototype._augmentLayer = function (user, layer, analy
                 filter_stats: stats
             }));
 
-            return callback(null, layer);
+            return callback(null, { layer, overviewsAddedToMapconfig });
         });
     });
 };

--- a/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
+++ b/lib/cartodb/models/mapconfig/adapter/mapconfig-overviews-adapter.js
@@ -26,9 +26,7 @@ MapConfigOverviewsAdapter.prototype.getMapConfig = function (user, requestMapCon
         }
 
         const layers = results.map(result => result.layer);
-        const overviewsAddedToMapconfig = results
-                               .map(result => result.overviewsAddedToMapconfig)
-                               .some(overviewsInLayer => overviewsInLayer);
+        const overviewsAddedToMapconfig = results.some(result => result.overviewsAddedToMapconfig);
 
         if (!layers || layers.length === 0) {
             return callback(new Error('Missing layers array from layergroup config'));

--- a/lib/cartodb/models/mapconfig/provider/named-map-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/named-map-provider.js
@@ -99,7 +99,7 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
                 const { user, rendererParams } = this;
 
                 this.mapConfigAdapter.getMapConfig(
-                    user, requestMapConfig, rendererParams, context, (err, mapConfig) => {
+                    user, requestMapConfig, rendererParams, context, (err, mapConfig, stats = {}) => {
                     if (err) {
                         this.err = err;
                         return callback(err);
@@ -108,7 +108,7 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
                     this.mapConfig = (mapConfig === null) ? null : new MapConfig(mapConfig, context.datasource);
                     this.analysesResults = context.analysesResults || [];
 
-                    return callback(null, this.mapConfig, this.rendererParams, this.context);
+                        return callback(null, this.mapConfig, this.rendererParams, this.context, stats);
                 });
             });
         });

--- a/lib/cartodb/models/mapconfig/provider/named-map-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/named-map-provider.js
@@ -108,7 +108,7 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
                     this.mapConfig = (mapConfig === null) ? null : new MapConfig(mapConfig, context.datasource);
                     this.analysesResults = context.analysesResults || [];
 
-                        return callback(null, this.mapConfig, this.rendererParams, this.context, stats);
+                    return callback(null, this.mapConfig, this.rendererParams, this.context, stats);
                 });
             });
         });

--- a/test/acceptance/overviews_metadata.js
+++ b/test/acceptance/overviews_metadata.js
@@ -115,42 +115,81 @@ describe('overviews metadata', function() {
         );
     });
 
-    it("Flags overviews usage", function (done) {
-        var layergroup = {
-            version: '1.0.0',
-            layers: [overviews_layer, non_overviews_layer]
-        };
+    describe('Overviews Flags', function () {
+        it("Overviews used", function (done) {
+            var layergroup = {
+                version: '1.0.0',
+                layers: [overviews_layer, non_overviews_layer]
+            };
 
-        var layergroup_url = '/api/v1/map';
+            var layergroup_url = '/api/v1/map';
 
-        var expected_token;
-        step(
-            function do_post() {
-                var next = this;
-                assert.response(server, {
-                    url: layergroup_url,
-                    method: 'POST',
-                    headers: { host: 'localhost', 'Content-Type': 'application/json' },
-                    data: JSON.stringify(layergroup)
-                }, {}, function (res) {
-                    assert.equal(res.statusCode, 200, res.body);
+            var expected_token;
+            step(
+                function do_post() {
+                    var next = this;
+                    assert.response(server, {
+                        url: layergroup_url,
+                        method: 'POST',
+                        headers: { host: 'localhost', 'Content-Type': 'application/json' },
+                        data: JSON.stringify(layergroup)
+                    }, {}, function (res) {
+                        assert.equal(res.statusCode, 200, res.body);
 
-                    const headers = JSON.parse(res.headers['x-tiler-profiler']);
+                        const headers = JSON.parse(res.headers['x-tiler-profiler']);
 
-                    assert.ok(headers.overviewsAddedToMapconfig);
-                    assert.equal(headers.mapType, 'anonymous');
-                    
-                    const parsedBody = JSON.parse(res.body);
-                    expected_token = parsedBody.layergroupid;
-                    next();
-                });
-            },
-            function finish(err) {
-                keysToDelete['map_cfg|' + LayergroupToken.parse(expected_token).token] = 0;
-                keysToDelete['user:localhost:mapviews:global'] = 5;
-                done(err);
-            }
-        );
+                        assert.ok(headers.overviewsAddedToMapconfig);
+                        assert.equal(headers.mapType, 'anonymous');
+
+                        const parsedBody = JSON.parse(res.body);
+                        expected_token = parsedBody.layergroupid;
+                        next();
+                    });
+                },
+                function finish(err) {
+                    keysToDelete['map_cfg|' + LayergroupToken.parse(expected_token).token] = 0;
+                    keysToDelete['user:localhost:mapviews:global'] = 5;
+                    done(err);
+                }
+            );
+        });
+        it("Overviews NOT used", function (done) {
+            var layergroup = {
+                version: '1.0.0',
+                layers: [non_overviews_layer]
+            };
+
+            var layergroup_url = '/api/v1/map';
+
+            var expected_token;
+            step(
+                function do_post() {
+                    var next = this;
+                    assert.response(server, {
+                        url: layergroup_url,
+                        method: 'POST',
+                        headers: { host: 'localhost', 'Content-Type': 'application/json' },
+                        data: JSON.stringify(layergroup)
+                    }, {}, function (res) {
+                        assert.equal(res.statusCode, 200, res.body);
+
+                        const headers = JSON.parse(res.headers['x-tiler-profiler']);
+
+                        assert.equal(headers.overviewsAddedToMapconfig, false);
+                        assert.equal(headers.mapType, 'anonymous');
+
+                        const parsedBody = JSON.parse(res.body);
+                        expected_token = parsedBody.layergroupid;
+                        next();
+                    });
+                },
+                function finish(err) {
+                    keysToDelete['map_cfg|' + LayergroupToken.parse(expected_token).token] = 0;
+                    keysToDelete['user:localhost:mapviews:global'] = 5;
+                    done(err);
+                }
+            );
+        });
     });
 });
 

--- a/test/acceptance/overviews_metadata.js
+++ b/test/acceptance/overviews_metadata.js
@@ -72,7 +72,12 @@ describe('overviews metadata', function() {
                   data: JSON.stringify(layergroup)
               }, {}, function(res) {
                   assert.equal(res.statusCode, 200, res.body);
-                  assert.ok(JSON.parse(res.headers['x-tiler-profiler']).overviewsAddedToMapconfig);
+
+                  const headers = JSON.parse(res.headers['x-tiler-profiler']);
+
+                  assert.ok(headers.overviewsAddedToMapconfig);
+                  assert.equal(headers.mapType, 'anonymous');
+
                   var parsedBody = JSON.parse(res.body);
                   assert.equal(res.headers['x-layergroup-id'], parsedBody.layergroupid);
                   expected_token = parsedBody.layergroupid;

--- a/test/acceptance/overviews_metadata.js
+++ b/test/acceptance/overviews_metadata.js
@@ -72,6 +72,7 @@ describe('overviews metadata', function() {
                   data: JSON.stringify(layergroup)
               }, {}, function(res) {
                   assert.equal(res.statusCode, 200, res.body);
+                  assert.ok(JSON.parse(res.headers['x-tiler-profiler']).overviewsAddedToMapconfig);
                   var parsedBody = JSON.parse(res.body);
                   assert.equal(res.headers['x-layergroup-id'], parsedBody.layergroupid);
                   expected_token = parsedBody.layergroupid;

--- a/test/acceptance/overviews_metadata.js
+++ b/test/acceptance/overviews_metadata.js
@@ -73,11 +73,6 @@ describe('overviews metadata', function() {
               }, {}, function(res) {
                   assert.equal(res.statusCode, 200, res.body);
 
-                  const headers = JSON.parse(res.headers['x-tiler-profiler']);
-
-                  assert.ok(headers.overviewsAddedToMapconfig);
-                  assert.equal(headers.mapType, 'anonymous');
-
                   var parsedBody = JSON.parse(res.body);
                   assert.equal(res.headers['x-layergroup-id'], parsedBody.layergroupid);
                   expected_token = parsedBody.layergroupid;
@@ -111,6 +106,44 @@ describe('overviews metadata', function() {
                   });
 
                   next(err);
+            },
+            function finish(err) {
+                keysToDelete['map_cfg|' + LayergroupToken.parse(expected_token).token] = 0;
+                keysToDelete['user:localhost:mapviews:global'] = 5;
+                done(err);
+            }
+        );
+    });
+
+    it("Flags overviews usage", function (done) {
+        var layergroup = {
+            version: '1.0.0',
+            layers: [overviews_layer, non_overviews_layer]
+        };
+
+        var layergroup_url = '/api/v1/map';
+
+        var expected_token;
+        step(
+            function do_post() {
+                var next = this;
+                assert.response(server, {
+                    url: layergroup_url,
+                    method: 'POST',
+                    headers: { host: 'localhost', 'Content-Type': 'application/json' },
+                    data: JSON.stringify(layergroup)
+                }, {}, function (res) {
+                    assert.equal(res.statusCode, 200, res.body);
+
+                    const headers = JSON.parse(res.headers['x-tiler-profiler']);
+
+                    assert.ok(headers.overviewsAddedToMapconfig);
+                    assert.equal(headers.mapType, 'anonymous');
+                    
+                    const parsedBody = JSON.parse(res.body);
+                    expected_token = parsedBody.layergroupid;
+                    next();
+                });
             },
             function finish(err) {
                 keysToDelete['map_cfg|' + LayergroupToken.parse(expected_token).token] = 0;

--- a/test/acceptance/overviews_metadata_named_maps.js
+++ b/test/acceptance/overviews_metadata_named_maps.js
@@ -177,58 +177,128 @@ describe('overviews metadata for named maps', function() {
         );
     });
 
-    it("Flags overviews usage", function (done) {
-        step(
-            function postTemplate() {
-                var next = this;
+    describe('Overviews Flags', function() {
+        it("Overviews used", function (done) {
+            step(
+                function postTemplate() {
+                    var next = this;
 
-                assert.response(server, {
-                    url: '/api/v1/map/named?api_key=1234',
-                    method: 'POST',
-                    headers: { host: 'localhost', 'Content-Type': 'application/json' },
-                    data: JSON.stringify(template)
-                }, {}, function (res, err) {
-                    next(err, res);
-                });
-            },
-            function instantiateTemplate(err) {
-                assert.ifError(err);
-
-                var next = this;
-                assert.response(server, {
-                    url: '/api/v1/map/named/' + templateId,
-                    method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    }
-                }, {},
-                    function (res, err) {
-                        return next(err, res);
+                    assert.response(server, {
+                        url: '/api/v1/map/named?api_key=1234',
+                        method: 'POST',
+                        headers: { host: 'localhost', 'Content-Type': 'application/json' },
+                        data: JSON.stringify(template)
+                    }, {}, function (res, err) {
+                        next(err, res);
                     });
+                },
+                function instantiateTemplate(err) {
+                    assert.ifError(err);
 
-            },
-            function checkFlags(err, res) {
-                assert.ifError(err);
+                    var next = this;
+                    assert.response(server, {
+                        url: '/api/v1/map/named/' + templateId,
+                        method: 'POST',
+                        headers: {
+                            host: 'localhost',
+                            'Content-Type': 'application/json'
+                        }
+                    }, {},
+                        function (res, err) {
+                            return next(err, res);
+                        });
 
-                var next = this;
+                },
+                function checkFlags(err, res) {
+                    assert.ifError(err);
 
-                var parsedBody = JSON.parse(res.body);
+                    var next = this;
 
-                keysToDelete['map_cfg|' + LayergroupToken.parse(parsedBody.layergroupid).token] = 0;
-                keysToDelete['user:localhost:mapviews:global'] = 5;
+                    var parsedBody = JSON.parse(res.body);
 
-                const headers = JSON.parse(res.headers['x-tiler-profiler']);
+                    keysToDelete['map_cfg|' + LayergroupToken.parse(parsedBody.layergroupid).token] = 0;
+                    keysToDelete['user:localhost:mapviews:global'] = 5;
 
-                assert.ok(headers.overviewsAddedToMapconfig);
-                assert.equal(headers.mapType, 'named');
+                    const headers = JSON.parse(res.headers['x-tiler-profiler']);
 
-                next();
-            },
+                    assert.ok(headers.overviewsAddedToMapconfig);
+                    assert.equal(headers.mapType, 'named');
 
-            function finish(err) {
-                done(err);
-            }
-        );
+                    next();
+                },
+
+                function finish(err) {
+                    done(err);
+                }
+            );
+        });
+
+        it("Overviews NOT used", function (done) {
+
+            const nonOverviewsTemplateId = 'non-overviews-template';
+
+            var nonOverviewsTemplate = {
+                version: '0.0.1',
+                name: nonOverviewsTemplateId,
+                auth: { method: 'open' },
+                layergroup: {
+                    version: '1.0.0',
+                    layers: [non_overviews_layer]
+                }
+            };
+
+            step(
+                function postTemplate() {
+                    var next = this;
+
+                    assert.response(server, {
+                        url: '/api/v1/map/named?api_key=1234',
+                        method: 'POST',
+                        headers: { host: 'localhost', 'Content-Type': 'application/json' },
+                        data: JSON.stringify(nonOverviewsTemplate)
+                    }, {}, function (res, err) {
+                        next(err, res);
+                    });
+                },
+                function instantiateTemplate(err) {
+                    assert.ifError(err);
+
+                    var next = this;
+                    assert.response(server, {
+                        url: '/api/v1/map/named/' + nonOverviewsTemplateId,
+                        method: 'POST',
+                        headers: {
+                            host: 'localhost',
+                            'Content-Type': 'application/json'
+                        }
+                    }, {},
+                        function (res, err) {
+                            return next(err, res);
+                        });
+
+                },
+                function checkFlags(err, res) {
+                    assert.ifError(err);
+
+                    var next = this;
+
+                    var parsedBody = JSON.parse(res.body);
+
+                    keysToDelete['map_cfg|' + LayergroupToken.parse(parsedBody.layergroupid).token] = 0;
+                    keysToDelete['user:localhost:mapviews:global'] = 5;
+
+                    const headers = JSON.parse(res.headers['x-tiler-profiler']);
+
+                    assert.equal(headers.overviewsAddedToMapconfig, false);
+                    assert.equal(headers.mapType, 'named');
+
+                    next();
+                },
+
+                function finish(err) {
+                    done(err);
+                }
+            );
+        });
     });
 });

--- a/test/acceptance/overviews_metadata_named_maps.js
+++ b/test/acceptance/overviews_metadata_named_maps.js
@@ -119,6 +119,11 @@ describe('overviews metadata for named maps', function() {
                 assert.ok(parsedBody.layergroupid);
                 assert.ok(parsedBody.last_updated);
 
+                const headers = JSON.parse(res.headers['x-tiler-profiler']);
+
+                assert.ok(headers.overviewsAddedToMapconfig);
+                assert.equal(headers.mapType, 'named');
+
                 next(null, parsedBody.layergroupid);
             },
 


### PR DESCRIPTION
Comes from https://github.com/CartoDB/cartodb-management/issues/5201

In order to enhance the metrics on overviews usage, we want to log the overviews usage during the map instantiations. For every instantiation, we will add to the tiler profiler 2 fields:
```javascript
{
    overviewsAddedToMapconfig: true|false
    mapType: 'anonymous'|'named'
}
```

It has to be done for:

- [x] Anonymous maps
- [x] Named maps