### PR TITLE
upgrades Windshaft (remove step)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## 6.3.1
-Released 2018-mm-dd
+## 6.4.0
+Released 2018-09-24
 
 - Upgrades Camshaft to [0.62.3](https://github.com/CartoDB/camshaft/releases/tag/0.61.11):
   - Build query from node's cache to compute output columns when building analysis
@@ -10,15 +10,17 @@ Released 2018-mm-dd
 - Bug Fixes: (#1020)
   - Fix bug in date-wrapper regarding columns with spaces
   - Fix bug in aggregation-query regarding columns with spaces
-- Upgrades Windshaft to [4.9.0](https://github.com/CartoDB/Windshaft/blob/4.9.0/NEWS.md#version-490)
+- Upgrades Windshaft to [4.10.0](https://github.com/CartoDB/Windshaft/blob/4.10.0/NEWS.md#version-4100)
   - `pg-mvt`:
     - Now matches the behaviour of the `mapnik` renderer for MVTs.
     - Removed undocummented filtering by `layer.options.columns`.
+    - Implement timeout in getTile.
     - Several bugfixes.
   - Dependency updates: Fixed a bug in Mapnik MVT renderer and cleanup in `tilelive-mapnik`.
   - [MapConfig 1.8.0 released](https://github.com/CartoDB/Windshaft/blob/master/doc/MapConfig-1.8.0.md) with new options for MVTs:
     - Add **`vector_extent`** option in MapConfig to setup the layer extent.
     - Add **`vector_simplify_extent`** option in MapConfig to configure the simplification process.
+  - Remove use of `step` module to handle asynchronous code, now it's defined as development dependency.
 
 ## 6.3.0
 Released 2018-07-26

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "step-profiler": "0.3.0",
     "turbo-carto": "0.20.4",
     "underscore": "1.6.0",
-    "windshaft": "cartodb/Windshaft#remove-step",
+    "windshaft": "4.10.0",
     "yargs": "11.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "step-profiler": "0.3.0",
     "turbo-carto": "0.20.4",
     "underscore": "1.6.0",
-    "windshaft": "4.9.0",
+    "windshaft": "cartodb/Windshaft#remove-step",
     "yargs": "11.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "windshaft-cartodb",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "description": "A map tile server for CartoDB",
   "keywords": [
     "cartodb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@
     nan "2.10.0"
     node-pre-gyp "0.10.0"
 
-"@carto/tilelive-bridge@cartodb/tilelive-bridge#2.5.1-cdb10":
+"@carto/tilelive-bridge@github:cartodb/tilelive-bridge#2.5.1-cdb10":
   version "2.5.1-cdb10"
   resolved "https://codeload.github.com/cartodb/tilelive-bridge/tar.gz/118ac7e7f6582ac7be0fc0246ea2afd1a7795a43"
   dependencies:
@@ -26,7 +26,7 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz#70237b9774095ed1cfdbcea7a8fd1fc82b2691f2"
 
-abaculus@cartodb/abaculus#2.0.3-cdb11:
+"abaculus@github:cartodb/abaculus#2.0.3-cdb11":
   version "2.0.3-cdb11"
   resolved "https://codeload.github.com/cartodb/abaculus/tar.gz/b2d4dce48c50fefc5b06f21c6365d82ccf75358d"
   dependencies:
@@ -275,7 +275,7 @@ camshaft@0.62.3:
     dot "^1.0.3"
     request "2.85.0"
 
-canvas@cartodb/node-canvas#1.6.2-cdb2:
+"canvas@github:cartodb/node-canvas#1.6.2-cdb2":
   version "1.6.2-cdb2"
   resolved "https://codeload.github.com/cartodb/node-canvas/tar.gz/8acf04557005c633f9e68524488a2657c04f3766"
   dependencies:
@@ -293,17 +293,17 @@ carto@0.16.3:
     semver "^5.1.0"
     yargs "^4.2.0"
 
-carto@cartodb/carto#0.15.1-cdb3:
-  version "0.15.1-cdb3"
-  resolved "https://codeload.github.com/cartodb/carto/tar.gz/945f5efb74fd1af1f5e1f69f409f9567f94fb5a7"
+carto@cartodb/carto#master:
+  version "0.15.1"
+  resolved "https://codeload.github.com/cartodb/carto/tar.gz/31abb8bee02df605521247b0223d508320f7d4c8"
   dependencies:
     mapnik-reference "~6.0.2"
     optimist "~0.6.0"
     underscore "1.8.3"
 
-carto@cartodb/carto#master:
-  version "0.15.1"
-  resolved "https://codeload.github.com/cartodb/carto/tar.gz/31abb8bee02df605521247b0223d508320f7d4c8"
+"carto@github:cartodb/carto#0.15.1-cdb3":
+  version "0.15.1-cdb3"
+  resolved "https://codeload.github.com/cartodb/carto/tar.gz/945f5efb74fd1af1f5e1f69f409f9567f94fb5a7"
   dependencies:
     mapnik-reference "~6.0.2"
     optimist "~0.6.0"
@@ -2580,7 +2580,7 @@ through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-tilelive-mapnik@cartodb/tilelive-mapnik#0.6.18-cdb15:
+"tilelive-mapnik@github:cartodb/tilelive-mapnik#0.6.18-cdb15":
   version "0.6.18-cdb15"
   resolved "https://codeload.github.com/cartodb/tilelive-mapnik/tar.gz/b6c1404a9e37fc60e545d977081867a86eb42b2b"
   dependencies:
@@ -2759,9 +2759,9 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
-windshaft@cartodb/Windshaft#remove-step:
+windshaft@4.10.0:
   version "4.10.0"
-  resolved "https://codeload.github.com/cartodb/Windshaft/tar.gz/822362f16cd20b3689685ae5849ccda24b9952ca"
+  resolved "https://registry.yarnpkg.com/windshaft/-/windshaft-4.10.0.tgz#ed9e1117b7d9ab035c93dbb4f11c1b7046a43edf"
   dependencies:
     "@carto/mapnik" "3.6.2-carto.11"
     "@carto/tilelive-bridge" cartodb/tilelive-bridge#2.5.1-cdb10

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@
     nan "2.10.0"
     node-pre-gyp "0.10.0"
 
-"@carto/tilelive-bridge@github:cartodb/tilelive-bridge#2.5.1-cdb10":
+"@carto/tilelive-bridge@cartodb/tilelive-bridge#2.5.1-cdb10":
   version "2.5.1-cdb10"
   resolved "https://codeload.github.com/cartodb/tilelive-bridge/tar.gz/118ac7e7f6582ac7be0fc0246ea2afd1a7795a43"
   dependencies:
@@ -26,7 +26,7 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz#70237b9774095ed1cfdbcea7a8fd1fc82b2691f2"
 
-"abaculus@github:cartodb/abaculus#2.0.3-cdb11":
+abaculus@cartodb/abaculus#2.0.3-cdb11:
   version "2.0.3-cdb11"
   resolved "https://codeload.github.com/cartodb/abaculus/tar.gz/b2d4dce48c50fefc5b06f21c6365d82ccf75358d"
   dependencies:
@@ -275,7 +275,7 @@ camshaft@0.62.3:
     dot "^1.0.3"
     request "2.85.0"
 
-"canvas@github:cartodb/node-canvas#1.6.2-cdb2":
+canvas@cartodb/node-canvas#1.6.2-cdb2:
   version "1.6.2-cdb2"
   resolved "https://codeload.github.com/cartodb/node-canvas/tar.gz/8acf04557005c633f9e68524488a2657c04f3766"
   dependencies:
@@ -293,17 +293,17 @@ carto@0.16.3:
     semver "^5.1.0"
     yargs "^4.2.0"
 
-carto@cartodb/carto#master:
-  version "0.15.1"
-  resolved "https://codeload.github.com/cartodb/carto/tar.gz/31abb8bee02df605521247b0223d508320f7d4c8"
+carto@cartodb/carto#0.15.1-cdb3:
+  version "0.15.1-cdb3"
+  resolved "https://codeload.github.com/cartodb/carto/tar.gz/945f5efb74fd1af1f5e1f69f409f9567f94fb5a7"
   dependencies:
     mapnik-reference "~6.0.2"
     optimist "~0.6.0"
     underscore "1.8.3"
 
-"carto@github:cartodb/carto#0.15.1-cdb3":
-  version "0.15.1-cdb3"
-  resolved "https://codeload.github.com/cartodb/carto/tar.gz/945f5efb74fd1af1f5e1f69f409f9567f94fb5a7"
+carto@cartodb/carto#master:
+  version "0.15.1"
+  resolved "https://codeload.github.com/cartodb/carto/tar.gz/31abb8bee02df605521247b0223d508320f7d4c8"
   dependencies:
     mapnik-reference "~6.0.2"
     optimist "~0.6.0"
@@ -1432,7 +1432,7 @@ mapnik-reference@~8.5.3:
   dependencies:
     semver "^5.1.0"
 
-"mapnik-vector-tile@github:cartodb/mapnik-vector-tile#v1.6.1-carto.2":
+mapnik-vector-tile@cartodb/mapnik-vector-tile#v1.6.1-carto.2:
   version "1.6.1-carto.2"
   resolved "https://codeload.github.com/cartodb/mapnik-vector-tile/tar.gz/e7ca5471f9e5de81243e6035e70444321fc0a82f"
 
@@ -2580,7 +2580,7 @@ through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-"tilelive-mapnik@github:cartodb/tilelive-mapnik#0.6.18-cdb15":
+tilelive-mapnik@cartodb/tilelive-mapnik#0.6.18-cdb15:
   version "0.6.18-cdb15"
   resolved "https://codeload.github.com/cartodb/tilelive-mapnik/tar.gz/b6c1404a9e37fc60e545d977081867a86eb42b2b"
   dependencies:
@@ -2759,9 +2759,9 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
-windshaft@4.9.0:
+windshaft@cartodb/Windshaft#remove-step:
   version "4.9.0"
-  resolved "https://registry.yarnpkg.com/windshaft/-/windshaft-4.9.0.tgz#adaeb7adcbe45aa9f196292b7130f255d39513b1"
+  resolved "https://codeload.github.com/cartodb/Windshaft/tar.gz/d8bd1b19a8b500b2fe2d6cd4044765139b96e55e"
   dependencies:
     "@carto/mapnik" "3.6.2-carto.11"
     "@carto/tilelive-bridge" cartodb/tilelive-bridge#2.5.1-cdb10

--- a/yarn.lock
+++ b/yarn.lock
@@ -2760,8 +2760,8 @@ window-size@^0.2.0:
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
 windshaft@cartodb/Windshaft#remove-step:
-  version "4.9.0"
-  resolved "https://codeload.github.com/cartodb/Windshaft/tar.gz/d8bd1b19a8b500b2fe2d6cd4044765139b96e55e"
+  version "4.10.0"
+  resolved "https://codeload.github.com/cartodb/Windshaft/tar.gz/822362f16cd20b3689685ae5849ccda24b9952ca"
   dependencies:
     "@carto/mapnik" "3.6.2-carto.11"
     "@carto/tilelive-bridge" cartodb/tilelive-bridge#2.5.1-cdb10
@@ -2777,7 +2777,6 @@ windshaft@cartodb/Windshaft#remove-step:
     request "2.87.0"
     semver "5.5.0"
     sphericalmercator "1.0.5"
-    step "1.0.0"
     tilelive "5.12.3"
     tilelive-mapnik cartodb/tilelive-mapnik#0.6.18-cdb15
     torque.js "2.16.2"


### PR DESCRIPTION
Upgrades Windshaft version: remove step https://github.com/CartoDB/Windshaft/issues/644

Pending: 
- [x] Wait until Windshaft new version is deployed and use it here
- [x] Update NEWS