### PR TITLE
Improve efficiency of query samples (esp. for FDW's)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ Released 2019-XX-XX
 
 Announcements:
 
+- Improved efficiency of query samples while instatiating a map (#1120).
 - Cache control header fine tuning. Set a shorter value for "max-age" directive if there is no way to know when to trigger the invalidation.
 - Update deps:
   - Update `cartodb-query-tables` to version [`0.5.0`](https://github.com/CartoDB/node-cartodb-query-tables/releases/tag/0.5.0)

--- a/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
+++ b/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
@@ -132,9 +132,7 @@ function _sample(ctx) {
         return Promise.resolve();
     }
 
-    // We'll use a safety limit just in case numRows is a bad estimate
-    const requestedRows = ctx.metaOptions.sample.num_rows || DEFAULT_SAMPLE_ROWS;
-    const limit = Math.ceil(requestedRows * 1.5);
+    const limit = ctx.metaOptions.sample.num_rows || DEFAULT_SAMPLE_ROWS;
     const columns = ctx.metaOptions.sample.include_columns;
 
     const sqlMaxMin = _getSQL(ctx, sql => queryUtils.getMaxMinSpanColumnQuery(sql));

--- a/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
+++ b/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
@@ -137,7 +137,7 @@ function _sample(ctx) {
     const limit = Math.ceil(requestedRows * 1.5);
     const columns = ctx.metaOptions.sample.include_columns;
 
-    const sqlMaxMin = _getSQL(ctx, sql => queryUtils.getMaxMinColumnQuery(sql));
+    const sqlMaxMin = _getSQL(ctx, sql => queryUtils.getMaxMinSpanColumnQuery(sql));
     return queryUtils.queryPromise(ctx.dbConnection, sqlMaxMin)
         .then(maxMinRes => {
             const { min_id: min, id_span: span } = maxMinRes.rows[0];

--- a/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
+++ b/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
@@ -125,22 +125,28 @@ function mergeColumns(results) {
     }
 }
 
-const SAMPLE_SEED = 0.5;
 const DEFAULT_SAMPLE_ROWS = 100;
 
-function _sample(ctx, numRows) {
-    if (ctx.metaOptions.sample) {
-        const sampleProb = Math.min(ctx.metaOptions.sample.num_rows / numRows, 1);
-        // We'll use a safety limit just in case numRows is a bad estimate
-        const requestedRows = ctx.metaOptions.sample.num_rows || DEFAULT_SAMPLE_ROWS;
-        const limit = Math.ceil(requestedRows * 1.5);
-        let columns = ctx.metaOptions.sample.include_columns;
-        return queryUtils.queryPromise(ctx.dbConnection, _getSQL(
-            ctx,
-            sql => queryUtils.getQuerySample(sql, sampleProb, limit, SAMPLE_SEED, columns)
-        )).then(res => ({ sample: res.rows }));
+function _sample(ctx) {
+    if (!ctx.metaOptions.sample) {
+        return Promise.resolve();
     }
-    return Promise.resolve();
+
+    // We'll use a safety limit just in case numRows is a bad estimate
+    const requestedRows = ctx.metaOptions.sample.num_rows || DEFAULT_SAMPLE_ROWS;
+    const limit = Math.ceil(requestedRows * 1.5);
+    const columns = ctx.metaOptions.sample.include_columns;
+
+    const sqlMaxMin = _getSQL(ctx, sql => queryUtils.getMaxMinColumnQuery(sql));
+    return queryUtils.queryPromise(ctx.dbConnection, sqlMaxMin)
+        .then(maxMinRes => {
+            const { min_id: min, id_span: span } = maxMinRes.rows[0];
+            const ids = queryUtils.getSampleValuesFromRange(min, span, limit);
+            const sqlSample = _getSQL(ctx, sql => queryUtils.getSampleFromIdsQuery(sql, ids, columns));
+
+            return queryUtils.queryPromise(ctx.dbConnection, sqlSample);
+        })
+        .then(res => ({ sample: res.rows }));
 }
 
 function _columnsMetadataRequired(options) {

--- a/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
+++ b/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
@@ -141,12 +141,24 @@ function _sample(ctx) {
     return queryUtils.queryPromise(ctx.dbConnection, sqlMaxMin)
         .then(maxMinRes => {
             const { min_id: min, id_span: span } = maxMinRes.rows[0];
-            const ids = queryUtils.getSampleValuesFromRange(min, span, limit);
-            const sqlSample = _getSQL(ctx, sql => queryUtils.getSampleFromIdsQuery(sql, ids, columns));
+            const values = _getSampleValuesFromRange(min, span, limit);
+            const sqlSample = _getSQL(ctx, sql => queryUtils.getSampleFromIdsQuery(sql, values, columns));
 
             return queryUtils.queryPromise(ctx.dbConnection, sqlSample);
         })
         .then(res => ({ sample: res.rows }));
+}
+
+function _getSampleValuesFromRange (min, span, limit) {
+    const sample = new Set();
+
+    limit = limit < span ? limit : span;
+
+    while (sample.size < limit) {
+        sample.add(Math.floor(min + Math.random() * span));
+    }
+
+    return Array.from(sample);
 }
 
 function _columnsMetadataRequired(options) {

--- a/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
+++ b/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
@@ -300,8 +300,8 @@ function (layer, dbConnection, callback) {
 
     Promise.all([
         _estimatedFeatureCount(ctx).then(
-            ({ estimatedFeatureCount }) => _sample(ctx, estimatedFeatureCount)
-                .then(sampleResults => mergeResults([sampleResults, { estimatedFeatureCount }]))
+            ({ estimatedFeatureCount }) => _sample(ctx)
+                .then(sampleResults => mergeResults([ sampleResults, { estimatedFeatureCount }] ))
         ),
         _featureCount(ctx),
         _aggrFeatureCount(ctx),

--- a/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
+++ b/lib/cartodb/backends/layer-stats/mapnik-layer-stats.js
@@ -139,6 +139,11 @@ function _sample(ctx) {
     return queryUtils.queryPromise(ctx.dbConnection, sqlMaxMin)
         .then(maxMinRes => {
             const { min_id: min, id_span: span } = maxMinRes.rows[0];
+
+            if (!min || !span) {
+                return { rows: {} };
+            }
+
             const values = _getSampleValuesFromRange(min, span, limit);
             const sqlSample = _getSQL(ctx, sql => queryUtils.getSampleFromIdsQuery(sql, values, columns));
 

--- a/lib/cartodb/utils/query-utils.js
+++ b/lib/cartodb/utils/query-utils.js
@@ -156,7 +156,7 @@ module.exports.getMaxMinColumnQuery = function (query, column = 'cartodb_id') {
             min(${column}) AS min_id,
             max(${column}) AS max_id,
             (max(${column}) - min(${column})) AS id_span
-        FROM (${query}) _cdb_metadata_max_min;
+        FROM (${substituteDummyTokens(query)}) _cdb_metadata_max_min;
     `;
 };
 
@@ -164,7 +164,7 @@ module.exports.getSampleFromIdsQuery = function (query, ids, columns, column = '
     return `
         SELECT
             ${columnSelector(columns)}
-        FROM (${query}) _cdb_metadata_sample
+        FROM (${substituteDummyTokens(query)}) _cdb_metadata_sample
         WHERE ${column} IN (${ids.join(',')})
     `;
 };

--- a/lib/cartodb/utils/query-utils.js
+++ b/lib/cartodb/utils/query-utils.js
@@ -160,18 +160,6 @@ module.exports.getMaxMinColumnQuery = function (query, column = 'cartodb_id') {
     `;
 };
 
-module.exports.getSampleValuesFromRange = function getSampleValuesFromRange (min, span, limit) {
-    const sample = new Set();
-
-    limit = limit < span ? limit : span;
-
-    while (sample.size < limit) {
-        sample.add(Math.floor(min + Math.random() * span));
-    }
-
-    return Array.from(sample);
-};
-
 module.exports.getSampleFromIdsQuery = function (query, ids, columns, column = 'cartodb_id') {
     return `
         SELECT

--- a/lib/cartodb/utils/query-utils.js
+++ b/lib/cartodb/utils/query-utils.js
@@ -150,13 +150,13 @@ function simpleQueryTable(sql) {
     return false;
 }
 
-module.exports.getMaxMinColumnQuery = function (query, column = 'cartodb_id') {
+module.exports.getMaxMinSpanColumnQuery = function (query, column = 'cartodb_id') {
     return `
         SELECT
             min(${column}) AS min_id,
             max(${column}) AS max_id,
             (max(${column}) - min(${column})) AS id_span
-        FROM (${substituteDummyTokens(query)}) _cdb_metadata_max_min;
+        FROM (${substituteDummyTokens(query)}) _cdb_metadata_max_min_span;
     `;
 };
 

--- a/lib/cartodb/utils/query-utils.js
+++ b/lib/cartodb/utils/query-utils.js
@@ -98,58 +98,6 @@ function columnSelector(columns) {
     throw new TypeError(`Bad argument type for columns: ${typeof columns}`);
 }
 
-module.exports.getQuerySample = function (query, sampleProb, limit = null, randomSeed = 0.5, columns = null) {
-    const singleTable = simpleQueryTable(query);
-    if (singleTable) {
-        return getTableSample(singleTable.table, columns || singleTable.columns, sampleProb, limit, randomSeed);
-    }
-    const limitClause = limit ? `LIMIT ${limit}` : '';
-    return `
-        WITH __cdb_rndseed AS (
-            SELECT setseed(${randomSeed})
-        )
-        SELECT ${columnSelector(columns)}
-            FROM (${substituteDummyTokens(query)}) AS __cdb_query
-            WHERE random() < ${sampleProb}
-            ${limitClause}
-    `;
-};
-
-function getTableSample(table, columns, sampleProb, limit = null, randomSeed = 0.5) {
-    const limitClause = limit ? `LIMIT ${limit}` : '';
-    sampleProb *= 100;
-    randomSeed *= Math.pow(2, 31) - 1;
-    return `
-        SELECT ${columnSelector(columns)}
-        FROM ${table}
-        TABLESAMPLE BERNOULLI (${sampleProb}) REPEATABLE (${randomSeed}) ${limitClause}
-    `;
-}
-
-function simpleQueryTable(sql) {
-    const basicQuery =
-        /\s*SELECT\s+([\*a-z0-9_,\s]+?)\s+FROM\s+((\"[^"]+\"|[a-z0-9_]+)\.)?(\"[^"]+\"|[a-z0-9_]+)\s*;?\s*/i;
-    const unwrappedQuery = new RegExp('^' + basicQuery.source + '$', 'i');
-    // queries for named maps are wrapped like this:
-    var wrappedQuery = new RegExp(
-        '^\\s*SELECT\\s+\\*\\s+FROM\\s+\\(' +
-        basicQuery.source +
-        '\\)\\s+AS\\s+wrapped_query\\s+WHERE\\s+\\d+=1\\s*$',
-        'i'
-    );
-    let match = sql.match(unwrappedQuery);
-    if (!match) {
-        match = sql.match(wrappedQuery);
-    }
-    if (match) {
-        const columns = match[1];
-        const schema = match[3];
-        const table = match[4];
-        return { table: schema ? `${schema}.${table}` : table, columns };
-    }
-    return false;
-}
-
 module.exports.getMaxMinSpanColumnQuery = function (query, column = 'cartodb_id') {
     return `
         SELECT

--- a/lib/cartodb/utils/query-utils.js
+++ b/lib/cartodb/utils/query-utils.js
@@ -150,6 +150,36 @@ function simpleQueryTable(sql) {
     return false;
 }
 
+module.exports.getMaxMinColumnQuery = function (query, column = 'cartodb_id') {
+    return `
+        SELECT
+            min(${column}) AS min_id,
+            max(${column}) AS max_id,
+            (max(${column}) - min(${column})) AS id_span
+        FROM (${query}) _cdb_metadata_max_min;
+    `;
+};
+
+module.exports.getSampleValuesFromRange = function getSampleValuesFromRange (min, span, limit) {
+    const sample = new Set();
+
+    limit = limit < span ? limit : span;
+
+    while (sample.size < limit) {
+        sample.add(Math.floor(min + Math.random() * span));
+    }
+
+    return Array.from(sample);
+};
+
+module.exports.getSampleFromIdsQuery = function (query, ids, columns, column = 'cartodb_id') {
+    return `
+        SELECT
+            ${columnSelector(columns)}
+        FROM (${query}) _cdb_metadata_sample
+        WHERE ${column} IN (${ids.join(',')})
+    `;
+};
 
 function getQueryLimited(query, limit = 0) {
     return `

--- a/test/acceptance/stats/mapnik_stats_layergroup.js
+++ b/test/acceptance/stats/mapnik_stats_layergroup.js
@@ -596,8 +596,7 @@ describe(`[${desc}] Create mapnik layergroup`, function() {
                         "metadata": {
                             "sample": {
                                 "num_rows": 30
-                            },
-                            "sql": "select * from test_table_100 limit 0"
+                            }
                         }
                     }
                 }
@@ -606,11 +605,7 @@ describe(`[${desc}] Create mapnik layergroup`, function() {
 
         testClient.getLayergroup(function(err, layergroup) {
             assert.ifError(err);
-            assert.equal(layergroup.metadata.layers[0].id, mapnikBasicLayerId(0));
-            assert.equal(layergroup.metadata.layers[0].meta.stats.estimatedFeatureCount, 100);
-            assert(layergroup.metadata.layers[0].meta.stats.sample.length > 0);
-            const expectedCols = [ 'cartodb_id', 'value', 'the_geom', 'the_geom_webmercator' ].sort();
-            assert.deepEqual(Object.keys(layergroup.metadata.layers[0].meta.stats.sample[0]).sort(), expectedCols);
+            assert.deepStrictEqual(layergroup.metadata.layers[0].meta.stats.sample, {});
             testClient.drain(done);
         });
     });

--- a/test/acceptance/stats/mapnik_stats_layergroup.js
+++ b/test/acceptance/stats/mapnik_stats_layergroup.js
@@ -585,17 +585,17 @@ describe(`[${desc}] Create mapnik layergroup`, function() {
 
     it('should not provide a sample when the source table is empty', function (done) {
         var testClient = new TestClient({
-            "version": "1.4.0",
-            "layers": [
+            version: "1.4.0",
+            layers: [
                 {
-                    "type": "mapnik",
-                    "options": {
-                        "sql": "SELECT * FROM test_table_100 limit 0",
-                        "cartocss_version": "2.3.0",
-                        "cartocss": "#layer { line-width:16; }",
-                        "metadata": {
-                            "sample": {
-                                "num_rows": 30
+                    type: "mapnik",
+                    options: {
+                        sql: "SELECT * FROM test_table_100 limit 0",
+                        cartocss_version: "2.3.0",
+                        cartocss: "#layer { line-width:16; }",
+                        metadata: {
+                            sample: {
+                                num_rows: 30
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #1118 

*Note*: the new sample implementation may be inefficient when the numeric ID column (cartodb_id) has many (or moderately many) gaps. 