### PR TITLE
Update windshaft with a patch fo pg-mvt renderer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ New features
 - Use overviews query rewriter for mvt-renderer. Upgrades Windshaft to [4.11.1](https://github.com/CartoDB/Windshaft/blob/4.11.0/NEWS.md#version-4111)
   - `pg-mvt`: Use `query-rewriter` to compose the query to render a MVT tile. If not defined, it will use a Default Query Rewriter.
   - `pg-mvt`: Fix bug while building query and there is no columns defined for the layer.
+  - `pg-mvt`: Accept trailing semicolon in input queries.
 
 ## 6.4.0
 Released 2018-09-24

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "step-profiler": "0.3.0",
     "turbo-carto": "0.20.4",
     "underscore": "1.6.0",
-    "windshaft": "4.11.1",
+    "windshaft": "4.11.2",
     "yargs": "11.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update windshaft to version 4.11.2, which contains a patch that makes
the pg-mvt renderer accept a trailing semicolon in the input query.