### PR TITLE
Fix iso format for hours in time dimensions

### DIFF
--- a/lib/cartodb/models/aggregation/time-dimension.js
+++ b/lib/cartodb/models/aggregation/time-dimension.js
@@ -129,9 +129,9 @@ function serialSqlExpr(params) {
 }
 
 const isoParts = {
-    second: `to_char($t, 'YYYY-MM-DD"T"HH:MI:SS')`,
-    minute: `to_char($t, 'YYYY-MM-DD"T"HH:MI')`,
-    hour: `to_char($t, 'YYYY-MM-DD"T"HH')`,
+    second: `to_char($t, 'YYYY-MM-DD"T"HH24:MI:SS')`,
+    minute: `to_char($t, 'YYYY-MM-DD"T"HH24:MI')`,
+    hour: `to_char($t, 'YYYY-MM-DD"T"HH24')`,
     day: `to_char($t, 'YYYY-MM-DD')`,
     month: `to_char($t, 'YYYY-MM')`,
     year: `to_char($t, 'YYYY')`,


### PR DESCRIPTION
The HH specifies hour of day 01-12, we need HH24 for 00-23

So we were getting am & pm hours mixed up.