### PR TITLE
Fix cURL docs for Windows users by using files

### DIFF
--- a/docs/reference/swagger.yaml
+++ b/docs/reference/swagger.yaml
@@ -90,10 +90,26 @@ paths:
       x-code-samples:
         - lang: Curl
           source: |
-            curl -X POST -H "Content-Type: application/json" -d '{ \
-              "q": "SELECT count(*) FROM cities", \
-              "filename": "number_of_cities.json" \
-            }' "https://username.carto.com/api/v2/sql"
+            # body.json
+            {
+              "version": "1.3.0",
+              "layers": [
+                {
+                  "type": "mapnik",
+                  "options": {
+                    "cartocss_version": "2.1.1",
+                    "cartocss": "#layer { polygon-fill: #FFF; }",
+                    "sql": "select * from european_countries_e",
+                    "interactivity": [
+                      "cartodb_id",
+                      "iso3"
+                    ]
+                  }
+                }
+              ]
+            }
+
+            curl -X POST -H "Content-Type: application/json" -d @body.json "https://username.carto.com/api/v2/sql"
   '/map/{layergroupid}/{z}/{x}/{y}.png':
     get:
       parameters:
@@ -277,57 +293,60 @@ paths:
       x-code-samples:
         - lang: Curl
           source: |
-            curl -X POST -H "Content-Type: application/json" -d '{ \
-              "version": "0.0.1", \
-              "name": "template_name", \
-              "auth": { \
-                "method": "token", \
-                "valid_tokens": [ \
-                  "auth_token1", \
-                  "auth_token2" \
-                ] \
-              }, \
-              "placeholders": { \
-                "color": { \
-                  "type": "css_color", \
-                  "default": "red" \
-                }, \
-                "cartodb_id": { \
-                  "type": "number", \
-                  "default": 1 \
-                } \
-              }, \
-              "layergroup": { \
-                "version": "1.7.0", \
-                "layers": [ \
-                  { \
-                    "type": "cartodb", \
-                    "options": { \
-                      "cartocss_version": "2.3.0", \
-                      "cartocss": "#layer { polygon-fill: <%= color %>; }", \
-                      "sql": "select * from european_countries_e WHERE cartodb_id = <%= cartodb_id %>" \
-                    } \
-                  } \
-                ] \
-              }, \
-              "view": { \
-                "zoom": 4, \
-                "center": { \
-                  "lng": 0, \
-                  "lat": 0 \
-                }, \
-                "bounds": { \
-                  "west": -45, \
-                  "south": -45, \
-                  "east": 45, \
-                  "north": 45 \
-                }, \
-                "preview_layers": { \
-                  "0": true, \
-                  "layer1": false \
-                } \
-              } \
-            }' "https://{username}.carto.com/api/v1/map/named?api_key={api_key}"
+            # body.json
+            {
+              "version": "0.0.1",
+              "name": "template_name",
+              "auth": {
+                "method": "token",
+                "valid_tokens": [
+                  "auth_token1",
+                  "auth_token2"
+                ]
+              },
+              "placeholders": {
+                "color": {
+                  "type": "css_color",
+                  "default": "red"
+                },
+                "cartodb_id": {
+                  "type": "number",
+                  "default": 1
+                }
+              },
+              "layergroup": {
+                "version": "1.7.0",
+                "layers": [
+                  {
+                    "type": "cartodb",
+                    "options": {
+                      "cartocss_version": "2.3.0",
+                      "cartocss": "#layer { polygon-fill: <%= color %>; }",
+                      "sql": "select * from european_countries_e WHERE cartodb_id = <%= cartodb_id %>"
+                    }
+                  }
+                ]
+              },
+              "view": {
+                "zoom": 4,
+                "center": {
+                  "lng": 0,
+                  "lat": 0
+                },
+                "bounds": {
+                  "west": -45,
+                  "south": -45,
+                  "east": 45,
+                  "north": 45
+                },
+                "preview_layers": {
+                  "0": true,
+                  "layer1": false
+                }
+              }
+            }
+
+            curl -X POST -H "Content-Type: application/json" -d @body.json "https://{username}.carto.com/api/v1/map/named?api_key={api_key}"
     get:
       summary: List user's templates
       description: |
@@ -424,59 +443,62 @@ paths:
       x-code-samples:
         - lang: Curl
           source: |
+            # body.json
+            {
+              "version": "0.0.1",
+              "name": "template_name",
+              "auth": {
+                "method": "token",
+                "valid_tokens": [
+                  "auth_token1",
+                  "auth_token2"
+                ]
+              },
+              "placeholders": {
+                "color": {
+                  "type": "css_color",
+                  "default": "red"
+                },
+                "cartodb_id": {
+                  "type": "number",
+                  "default": 1
+                }
+              },
+              "layergroup": {
+                "version": "1.7.0",
+                "layers": [
+                  {
+                    "type": "cartodb",
+                    "options": {
+                      "cartocss_version": "2.3.0",
+                      "cartocss": "#layer { polygon-fill: <%= color %>; }",
+                      "sql": "select * from european_countries_e WHERE cartodb_id = <%= cartodb_id %>"
+                    }
+                  }
+                ]
+              },
+              "view": {
+                "zoom": 4,
+                "center": {
+                  "lng": 0,
+                  "lat": 0
+                },
+                "bounds": {
+                  "west": -45,
+                  "south": -45,
+                  "east": 45,
+                  "north": 45
+                },
+                "preview_layers": {
+                  "0": true,
+                  "layer1": false
+                }
+              }
+            }
+
             curl -X PUT \
               -H 'Content-Type: application/json' \
-              -d '{ \
-                "version": "0.0.1", \
-                "name": "template_name", \
-                "auth": { \
-                  "method": "token", \
-                  "valid_tokens": [ \
-                    "auth_token1", \
-                    "auth_token2" \
-                  ] \
-                }, \
-                "placeholders": { \
-                  "color": { \
-                    "type": "css_color", \
-                    "default": "red" \
-                  }, \
-                  "cartodb_id": { \
-                    "type": "number", \
-                    "default": 1 \
-                  } \
-                }, \
-                "layergroup": { \
-                  "version": "1.7.0", \
-                  "layers": [ \
-                    { \
-                      "type": "cartodb", \
-                      "options": { \
-                        "cartocss_version": "2.3.0", \
-                        "cartocss": "#layer { polygon-fill: <%= color %>; }", \
-                        "sql": "select * from european_countries_e WHERE cartodb_id = <%= cartodb_id %>" \
-                      } \
-                    } \
-                  ] \
-                }, \
-                "view": { \
-                  "zoom": 4, \
-                  "center": { \
-                    "lng": 0, \
-                    "lat": 0 \
-                  }, \
-                  "bounds": { \
-                    "west": -45, \
-                    "south": -45, \
-                    "east": 45, \
-                    "north": 45 \
-                  }, \
-                  "preview_layers": { \
-                    "0": true, \
-                    "layer1": false \
-                  } \
-                } \
-              }' \
+              -d @body.json
               'https://{username}.carto.com/api/v1/map/named/{template_name}?api_key={api_key}'
     delete:
       summary: Delete template
@@ -548,12 +570,15 @@ paths:
       x-code-samples:
         - lang: Curl
           source: |
+            # body.json
+            {
+              "color": "#ff0000",
+              "cartodb_id": 3
+            }
+
             curl -X POST \
               -H 'Content-Type: application/json' \
-              -d '{ \
-                "color": "#ff0000", \
-                "cartodb_id": 3 \
-              }' \
+              -d @body.json
               'https://{username}.carto.com/api/v1/map/named/{template_name}?auth_token={auth_token}'
   '/map/named/{template_name}/jsonp':
     get:


### PR DESCRIPTION
Related ticket: Cartodb/product#329

We're trying to improve how Windows users use our docs, and the escaping we were using for inline files doesn't work there, so we're going for a -d @filename approach