### PR TITLE
Update cartodb-psql to 0.13.1 and related reverse dependenciess

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@ New features
   - Upgrade grainstore to [1.10.0](https://github.com/CartoDB/grainstore/releases/tag/1.10.0)
 - Upgrade cartodb-redis to [2.1.0](https://github.com/CartoDB/node-cartodb-redis/releases/tag/2.1.0)
 - Upgrade cartodb-query-tables to [0.4.0](https://github.com/CartoDB/node-cartodb-query-tables/releases/tag/0.4.0)
-- Upgrade cartodb-psql to [0.13.0](https://github.com/CartoDB/node-cartodb-psql/releases/tag/0.13.0)
+- Upgrade cartodb-psql to [0.13.1](https://github.com/CartoDB/node-cartodb-psql/releases/tag/0.13.1)
 - Upgrade turbo-carto to [0.21.0](https://github.com/CartoDB/turbo-carto/releases/tag/0.21.0)
 - Upgrade camshaft to [0.63.0](https://github.com/CartoDB/camshaft/releases/tag/0.63.0)
 - Upgrade redis-mpool to [0.7.0](https://github.com/CartoDB/node-redis-mpool/releases/tag/0.7.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ New features
 - Configure travis to run docker tests against Node.js 6 & 10 versions
 - Aggregation time dimensions
 - Update sample configurations to use PostGIS to generate MVT's by default (as in production)
-- Upgrades Windshaft to [4.12.0](https://github.com/CartoDB/Windshaft/blob/4.12.0/NEWS.md#version-4120)
+- Upgrades Windshaft to [4.12.1](https://github.com/CartoDB/Windshaft/blob/4.12.1/NEWS.md#version-4121)
   - `pg-mvt`: Use `query-rewriter` to compose the query to render a MVT tile. If not defined, it will use a Default Query Rewriter.
   - `pg-mvt`: Fix bug while building query and there is no columns defined for the layer.
   - `pg-mvt`: Accept trailing semicolon in input queries.
@@ -19,7 +19,7 @@ New features
 - Upgrade cartodb-query-tables to [0.4.0](https://github.com/CartoDB/node-cartodb-query-tables/releases/tag/0.4.0)
 - Upgrade cartodb-psql to [0.13.1](https://github.com/CartoDB/node-cartodb-psql/releases/tag/0.13.1)
 - Upgrade turbo-carto to [0.21.0](https://github.com/CartoDB/turbo-carto/releases/tag/0.21.0)
-- Upgrade camshaft to [0.63.0](https://github.com/CartoDB/camshaft/releases/tag/0.63.0)
+- Upgrade camshaft to [0.63.1](https://github.com/CartoDB/camshaft/releases/tag/0.63.1)
 - Upgrade redis-mpool to [0.7.0](https://github.com/CartoDB/node-redis-mpool/releases/tag/0.7.0)
 
 Bug Fixes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -296,13 +296,13 @@
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
     },
     "camshaft": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/camshaft/-/camshaft-0.63.0.tgz",
-      "integrity": "sha512-od8nWaOpZ4QdxptW2A7iT7XjWPvycRbhcz6txzf/iukPKtRNZgW6T1Ds/6P5zEi3+3V/Ynj2EBxgPSe/w5+0GQ==",
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/camshaft/-/camshaft-0.63.1.tgz",
+      "integrity": "sha512-+vjDZtsD8CGhz2WBULvj272/0uachFuc+BDTSvhfEYz/zJGMdJCGTe6UPINsMv7ntq67pefZXX5fjPlPsBS9SQ==",
       "requires": {
         "async": "^1.5.2",
         "bunyan": "1.8.1",
-        "cartodb-psql": "0.13.0",
+        "cartodb-psql": "0.13.1",
         "debug": "^3.1.0",
         "dot": "^1.0.3",
         "request": "2.85.0"
@@ -371,9 +371,9 @@
       }
     },
     "cartodb-psql": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.13.0.tgz",
-      "integrity": "sha512-+MBxpgijBgSgXciuwUMGedVB1lABToySoxipODB8YasRc3X15oVSSku9WcMYICnZZg1x2b2Sq4POazBAYoVHxA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.13.1.tgz",
+      "integrity": "sha512-1z3Dk9G8KQlNGurbcmGBvNj8DVCh1Keue9uzyyvB6hKOYzBHMxixAMG0D+8nSsA7oQmWUsx/xkZZ5ZxT9toEHA==",
       "requires": {
         "debug": "^3.1.0",
         "pg": "github:cartodb/node-postgres#5417d7b29b7272ca2e71bb396899ab3f177a9ae6",
@@ -3813,16 +3813,16 @@
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
     },
     "windshaft": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-4.12.0.tgz",
-      "integrity": "sha512-8hfFMXGA8L3RR21wOoayoIVFCWVWESdJZNzYxaXEqJBqa4qxZgZXmVv4j4qu2EUsV2rUGbDbNpeEm/RUGUMGGg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-4.12.1.tgz",
+      "integrity": "sha512-sXsSjyTUS3cHGSzHVYKOqB/cpgyGHD9UJiNFLOPHVPur4M2hJvH0kwHvYmsdxr74xtFUxeV6XJMqYaEmIX6mCw==",
       "requires": {
         "@carto/mapnik": "3.6.2-carto.11",
         "@carto/tilelive-bridge": "github:cartodb/tilelive-bridge#e35ae36a6e2d555a6b312440f7e1904c5ad03664",
         "abaculus": "github:cartodb/abaculus#3283c523d8bd4bdec78d90166d9c23ff09865ca8",
         "canvas": "github:cartodb/node-canvas#45bd3c7cc5e6f99ba75b0d417b6ac6384b43083d",
         "carto": "github:cartodb/carto#85881d99dd7fcf2c4e16478b04db67108d27a50c",
-        "cartodb-psql": "0.13.0",
+        "cartodb-psql": "0.13.1",
         "debug": "3.1.0",
         "dot": "1.1.2",
         "grainstore": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "@carto/fqdn-sync": "0.2.2",
     "basic-auth": "2.0.0",
     "body-parser": "1.18.3",
-    "camshaft": "0.63.0",
-    "cartodb-psql": "0.13.0",
+    "camshaft": "0.63.1",
+    "cartodb-psql": "0.13.1",
     "cartodb-query-tables": "0.4.0",
     "cartodb-redis": "2.1.0",
     "debug": "3.1.0",
@@ -48,7 +48,7 @@
     "step-profiler": "0.3.0",
     "turbo-carto": "0.21.0",
     "underscore": "1.6.0",
-    "windshaft": "4.12.0",
+    "windshaft": "4.12.1",
     "yargs": "11.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,13 +246,13 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-camshaft@0.63.0:
-  version "0.63.0"
-  resolved "https://registry.yarnpkg.com/camshaft/-/camshaft-0.63.0.tgz#944b207aa942c3bd3229c460042d80cbef6fbc67"
+camshaft@0.63.1:
+  version "0.63.1"
+  resolved "https://registry.yarnpkg.com/camshaft/-/camshaft-0.63.1.tgz#abdcf4c5e9fad8b1192a7e9d083b2b8b552eef1c"
   dependencies:
     async "^1.5.2"
     bunyan "1.8.1"
-    cartodb-psql "0.13.0"
+    cartodb-psql "0.13.1"
     debug "^3.1.0"
     dot "^1.0.3"
     request "2.85.0"
@@ -275,7 +275,7 @@ carto@0.16.3:
     semver "^5.1.0"
     yargs "^4.2.0"
 
-"carto@github:cartodb/carto#0.15.1-cdb5", "carto@github:cartodb/carto#master":
+carto@cartodb/carto#master, "carto@github:cartodb/carto#0.15.1-cdb5":
   version "0.15.1-cdb5"
   resolved "https://codeload.github.com/cartodb/carto/tar.gz/85881d99dd7fcf2c4e16478b04db67108d27a50c"
   dependencies:
@@ -289,9 +289,9 @@ cartocolor@4.0.0:
   dependencies:
     colorbrewer "1.0.0"
 
-cartodb-psql@0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/cartodb-psql/-/cartodb-psql-0.13.0.tgz#1f07ced2dfbd80a54f1b411ca6e38b7f685efedc"
+cartodb-psql@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/cartodb-psql/-/cartodb-psql-0.13.1.tgz#74abfe71c9a5e0ad3bf287b66b90d13772f25544"
   dependencies:
     debug "^3.1.0"
     pg "github:cartodb/node-postgres#6.4.2-cdb2"
@@ -1354,7 +1354,7 @@ mapnik-reference@~8.5.3:
   dependencies:
     semver "^5.1.0"
 
-"mapnik-vector-tile@github:cartodb/mapnik-vector-tile#v1.6.1-carto.2":
+mapnik-vector-tile@cartodb/mapnik-vector-tile#v1.6.1-carto.2:
   version "1.6.1-carto.2"
   resolved "https://codeload.github.com/cartodb/mapnik-vector-tile/tar.gz/e7ca5471f9e5de81243e6035e70444321fc0a82f"
 
@@ -2667,16 +2667,16 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
-windshaft@4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/windshaft/-/windshaft-4.12.0.tgz#b42c6bc5703121d180b7e323661c3656d8198d67"
+windshaft@4.12.1:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/windshaft/-/windshaft-4.12.1.tgz#2b2d80e7a2ccbdc9487e0f02e9ed475b2f543dc9"
   dependencies:
     "@carto/mapnik" "3.6.2-carto.11"
     "@carto/tilelive-bridge" cartodb/tilelive-bridge#2.5.1-cdb11
     abaculus "github:cartodb/abaculus#2.0.3-cdb13"
     canvas "github:cartodb/node-canvas#1.6.2-cdb3"
     carto "github:cartodb/carto#0.15.1-cdb5"
-    cartodb-psql "0.13.0"
+    cartodb-psql "0.13.1"
     debug "3.1.0"
     dot "1.1.2"
     grainstore "1.10.0"


### PR DESCRIPTION
Related to CartoDB/node-cartodb-psql#38 and similar to what was done for the SQL API.