### PR TITLE
Improve named map provider cache

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ Released 2019-XX-XX
 
 Announcements:
 
+- Stop caching map template errors in Named Map Provider Cache
+- Gather metrics from Named Maps Providers Cache
 - Improved efficiency of query samples while instatiating a map (#1120).
 - Cache control header fine tuning. Set a shorter value for "max-age" directive if there is no way to know when to trigger the invalidation.
 - Update deps:

--- a/lib/cartodb/api/api-router.js
+++ b/lib/cartodb/api/api-router.js
@@ -161,10 +161,6 @@ module.exports = class ApiRouter {
             layergroupAffectedTablesCache
         );
 
-        ['update', 'delete'].forEach(function(eventType) {
-            templateMaps.on(eventType, namedMapProviderCache.invalidate.bind(namedMapProviderCache));
-        });
-
         const collaborators = {
             analysisStatusBackend,
             attributesBackend,

--- a/lib/cartodb/api/api-router.js
+++ b/lib/cartodb/api/api-router.js
@@ -29,6 +29,7 @@ const VarnishHttpCacheBackend = require('../cache/backend/varnish_http');
 const FastlyCacheBackend = require('../cache/backend/fastly');
 const NamedMapProviderCache = require('../cache/named_map_provider_cache');
 const NamedMapsCacheEntry = require('../cache/model/named_maps_entry');
+const NamedMapProviderReporter = require('../stats/reporter/named-map-provider');
 
 const SqlWrapMapConfigAdapter = require('../models/mapconfig/adapter/sql-wrap-mapconfig-adapter');
 const MapConfigNamedLayersAdapter = require('../models/mapconfig/adapter/mapconfig-named-layers-adapter');
@@ -160,6 +161,13 @@ module.exports = class ApiRouter {
             mapConfigAdapter,
             layergroupAffectedTablesCache
         );
+
+        const namedMapProviderReporter = new NamedMapProviderReporter({
+            namedMapProviderCache,
+            intervalInMilliseconds: rendererCacheOpts.statsInterval
+        });
+
+        namedMapProviderReporter.start();
 
         const collaborators = {
             analysisStatusBackend,

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('underscore');
-var dot = require('dot');
 var NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
 var templateName = require('../backends/template_maps').templateName;
 
@@ -68,8 +67,7 @@ function createNamedMapKey(user, templateId) {
     return user + ':' + templateName(templateId);
 }
 
-var providerKey = '{{=it.authToken}}:{{=it.configHash}}:{{=it.format}}:{{=it.layer}}:{{=it.scale_factor}}';
-var providerKeyTpl = dot.template(providerKey);
+var providerKeyTpl = ctx => `${ctx.authToken}:${ctx.configHash}:${ctx.format}:${ctx.layer}:${ctx.scale_factor}`;
 
 function createProviderKey(config, authToken, params) {
     var tplValues = _.defaults({}, params, {

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -8,58 +8,58 @@ const { templateName } = require('../backends/template_maps');
 const TEN_MINUTES_IN_MILLISECONDS = 1000 * 60 * 10;
 const ACTIONS = ['update', 'delete'];
 
-function NamedMapProviderCache(
-    templateMaps,
-    pgConnection,
-    metadataBackend,
-    userLimitsBackend,
-    mapConfigAdapter,
-    affectedTablesCache
-) {
-    this.templateMaps = templateMaps;
-    this.pgConnection = pgConnection;
-    this.metadataBackend = metadataBackend;
-    this.userLimitsBackend = userLimitsBackend;
-    this.mapConfigAdapter = mapConfigAdapter;
-    this.affectedTablesCache = affectedTablesCache;
+module.exports = class NamedMapProviderCache {
+    constructor (
+        templateMaps,
+        pgConnection,
+        metadataBackend,
+        userLimitsBackend,
+        mapConfigAdapter,
+        affectedTablesCache
+    ) {
+        this.templateMaps = templateMaps;
+        this.pgConnection = pgConnection;
+        this.metadataBackend = metadataBackend;
+        this.userLimitsBackend = userLimitsBackend;
+        this.mapConfigAdapter = mapConfigAdapter;
+        this.affectedTablesCache = affectedTablesCache;
 
-    this.providerCache = new LruCache({ max: 2000, maxAge: TEN_MINUTES_IN_MILLISECONDS });
+        this.providerCache = new LruCache({ max: 2000, maxAge: TEN_MINUTES_IN_MILLISECONDS });
 
-    ACTIONS.forEach(action => templateMaps.on(action, (...args) => this.invalidate(...args)));
-}
+        ACTIONS.forEach(action => templateMaps.on(action, (...args) => this.invalidate(...args)));
+    }
 
-module.exports = NamedMapProviderCache;
+    get (user, templateId, config, authToken, params, callback) {
+        const namedMapKey = createNamedMapKey(user, templateId);
+        const namedMapProviders = this.providerCache.get(namedMapKey) || {};
+        const providerKey = createProviderKey(config, authToken, params);
 
-NamedMapProviderCache.prototype.get = function(user, templateId, config, authToken, params, callback) {
-    const namedMapKey = createNamedMapKey(user, templateId);
-    const namedMapProviders = this.providerCache.get(namedMapKey) || {};
-    const providerKey = createProviderKey(config, authToken, params);
+        if (namedMapProviders.hasOwnProperty(providerKey)) {
+            return callback(null, namedMapProviders[providerKey]);
+        }
 
-    if (namedMapProviders.hasOwnProperty(providerKey)) {
+        namedMapProviders[providerKey] = new NamedMapMapConfigProvider(
+            this.templateMaps,
+            this.pgConnection,
+            this.metadataBackend,
+            this.userLimitsBackend,
+            this.mapConfigAdapter,
+            this.affectedTablesCache,
+            user,
+            templateId,
+            config,
+            authToken,
+            params
+        );
+
+        this.providerCache.set(namedMapKey, namedMapProviders);
+
         return callback(null, namedMapProviders[providerKey]);
     }
 
-    namedMapProviders[providerKey] = new NamedMapMapConfigProvider(
-        this.templateMaps,
-        this.pgConnection,
-        this.metadataBackend,
-        this.userLimitsBackend,
-        this.mapConfigAdapter,
-        this.affectedTablesCache,
-        user,
-        templateId,
-        config,
-        authToken,
-        params
-    );
-
-    this.providerCache.set(namedMapKey, namedMapProviders);
-
-    return callback(null, namedMapProviders[providerKey]);
-};
-
-NamedMapProviderCache.prototype.invalidate = function(user, templateId) {
-    this.providerCache.del(createNamedMapKey(user, templateId));
+    invalidate (user, templateId) {
+        this.providerCache.del(createNamedMapKey(user, templateId));
+    }
 };
 
 function createNamedMapKey (user, templateId) {

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -32,31 +32,29 @@ module.exports = NamedMapProviderCache;
 NamedMapProviderCache.prototype.get = function(user, templateId, config, authToken, params, callback) {
     var namedMapKey = createNamedMapKey(user, templateId);
     var namedMapProviders = this.providerCache.get(namedMapKey) || {};
-
     var providerKey = createProviderKey(config, authToken, params);
-    if (!namedMapProviders.hasOwnProperty(providerKey)) {
-        namedMapProviders[providerKey] = new NamedMapMapConfigProvider(
-            this.templateMaps,
-            this.pgConnection,
-            this.metadataBackend,
-            this.userLimitsBackend,
-            this.mapConfigAdapter,
-            this.affectedTablesCache,
-            user,
-            templateId,
-            config,
-            authToken,
-            params
-        );
-        this.providerCache.set(namedMapKey, namedMapProviders);
 
-        // early exit, if provider did not exist we just return it
+    if (namedMapProviders.hasOwnProperty(providerKey)) {
         return callback(null, namedMapProviders[providerKey]);
     }
 
-    var namedMapProvider = namedMapProviders[providerKey];
+    namedMapProviders[providerKey] = new NamedMapMapConfigProvider(
+        this.templateMaps,
+        this.pgConnection,
+        this.metadataBackend,
+        this.userLimitsBackend,
+        this.mapConfigAdapter,
+        this.affectedTablesCache,
+        user,
+        templateId,
+        config,
+        authToken,
+        params
+    );
 
-    return callback(null, namedMapProvider);
+    this.providerCache.set(namedMapKey, namedMapProviders);
+
+    return callback(null, namedMapProviders[providerKey]);
 };
 
 NamedMapProviderCache.prototype.invalidate = function(user, templateId) {

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
-const templateName = require('../backends/template_maps').templateName;
-
 const LruCache = require("lru-cache");
+
+const NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
+const { templateName } = require('../backends/template_maps');
 
 const TEN_MINUTES_IN_MILLISECONDS = 1000 * 60 * 10;
 const ACTIONS = ['update', 'delete'];
@@ -62,13 +62,13 @@ NamedMapProviderCache.prototype.invalidate = function(user, templateId) {
     this.providerCache.del(createNamedMapKey(user, templateId));
 };
 
-function createNamedMapKey(user, templateId) {
-    return user + ':' + templateName(templateId);
+function createNamedMapKey (user, templateId) {
+    return `${user}:${templateName(templateId)}`;
 }
 
 const providerKeyTpl = ctx => `${ctx.authToken}:${ctx.configHash}:${ctx.format}:${ctx.layer}:${ctx.scale_factor}`;
 
-function createProviderKey(config, authToken, params) {
+function createProviderKey (config, authToken, params) {
     const defaults = {
         authToken: authToken || '',
         configHash: NamedMapMapConfigProvider.configHash(config),

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const LruCache = require("lru-cache");
+const LruCache = require('lru-cache');
 
 const NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
 const { templateName } = require('../backends/template_maps');

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -26,7 +26,7 @@ module.exports = class NamedMapProviderCache {
 
         this.providerCache = new LruCache({ max: 2000, maxAge: TEN_MINUTES_IN_MILLISECONDS });
 
-        ACTIONS.forEach(action => templateMaps.on(action, (...args) => this.invalidate(...args)));
+        ACTIONS.forEach(action => templateMaps.on(action, (user, templateId) => this.invalidate(user, templateId)));
     }
 
     get (user, templateId, config, authToken, params, callback) {

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -8,6 +8,8 @@ var queue = require('queue-async');
 
 var LruCache = require("lru-cache");
 
+const TEN_MINUTES_IN_MILLISECONDS = 1000 * 60 * 10;
+
 function NamedMapProviderCache(
     templateMaps,
     pgConnection,
@@ -23,7 +25,7 @@ function NamedMapProviderCache(
     this.mapConfigAdapter = mapConfigAdapter;
     this.affectedTablesCache = affectedTablesCache;
 
-    this.providerCache = new LruCache({ max: 2000 });
+    this.providerCache = new LruCache({ max: 2000, maxAge: TEN_MINUTES_IN_MILLISECONDS });
 }
 
 module.exports = NamedMapProviderCache;

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
-var templateName = require('../backends/template_maps').templateName;
+const NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
+const templateName = require('../backends/template_maps').templateName;
 
-var LruCache = require("lru-cache");
+const LruCache = require("lru-cache");
 
 const TEN_MINUTES_IN_MILLISECONDS = 1000 * 60 * 10;
 const ACTIONS = ['update', 'delete'];
@@ -31,9 +31,9 @@ function NamedMapProviderCache(
 module.exports = NamedMapProviderCache;
 
 NamedMapProviderCache.prototype.get = function(user, templateId, config, authToken, params, callback) {
-    var namedMapKey = createNamedMapKey(user, templateId);
-    var namedMapProviders = this.providerCache.get(namedMapKey) || {};
-    var providerKey = createProviderKey(config, authToken, params);
+    const namedMapKey = createNamedMapKey(user, templateId);
+    const namedMapProviders = this.providerCache.get(namedMapKey) || {};
+    const providerKey = createProviderKey(config, authToken, params);
 
     if (namedMapProviders.hasOwnProperty(providerKey)) {
         return callback(null, namedMapProviders[providerKey]);
@@ -66,7 +66,7 @@ function createNamedMapKey(user, templateId) {
     return user + ':' + templateName(templateId);
 }
 
-var providerKeyTpl = ctx => `${ctx.authToken}:${ctx.configHash}:${ctx.format}:${ctx.layer}:${ctx.scale_factor}`;
+const providerKeyTpl = ctx => `${ctx.authToken}:${ctx.configHash}:${ctx.format}:${ctx.layer}:${ctx.scale_factor}`;
 
 function createProviderKey(config, authToken, params) {
     const defaults = {

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('underscore');
 var NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
 var templateName = require('../backends/template_maps').templateName;
 
@@ -70,12 +69,14 @@ function createNamedMapKey(user, templateId) {
 var providerKeyTpl = ctx => `${ctx.authToken}:${ctx.configHash}:${ctx.format}:${ctx.layer}:${ctx.scale_factor}`;
 
 function createProviderKey(config, authToken, params) {
-    var tplValues = _.defaults({}, params, {
+    const defaults = {
         authToken: authToken || '',
         configHash: NamedMapMapConfigProvider.configHash(config),
         layer: '',
         format: '',
         scale_factor: 1
-    });
-    return providerKeyTpl(tplValues);
+    };
+    const ctx = Object.assign({}, defaults, params);
+
+    return providerKeyTpl(ctx);
 }

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -8,6 +8,7 @@ var templateName = require('../backends/template_maps').templateName;
 var LruCache = require("lru-cache");
 
 const TEN_MINUTES_IN_MILLISECONDS = 1000 * 60 * 10;
+const ACTIONS = ['update', 'delete'];
 
 function NamedMapProviderCache(
     templateMaps,
@@ -25,6 +26,8 @@ function NamedMapProviderCache(
     this.affectedTablesCache = affectedTablesCache;
 
     this.providerCache = new LruCache({ max: 2000, maxAge: TEN_MINUTES_IN_MILLISECONDS });
+
+    ACTIONS.forEach(action => templateMaps.on(action, (...args) => this.invalidate(...args)));
 }
 
 module.exports = NamedMapProviderCache;

--- a/lib/cartodb/cache/named_map_provider_cache.js
+++ b/lib/cartodb/cache/named_map_provider_cache.js
@@ -4,7 +4,6 @@ var _ = require('underscore');
 var dot = require('dot');
 var NamedMapMapConfigProvider = require('../models/mapconfig/provider/named-map-provider');
 var templateName = require('../backends/template_maps').templateName;
-var queue = require('queue-async');
 
 var LruCache = require("lru-cache");
 
@@ -57,23 +56,7 @@ NamedMapProviderCache.prototype.get = function(user, templateId, config, authTok
 
     var namedMapProvider = namedMapProviders[providerKey];
 
-    var self = this;
-    queue(2)
-        .defer(namedMapProvider.getTemplate.bind(namedMapProvider))
-        .defer(this.templateMaps.getTemplate.bind(this.templateMaps), user, templateId)
-        .awaitAll(function templatesQueueDone(err, results) {
-            if (err) {
-                return callback(err);
-            }
-
-            // We want to reset provider its template has changed
-            // Ideally this should be done in a passive mode where this cache gets notified of template changes
-            var uniqueFingerprints = _.uniq(results.map(self.templateMaps.fingerPrint)).length;
-            if (uniqueFingerprints > 1) {
-                namedMapProvider.reset();
-            }
-            return callback(null, namedMapProvider);
-        });
+    return callback(null, namedMapProvider);
 };
 
 NamedMapProviderCache.prototype.invalidate = function(user, templateId) {

--- a/lib/cartodb/models/mapconfig/provider/named-map-provider.js
+++ b/lib/cartodb/models/mapconfig/provider/named-map-provider.js
@@ -48,7 +48,6 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
         this.affectedTablesCache = affectedTablesCache;
 
         // providing
-        this.err = null;
         this.mapConfig = null;
         this.rendererParams = null;
         this.context = {};
@@ -56,13 +55,12 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
     }
 
     getMapConfig (callback) {
-        if (!!this.err || this.mapConfig !== null) {
-            return callback(this.err, this.mapConfig, this.rendererParams, this.context);
+        if (this.mapConfig !== null) {
+            return callback(null, this.mapConfig, this.rendererParams, this.context);
         }
 
         this.getContext((err, context) => {
             if (err) {
-                this.err = err;
                 return callback(err);
             }
 
@@ -75,8 +73,6 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
                         this.config;
                 } catch (e) {
                     const err = new Error('malformed config parameter, should be a valid JSON');
-                    this.err = err;
-
                     return callback(err);
                 }
             }
@@ -85,7 +81,6 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
 
             this.getTemplate((err, template) => {
                 if (err) {
-                    this.err = err;
                     return callback(err);
                 }
 
@@ -94,7 +89,6 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
                 try {
                     requestMapConfig = this.templateMaps.instance(template, templateParams);
                 } catch (err) {
-                    this.err = err;
                     return callback(err);
                 }
 
@@ -103,7 +97,6 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
                 this.mapConfigAdapter.getMapConfig(
                     user, requestMapConfig, rendererParams, context, (err, mapConfig, stats = {}) => {
                     if (err) {
-                        this.err = err;
                         return callback(err);
                     }
 
@@ -148,7 +141,6 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
 
                 this.userLimitsBackend.getRenderLimits(this.user, this.params.api_key, (err, renderLimits) => {
                     if (err) {
-                        this.err = err;
                         return callback(err);
                     }
 
@@ -163,21 +155,18 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
     }
 
     getTemplate (callback) {
-        if (!!this.err || this.template !== null) {
-            return callback(this.err, this.template);
+        if (this.template !== null) {
+            return callback(null, this.template);
         }
 
         this.templateMaps.getTemplate(this.user, this.templateName, (err, tpl) => {
             if (err) {
-                this.err = err;
                 return callback(err);
             }
 
             if (!tpl) {
                 const error = new Error(`Template '${this.templateName}' of user '${this.user}' not found`);
                 error.http_status = 404;
-
-                this.err = error;
 
                 return callback(error);
             }
@@ -190,15 +179,12 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
                 const error = new Error('Failed to authorize template');
                 error.http_status = 403;
 
-                this.err = error;
-
                 return callback(error);
             }
 
             if (!authorized) {
                 const error = new Error('Unauthorized template instantiation');
                 error.http_status = 403;
-                this.err = error;
 
                 return callback(error);
             }
@@ -222,7 +208,6 @@ module.exports = class NamedMapMapConfigProvider extends BaseMapConfigProvider {
 
         this.affectedTables = null;
 
-        this.err = null;
         this.mapConfig = null;
 
         this.cacheBuster = Date.now();

--- a/lib/cartodb/stats/reporter/named-map-provider.js
+++ b/lib/cartodb/stats/reporter/named-map-provider.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const statKeyTemplate = ctx => `windshaft.named-map-provider-cache.${ctx.metric}`;
+
+module.exports = class NamedMapProviderReporter {
+    constructor ({ namedMapProviderCache, intervalInMilliseconds } = {}) {
+        this.namedMapProviderCache = namedMapProviderCache;
+        this.intervalInMilliseconds = intervalInMilliseconds;
+        this.intervalId = null;
+    }
+
+    start () {
+        const { providerCache: cache } = this.namedMapProviderCache;
+        const { statsClient: stats } = global;
+
+        this.intervalId = setInterval(() => {
+            stats.gauge(statKeyTemplate({ metric: 'named-map.count' }), cache.length);
+            const providers = cache.dump();
+
+            const namedMapIntantiations = providers.reduce((acc, { v: providers }) => {
+                acc += Object.keys(providers).length;
+                return acc;
+            }, 0);
+
+            stats.gauge(statKeyTemplate({ metric: 'named-map.intantiation.count' }), namedMapIntantiations);
+        }, this.intervalInMilliseconds);
+    }
+
+    stop () {
+        clearInterval(this.intervalId);
+        this.intervalId = null;
+    }
+};

--- a/lib/cartodb/stats/reporter/named-map-provider.js
+++ b/lib/cartodb/stats/reporter/named-map-provider.js
@@ -22,7 +22,7 @@ module.exports = class NamedMapProviderReporter {
                 return acc;
             }, 0);
 
-            stats.gauge(statKeyTemplate({ metric: 'named-map.intantiation.count' }), namedMapInstantiations);
+            stats.gauge(statKeyTemplate({ metric: 'named-map.instantiation.count' }), namedMapInstantiations);
         }, this.intervalInMilliseconds);
     }
 

--- a/lib/cartodb/stats/reporter/named-map-provider.js
+++ b/lib/cartodb/stats/reporter/named-map-provider.js
@@ -17,12 +17,12 @@ module.exports = class NamedMapProviderReporter {
             stats.gauge(statKeyTemplate({ metric: 'named-map.count' }), cache.length);
             const providers = cache.dump();
 
-            const namedMapIntantiations = providers.reduce((acc, { v: providers }) => {
+            const namedMapInstantiations = providers.reduce((acc, { v: providers }) => {
                 acc += Object.keys(providers).length;
                 return acc;
             }, 0);
 
-            stats.gauge(statKeyTemplate({ metric: 'named-map.intantiation.count' }), namedMapIntantiations);
+            stats.gauge(statKeyTemplate({ metric: 'named-map.intantiation.count' }), namedMapInstantiations);
         }, this.intervalInMilliseconds);
     }
 

--- a/test/acceptance/named-map-cache-regressions.js
+++ b/test/acceptance/named-map-cache-regressions.js
@@ -1,0 +1,231 @@
+'use strict';
+
+require('../support/test_helper');
+
+const request = require('request');
+const assert = require('assert');
+const Server = require('../../lib/cartodb/server');
+const serverOptions = require('../../lib/cartodb/server_options');
+const { mapnik } = require('windshaft');
+const helper = require('../support/test_helper');
+
+describe('named map cache regressions', function () {
+    const server = new Server(serverOptions);
+
+    const apiKey = 1234;
+
+    const template = {
+        version: '0.0.1',
+        name: 'named-map-cache-regression-missing-template',
+        layergroup: {
+            version: '1.8.0',
+            layers: [
+                {
+                    type: 'cartodb',
+                    options: {
+                        source: {
+                            id: 'a1'
+                        },
+                        cartocss: '#layer{marker-placement: point;marker-width: 5;marker-fill: red;}',
+                        cartocss_version: '2.3.0'
+                    }
+                }
+            ],
+            analyses: [
+                {
+                    id: 'a1',
+                    type: 'source',
+                    params: {
+                        query: 'select * from populated_places_simple_reduced'
+                    }
+                }
+            ]
+        }
+    };
+
+    const port = 0; // let the OS to choose a free port
+    const host = '127.0.0.1';
+
+    let listener;
+    let address;
+
+    const keysToDelete = {};
+
+    before(function (done) {
+        listener = server.listen(port, host);
+
+        listener.on('error', done);
+        listener.on('listening', () => {
+            const { address: host, port } = listener.address();
+
+            address = `${host}:${port}`;
+
+            done();
+        });
+    });
+
+    after(function (done) {
+        helper.deleteRedisKeys(keysToDelete, () => listener.close(done));
+    });
+
+    it('should not fail when a template gets recreated', function (done) {
+        this.timeout(10000);
+
+        const createTemplateRequest = {
+            url: `http://${address}/api/v1/map/named?api_key=${apiKey}`,
+            method: 'POST',
+            headers: {
+                host: 'localhost',
+                'Content-Type': 'application/json'
+            },
+            body: template,
+            json: true
+        };
+
+        request(createTemplateRequest, (err, res, body) => {
+            if (err) {
+                return done(err);
+            }
+
+            assert.strictEqual(res.statusCode, 200);
+
+            const templateId = body.template_id;
+
+            keysToDelete['map_tpl|localhost'] = 0;
+
+            const previewRequest = {
+                url: `http://${address}/api/v1/map/static/named/${templateId}/256/256.png?api_key=${apiKey}`,
+                encoding: 'binary',
+                method: 'GET',
+                headers: {
+                    host: 'localhost'
+                }
+            };
+
+            request(previewRequest, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                assert.strictEqual(res.statusCode, 200);
+
+                const preview = mapnik.Image.fromBytes(Buffer.from(res.body, 'binary'));
+
+                assert.strictEqual(preview.width(), 256);
+                assert.strictEqual(preview.height(), 256);
+
+                const templateUpdate = Object.assign({}, template);
+
+                templateUpdate.layergroup.analyses[0].params.query = 'select * from populated_places_simple_reduced limit 100';
+
+                const upateTemplateRequest = {
+                    url: `http://${address}/api/v1/map/named/${templateId}?api_key=${apiKey}`,
+                    method: 'PUT',
+                    headers: {
+                        host: 'localhost',
+                        'Content-Type': 'application/json'
+                    },
+                    body: templateUpdate,
+                    json: true
+                };
+
+                request(upateTemplateRequest, (err, res, body) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    assert.strictEqual(res.statusCode, 200);
+
+                    request(previewRequest, (err, res) => {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        const preview = mapnik.Image.fromBytes(Buffer.from(res.body, 'binary'));
+
+                        assert.strictEqual(preview.width(), 256);
+                        assert.strictEqual(preview.height(), 256);
+
+                        request(previewRequest, (err, res) => {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            const preview = mapnik.Image.fromBytes(Buffer.from(res.body, 'binary'));
+
+                            assert.strictEqual(preview.width(), 256);
+                            assert.strictEqual(preview.height(), 256);
+
+                            const deleteTemplateRequest = {
+                                url: `http://${address}/api/v1/map/named/${templateId}?api_key=${apiKey}`,
+                                method: 'DELETE',
+                                headers: {
+                                    host: 'localhost',
+                                }
+                            };
+
+                            request(deleteTemplateRequest, (err) => {
+                                if (err) {
+                                    return done(err);
+                                }
+
+                                delete keysToDelete['map_tpl|localhost'];
+
+                                assert.strictEqual(res.statusCode, 200);
+
+                                request(createTemplateRequest, (err, res, body) => {
+                                    if (err) {
+                                        return done(err);
+                                    }
+
+                                    assert.strictEqual(res.statusCode, 200);
+
+                                    const templateId = body.template_id;
+
+                                    keysToDelete['map_tpl|localhost'] = 0;
+
+                                    const previewRequest = {
+                                        url: `http://${address}/api/v1/map/static/named/${templateId}/256/256.png?api_key=${apiKey}`,
+                                        encoding: 'binary',
+                                        method: 'GET',
+                                        headers: {
+                                            host: 'localhost'
+                                        }
+                                    };
+
+                                    request(previewRequest, (err, res) => {
+                                        if (err) {
+                                            return done(err);
+                                        }
+
+                                        assert.strictEqual(res.statusCode, 200);
+
+                                        const preview = mapnik.Image.fromBytes(Buffer.from(res.body, 'binary'));
+
+                                        assert.strictEqual(preview.width(), 256);
+                                        assert.strictEqual(preview.height(), 256);
+
+                                        request(deleteTemplateRequest, (err) => {
+                                            if (err) {
+                                                return done(err);
+                                            }
+
+                                            delete keysToDelete['map_tpl|localhost'];
+
+                                            assert.strictEqual(res.statusCode, 200);
+
+                                            keysToDelete['user:localhost:mapviews:global'] = 0;
+                                            keysToDelete['user:localhost:mapviews:global'] = 5;
+
+                                            helper.deleteRedisKeys(keysToDelete, done);
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/acceptance/named-map-cache-regressions.js
+++ b/test/acceptance/named-map-cache-regressions.js
@@ -123,7 +123,7 @@ describe('named map cache regressions', function () {
                 const newQuery = 'select * from populated_places_simple_reduced limit 100';
                 templateUpdate.layergroup.analyses[0].params.query = newQuery;
 
-                const upateTemplateRequest = {
+                const updateTemplateRequest = {
                     url: `http://${address}/api/v1/map/named/${templateId}?api_key=${apiKey}`,
                     method: 'PUT',
                     headers: {
@@ -134,7 +134,7 @@ describe('named map cache regressions', function () {
                     json: true
                 };
 
-                request(upateTemplateRequest, (err, res) => {
+                request(updateTemplateRequest, (err, res) => {
                     if (err) {
                         return done(err);
                     }

--- a/test/acceptance/named-map-cache-regressions.js
+++ b/test/acceptance/named-map-cache-regressions.js
@@ -9,6 +9,10 @@ const serverOptions = require('../../lib/cartodb/server_options');
 const { mapnik } = require('windshaft');
 const helper = require('../support/test_helper');
 
+const namedTileUrlTemplate = (ctx) => {
+    return `http://${ctx.address}/api/v1/map/static/named/${ctx.templateId}/256/256.png?api_key=${ctx.apiKey}`;
+};
+
 describe('named map cache regressions', function () {
     const server = new Server(serverOptions);
 
@@ -116,7 +120,8 @@ describe('named map cache regressions', function () {
 
                 const templateUpdate = Object.assign({}, template);
 
-                templateUpdate.layergroup.analyses[0].params.query = 'select * from populated_places_simple_reduced limit 100';
+                const newQuery = 'select * from populated_places_simple_reduced limit 100';
+                templateUpdate.layergroup.analyses[0].params.query = newQuery;
 
                 const upateTemplateRequest = {
                     url: `http://${address}/api/v1/map/named/${templateId}?api_key=${apiKey}`,
@@ -129,7 +134,7 @@ describe('named map cache regressions', function () {
                     json: true
                 };
 
-                request(upateTemplateRequest, (err, res, body) => {
+                request(upateTemplateRequest, (err, res) => {
                     if (err) {
                         return done(err);
                     }
@@ -185,7 +190,7 @@ describe('named map cache regressions', function () {
                                     keysToDelete['map_tpl|localhost'] = 0;
 
                                     const previewRequest = {
-                                        url: `http://${address}/api/v1/map/static/named/${templateId}/256/256.png?api_key=${apiKey}`,
+                                        url: namedTileUrlTemplate({ address, templateId, apiKey }),
                                         encoding: 'binary',
                                         method: 'GET',
                                         headers: {

--- a/test/unit/cartodb/stats/reporter/named-map-provider.js
+++ b/test/unit/cartodb/stats/reporter/named-map-provider.js
@@ -49,7 +49,7 @@ describe('named-map-provider-reporter', function () {
             );
 
             assert.strictEqual(
-                global.statsClient['windshaft.named-map-provider-cache.named-map.intantiation.count'],
+                global.statsClient['windshaft.named-map-provider-cache.named-map.instantiation.count'],
                 6
             );
 

--- a/test/unit/cartodb/stats/reporter/named-map-provider.js
+++ b/test/unit/cartodb/stats/reporter/named-map-provider.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('assert');
+const NamedMapProviderReporter = require('../../../../../lib/cartodb/stats/reporter/named-map-provider');
+
+describe('named-map-provider-reporter', function () {
+    it('should report metrics every 100 ms', function (done) {
+        const oldStatsClient = global.statsClient;
+
+        global.statsClient = {
+            gauge: function (metric, value) {
+                this[metric] = value;
+            }
+        };
+
+        const dummyCacheEntries = [
+            {
+                k: 'foo:template_1',
+                v: { 'instantiation_1': 1 }
+            },
+            {
+                k: 'bar:template_2',
+                v: { 'instantiation_1': 1, 'instantiation_2': 2 }
+            },
+            {
+                k: 'buz:template_3',
+                v: { 'instantiation_1': 1, 'instantiation_2': 2, 'instantiation_3': 3 }
+            }
+        ];
+
+        const reporter = new NamedMapProviderReporter({
+            namedMapProviderCache: {
+                providerCache: {
+                    dump: () => dummyCacheEntries,
+                    length: dummyCacheEntries.length
+                }
+            },
+            intervalInMilliseconds: 100
+        });
+
+        reporter.start();
+
+        setTimeout(() => {
+            reporter.stop();
+
+            assert.strictEqual(
+                global.statsClient['windshaft.named-map-provider-cache.named-map.count'],
+                3
+            );
+
+            assert.strictEqual(
+                global.statsClient['windshaft.named-map-provider-cache.named-map.intantiation.count'],
+                6
+            );
+
+            global.statsClient = oldStatsClient;
+
+            done();
+        }, 110);
+    });
+});


### PR DESCRIPTION
- Do not cache map template CRUD errors in Named Map provider
- Add maxAge param to `lru-cache` to be able to refresh entries when staled
- Remove mechanism to reset named map's provider and leverage `lru-cache` as much as possible
- Refactors and ES7/8 goodies
- Gather metrics from Named Maps Providers Cache to understand better how it works

**Note**: to review this PR, better take a look to the following commits:
 - https://github.com/CartoDB/Windshaft-cartodb/pull/1122/commits/6229455d25da90bc010fce334ca517fdf33ee312
-  https://github.com/CartoDB/Windshaft-cartodb/pull/1122/commits/788cd9d6fb105f8bc9cb3b36d03087f85a26bdb5
- https://github.com/CartoDB/Windshaft-cartodb/pull/1122/commits/c19c7237952dd729c85febf336c9df41295822cc

You can see the new metrics in staging by clicking the image:

[<img width="1224" alt="Screenshot 2019-09-13 at 20 54 55" src="https://user-images.githubusercontent.com/1936888/64887441-ec3eeb00-d668-11e9-9d67-b08ebd74552c.png">](http://grafana-st.cartodb.net/d/nPuzjhBik/tiler-process-metrics?orgId=1&from=1568399393682&to=1568400912615)
