### PR TITLE
Adapt to extension changes

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,6 @@ OPT_CREATE_PGSQL=yes # create the PostgreSQL test environment
 OPT_DROP_REDIS=yes   # drop the redis test environment
 OPT_DROP_PGSQL=yes   # drop the PostgreSQL test environment
 OPT_COVERAGE=no      # run tests with coverage
-OPT_DOWNLOAD_SQL=yes # download a fresh copy of sql files
 OPT_REDIS_CELL=yes   # download redis cell
 
 export PGAPPNAME=cartodb_tiler_tester
@@ -75,10 +74,6 @@ while [ -n "$1" ]; do
                 OPT_CREATE_REDIS=no
                 shift
                 continue
-        elif test "$1" = "--no-sql-download"; then
-                OPT_DOWNLOAD_SQL=no
-                shift
-                continue
         elif test "$1" = "--with-coverage"; then
                 OPT_COVERAGE=yes
                 shift
@@ -128,9 +123,6 @@ if test x"$OPT_CREATE_PGSQL" != xyes; then
 fi
 if test x"$OPT_CREATE_REDIS" != xyes; then
   PREPARE_DB_OPTS="$PREPARE_DB_OPTS --skip-redis"
-fi
-if test x"$OPT_DOWNLOAD_SQL" != xyes; then
-  PREPARE_DB_OPTS="$PREPARE_DB_OPTS --no-sql-download"
 fi
 
 echo "Preparing the environment"

--- a/run_tests_docker.sh
+++ b/run_tests_docker.sh
@@ -4,6 +4,10 @@
 
 source /src/nodejs-install.sh
 
+# Install cartodb-postgresql extension
+git clone https://github.com/CartoDB/cartodb-postgresql.git
+cd cartodb-postgresql && make && make install && cd ..
+
 echo "Node.js version: "
 node -v
 

--- a/test/support/prepare_db.sh
+++ b/test/support/prepare_db.sh
@@ -12,7 +12,6 @@
 
 PREPARE_REDIS=yes
 PREPARE_PGSQL=yes
-DOWNLOAD_SQL_FILES=yes
 
 while [ -n "$1" ]; do
   OPTION=$(echo "$1" | tr -d '[:space:]')
@@ -21,9 +20,6 @@ while [ -n "$1" ]; do
     shift; continue
   elif [[ "$OPTION" == "--skip-redis" ]]; then
     PREPARE_REDIS=no
-    shift; continue
-  elif [[ "$OPTION" == "--no-sql-download" ]]; then
-    DOWNLOAD_SQL_FILES=no
     shift; continue
   else
     shift; continue;
@@ -77,31 +73,16 @@ if test x"$PREPARE_PGSQL" = xyes; then
   echo "preparing postgres..."
   dropdb "${TEST_DB}"
   createdb -Ttemplate_postgis -EUTF8 "${TEST_DB}" || die "Could not create test database"
+  psql -c "CREATE EXTENSION IF NOT EXISTS cartodb CASCADE;" ${TEST_DB}
 
   LOCAL_SQL_SCRIPTS='analysis_catalog windshaft.test gadm4 countries_null_values ported/populated_places_simple_reduced cdb_analysis_check cdb_invalidate_varnish'
-  REMOTE_SQL_SCRIPTS='CDB_QueryStatements CDB_QueryTables CDB_CartodbfyTable CDB_TableMetadata CDB_ForeignTable CDB_UserTables CDB_ColumnNames CDB_ZoomFromScale CDB_OverviewsSupport CDB_Overviews CDB_QuantileBins CDB_JenksBins CDB_HeadsTailsBins CDB_EqualIntervalBins CDB_Hexagon CDB_XYZ CDB_EstimateRowCount CDB_RectangleGrid'
-
-  if test x"$DOWNLOAD_SQL_FILES" = xyes; then
-    CURL_ARGS=""
-    for i in ${REMOTE_SQL_SCRIPTS}
-    do
-        CURL_ARGS="${CURL_ARGS}\"https://github.com/CartoDB/cartodb-postgresql/raw/master/scripts-available/$i.sql\" -o sql/$i.sql "
-    done
-    echo "Downloading and updating: ${REMOTE_SQL_SCRIPTS}"
-    echo ${CURL_ARGS} | xargs curl -L -s
-  fi
-
-  psql -c "CREATE EXTENSION IF NOT EXISTS plpythonu;" ${TEST_DB}
-  ALL_SQL_SCRIPTS="${REMOTE_SQL_SCRIPTS} ${LOCAL_SQL_SCRIPTS}"
-  for i in ${ALL_SQL_SCRIPTS}
+  for i in ${LOCAL_SQL_SCRIPTS}
   do
     cat sql/${i}.sql |
-      sed -e 's/cartodb\./public./g' -e "s/''cartodb''/''public''/g" |
-      sed -e 's/@extschema@/public/g' -e 's/@postgisschema@/public/g' |
-      sed "s/:PUBLICUSER/${PUBLICUSER}/" |
-      sed "s/:PUBLICPASS/${PUBLICPASS}/" |
-      sed "s/:TESTUSER/${TESTUSER}/" |
-      sed "s/:TESTPASS/${TESTPASS}/" |
+      sed -e "s/:PUBLICUSER/${PUBLICUSER}/g" |
+      sed -e "s/:PUBLICPASS/${PUBLICPASS}/g" |
+      sed -e "s/:TESTUSER/${TESTUSER}/g" |
+      sed -e "s/:TESTPASS/${TESTPASS}/g" |
       PGOPTIONS='--client-min-messages=WARNING' psql -q -v ON_ERROR_STOP=1 ${TEST_DB} > /dev/null || exit 1
   done
 fi

--- a/test/support/prepare_db.sh
+++ b/test/support/prepare_db.sh
@@ -97,6 +97,7 @@ if test x"$PREPARE_PGSQL" = xyes; then
   do
     cat sql/${i}.sql |
       sed -e 's/cartodb\./public./g' -e "s/''cartodb''/''public''/g" |
+      sed -e 's/@extschema@/public/g' -e 's/@postgisschema@/public/g' |
       sed "s/:PUBLICUSER/${PUBLICUSER}/" |
       sed "s/:PUBLICPASS/${PUBLICPASS}/" |
       sed "s/:TESTUSER/${TESTUSER}/" |

--- a/test/support/sql/windshaft.test.sql
+++ b/test/support/sql/windshaft.test.sql
@@ -11,17 +11,21 @@ SET standard_conforming_strings = off;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET escape_string_warning = off;
-SET search_path = public, pg_catalog;
+SET search_path = public, cartodb, pg_catalog;
 SET default_tablespace = '';
 SET default_with_oids = false;
 
 -- public user role
 DROP USER IF EXISTS :PUBLICUSER;
 CREATE USER :PUBLICUSER WITH PASSWORD ':PUBLICPASS';
+GRANT USAGE ON SCHEMA cartodb TO :PUBLICUSER;
+GRANT ALL ON CDB_TableMetadata TO :PUBLICUSER;
 
 -- db owner role
 DROP USER IF EXISTS :TESTUSER;
 CREATE USER :TESTUSER WITH PASSWORD ':TESTPASS';
+GRANT USAGE ON SCHEMA cartodb TO :TESTUSER;
+GRANT ALL ON CDB_TableMetadata TO :TESTUSER;
 
 -- regular user role 1
 DROP USER IF EXISTS test_windshaft_regular1;
@@ -183,12 +187,6 @@ CREATE TABLE test_table_private_1 (
 INSERT INTO test_table_private_1 SELECT * from test_table;
 
 GRANT ALL ON TABLE test_table_private_1 TO :TESTUSER;
-
-CREATE TABLE IF NOT EXISTS
-  CDB_TableMetadata (
-    tabname regclass not null primary key,
-    updated_at timestamp with time zone not null default now()
-  );
 
 INSERT INTO CDB_TableMetadata (tabname, updated_at) VALUES ('test_table'::regclass, '2009-02-13T23:31:30.123Z');
 INSERT INTO CDB_TableMetadata (tabname, updated_at) VALUES ('test_table_private_1'::regclass, '2009-02-13T23:31:30.123Z');


### PR DESCRIPTION
The extension now fully qualifies all calls (to avoid issues with pg_upgrade) by using `@extschema@` for extension functions or @postgisschema@ for postgis functions (usually replaced by `cartodb` and `public` respectively).

This meant that we had to add another hack to the .sql parsing mechanism, and I had to also look for a way to make the extension work in `public` and not in `cartodb`, but instead of doing that I decided to remove all direct file download and parsing and instead ask for the extension to be available.