### PR TITLE
carto-package.json: Update mapnik dependency to match what's installed

### DIFF
--- a/carto-package.json
+++ b/carto-package.json
@@ -4,7 +4,7 @@
         "requires": {
             "node": "^10.15.1",
             "npm": "^6.4.1",
-            "mapnik": "==3.0.15.9",
+            "mapnik": "==3.0.15.16",
             "crankshaft": "~0.8.1"
         },
         "works_with": {


### PR DESCRIPTION
We are currently installing node-mapnik `3.6.2-carto.15` which is using mapnik v3.0.15.16.