### PR TITLE
Fix for non-deterministic test (undefined server)

### DIFF
--- a/test/acceptance/ported/support/test_client.js
+++ b/test/acceptance/ported/support/test_client.js
@@ -129,7 +129,7 @@ function serverInstance(options) {
         return otherServer;
     }
 
-    return server;
+    return getServer();
 }
 
 function layergroupRequest(layergroupConfig, method, callbackName, extraParams) {


### PR DESCRIPTION
When running tests I got this error:

```
  1) multilayer error cases bogus sql raises 400 status code:
     TypeError: Cannot read property 'listen' of undefined
      at Function.assert.response (test/support/assert.js:93:26)
      at Function.requestLayergroup (test/acceptance/ported/support/test_client.js:79:20)
      at next (node_modules/step/lib/step.js:51:23)
      at Step (node_modules/step/lib/step.js:122:3)
      at Object.createLayergroup (test/acceptance/ported/support/test_client.js:75:5)
      at Context.<anonymous> (test/acceptance/ported/multilayer_error_cases.js:304:20)
```

The problem is that `server` is declared but its initialization
may depend on the order of execution of suites, which is basically
that of the filesystem/checkouts.

That is fixed by returning `getServer()`, which seems to be the
original intent: return a singleton of `CartodbServer` properly
initialized in case it is not overriden through options.