### PR TITLE
Prevent "Cannot read property 'geom_type' of undefined" on layer stats

### DIFF
--- a/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
+++ b/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
@@ -71,7 +71,7 @@ function _geometryType(ctx) {
         const geometryColumn = AggregationMapConfig.getAggregationGeometryColumn();
         const sqlQuery = _getSQL(ctx, sql => queryUtils.getQueryGeometryType(sql, geometryColumn));
         return queryUtils.queryPromise(ctx.dbConnection, sqlQuery)
-            .then(res => ({ geometryType: res.rows[0].geom_type }));
+            .then(res => ({ geometryType: (res.rows[0] || {}).geom_type }));
     }
     return Promise.resolve();
 }

--- a/test/acceptance/stats/mapnik_stats_layergroup.js
+++ b/test/acceptance/stats/mapnik_stats_layergroup.js
@@ -2,14 +2,32 @@ require('../../support/test_helper');
 
 var assert = require('../../support/assert');
 var TestClient = require('../../support/test-client');
+const serverOptions = require('../../../lib/cartodb/server_options');
 
-describe('Create mapnik layergroup', function() {
+const suites = [{
+    desc: 'mvt (mapnik)',
+    usePostGIS: false
+}];
+
+if (process.env.POSTGIS_VERSION >= '20400') {
+    suites.push({
+        desc: 'mvt (postgis)',
+        usePostGIS: true
+    });
+}
+
+suites.forEach(({desc, usePostGIS}) => {
+describe(`[${desc}] Create mapnik layergroup`, function() {
+    const originalUsePostGIS = serverOptions.renderer.mvt.usePostGIS;
+
     before(function() {
+        serverOptions.renderer.mvt.usePostGIS = usePostGIS;
         this.layerStatsConfig = global.environment.enabledFeatures.layerStats;
         global.environment.enabledFeatures.layerStats = true;
     });
 
     after(function() {
+        serverOptions.renderer.mvt.usePostGIS = originalUsePostGIS;
         global.environment.enabledFeatures.layerStats = this.layerStatsConfig;
     });
 
@@ -613,4 +631,5 @@ describe('Create mapnik layergroup', function() {
         });
     });
 
+});
 });

--- a/test/acceptance/stats/mapnik_stats_layergroup.js
+++ b/test/acceptance/stats/mapnik_stats_layergroup.js
@@ -556,7 +556,6 @@ describe(`[${desc}] Create mapnik layergroup`, function() {
         testClient.getLayergroup(function(err, layergroup) {
             assert.ifError(err);
             assert.equal(layergroup.metadata.layers[0].id, mapnikBasicLayerId(0));
-            assert.equal(layergroup.metadata.layers[0].meta.stats.estimatedFeatureCount, 0);
             assert.equal(layergroup.metadata.layers[0].meta.stats.geometryType, undefined);
             testClient.drain(done);
         });

--- a/test/acceptance/stats/mapnik_stats_layergroup.js
+++ b/test/acceptance/stats/mapnik_stats_layergroup.js
@@ -519,6 +519,31 @@ describe('Create mapnik layergroup', function() {
         });
     });
 
+    it(`should not fail "TypeError: ... 'geom_type' of undefined" for empty results`, function(done) {
+        var testClient = new TestClient({
+            version: '1.8.0',
+            layers: [
+                {
+                    type: 'mapnik',
+                    options: {
+                        sql: 'select * from test_table where false',
+                        metadata: {
+                            geometryType: true
+                        }
+                    }
+                }
+            ]
+        });
+
+        testClient.getLayergroup(function(err, layergroup) {
+            assert.ifError(err);
+            assert.equal(layergroup.metadata.layers[0].id, mapnikBasicLayerId(0));
+            assert.equal(layergroup.metadata.layers[0].meta.stats.estimatedFeatureCount, 0);
+            assert.equal(layergroup.metadata.layers[0].meta.stats.geometryType, undefined);
+            testClient.drain(done);
+        });
+    });
+
     it('should provide a sample as optional metadata', function(done) {
         var testClient = new TestClient({
             version: '1.4.0',


### PR DESCRIPTION
The server responds with a 400 error due to a TypeError, this avoids that and returns a valid response without the geometryType metadata.

This will help with https://github.com/CartoDB/carto-vl/issues/1049.