### PR TITLE
Validate aggregation method is either sum or count

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ Breaking changes:
 - Schema change for "routes" in configuration file, each "router" is now an array instead of an object. See [`dd06de2`](https://github.com/CartoDB/Windshaft-cartodb/pull/1126/commits/dd06de2632661e19d64c9fbc2be0ba1a8059f54c) for more details.
 
 Announcements:
-
+- Added validation to only allow "count" and "sum" aggregations in dataview overview.
 - Added mechanism to inject custom middlewares through configuration.
 - Stop requiring unused config properties: "base_url", "base_url_mapconfig", and "base_url_templated".
 

--- a/lib/models/dataview/overviews/aggregation.js
+++ b/lib/models/dataview/overviews/aggregation.js
@@ -94,6 +94,8 @@ var CATEGORIES_LIMIT = 6;
  function Aggregation(query, options, queryRewriter, queryRewriteData, params, queries) {
     BaseOverviewsDataview.call(this, query, options, BaseDataview, queryRewriter, queryRewriteData, params, queries);
 
+    this._checkOptions(options);
+
     this.query = query;
     this.queries = queries;
     this.column = options.column;
@@ -217,6 +219,26 @@ Aggregation.prototype.sql = function(psql, override, callback) {
 var aggregationFnQueryTpl = {
     count: dot.template('sum(_feature_count)'),
     sum:   dot.template('sum({{=it._aggregationColumn}}*_feature_count)')
+};
+
+const VALID_OPERATIONS = {
+    count: [],
+    sum: ['aggregationColumn']
+};
+
+Aggregation.prototype._checkOptions = function (options) {
+    if (!VALID_OPERATIONS[options.aggregation]) {
+        throw new Error(`Aggregation does not support '${options.aggregation}' operation in dataview overview options`);
+    }
+
+    const requiredOptions = VALID_OPERATIONS[options.aggregation];
+    const missingOptions = requiredOptions.filter(requiredOption => !options.hasOwnProperty(requiredOption));
+
+    if (missingOptions.length > 0) {
+        throw new Error(
+            `Aggregation '${options.aggregation}' is missing some options for overview: ${missingOptions.join(',')}`
+        );
+    }
 };
 
 Aggregation.prototype.getAggregationSql = function() {

--- a/test/acceptance/dataviews/overviews-test.js
+++ b/test/acceptance/dataviews/overviews-test.js
@@ -666,7 +666,7 @@ describe('dataviews using tables with overviews', function() {
             });
         });
 
-        describe.only('agreggation validation', function (){
+        describe('agreggation validation', function (){
             const params = {
                 response: {
                     status: 400,

--- a/test/acceptance/dataviews/overviews-test.js
+++ b/test/acceptance/dataviews/overviews-test.js
@@ -731,7 +731,7 @@ describe('dataviews using tables with overviews', function() {
                     aggregation: "sum",
                     aggregationColumn: "value"
                 };
-                var missingCOlumnMapConfig = createMapConfig(options);
+                var missingColumnMapConfig = createMapConfig(options);
 
                 var testClient = new TestClient(missingCOlumnMapConfig);
                 testClient.getDataview('test_invalid_aggregation', params, function (err, dataview) {

--- a/test/acceptance/dataviews/overviews-test.js
+++ b/test/acceptance/dataviews/overviews-test.js
@@ -685,13 +685,6 @@ describe('dataviews using tables with overviews', function() {
                             params: {
                                 query: 'select * from test_table_overviews'
                             }
-                        },
-                        {
-                            id: 'data-source-special-float-values',
-                            type: 'source',
-                            params: {
-                                query: 'select * from test_special_float_values_table_overviews'
-                            }
                         }
                     ],
                     dataviews:  {
@@ -709,17 +702,6 @@ describe('dataviews using tables with overviews', function() {
                                 cartocss: '#layer { marker-fill: red; marker-width: 32; marker-allow-overlap: true; }',
                                 cartocss_version: '2.3.0',
                                 source: { id: 'data-source' }
-                            }
-                        },
-                        {
-                            type: 'mapnik',
-                            options: {
-                                sql: 'select * from test_special_float_values_table_overviews',
-                                cartocss: '#layer { marker-fill: red; marker-width: 32; marker-allow-overlap: true; }',
-                                cartocss_version: '2.3.0',
-                                source: {
-                                    id: 'data-source-special-float-values'
-                                }
                             }
                         }
                     ]

--- a/test/acceptance/dataviews/overviews-test.js
+++ b/test/acceptance/dataviews/overviews-test.js
@@ -678,7 +678,7 @@ describe('dataviews using tables with overviews', function() {
 
             function createMapConfig(options) {
                 return {
-                    version: '1.5.0',
+                    version: '1.8.0',
                     analyses: [
                         { id: 'data-source',
                             type: 'source',
@@ -733,7 +733,7 @@ describe('dataviews using tables with overviews', function() {
                 };
                 var missingColumnMapConfig = createMapConfig(options);
 
-                var testClient = new TestClient(missingCOlumnMapConfig);
+                var testClient = new TestClient(missingColumnMapConfig);
                 testClient.getDataview('test_invalid_aggregation', params, function (err, dataview) {
                     if (err) {
                         return done(err);


### PR DESCRIPTION
Fixes #1137 

The method `checkOptions` in `models/dataview/aggregation` already validates that the necessary options are included and that the aggregation methods exist. However, the overview use case has a more restricted list of valid methods (it only accepts sum or count) and thus the existing validation wasn't enough in here.

Extra validation has been added for the overview together with some tests to validate that all cases are covered by one of the validation methods.