### PR TITLE
Add layergroupid to tiler-stats 

### DIFF
--- a/lib/api/api-router.js
+++ b/lib/api/api-router.js
@@ -56,6 +56,7 @@ const stats = require('./middlewares/stats');
 const lzmaMiddleware = require('./middlewares/lzma');
 const cors = require('./middlewares/cors');
 const user = require('./middlewares/user');
+const customProfile = require('./middlewares/custom-profile');
 const sendResponse = require('./middlewares/send-response');
 const syntaxError = require('./middlewares/syntax-error');
 const errorMiddleware = require('./middlewares/error-middleware');
@@ -229,6 +230,7 @@ module.exports = class ApiRouter {
             this.templateRouter.route(apiRouter, route.template);
             this.mapRouter.route(apiRouter, route.map);
 
+            apiRouter.use(customProfile());
             apiRouter.use(sendResponse());
             apiRouter.use(syntaxError());
             apiRouter.use(errorMiddleware());

--- a/lib/api/middlewares/custom-profile.js
+++ b/lib/api/middlewares/custom-profile.js
@@ -2,10 +2,10 @@
 
 module.exports = function customProfile () {
     return function customProfileMiddleware (req, res, next) {
-        const layergroupid = res.get('X-Layergroup-Id') || res.locals._layergroupid;
+        const __layergroup_id = res.get('X-Layergroup-Id') || res.locals._layergroupid;
 
-        if (layergroupid) {
-            req.profiler.add({ layergroupid });
+        if (__layergroup_id) {
+            req.profiler.add({ __layergroup_id });
         }
 
         next();

--- a/lib/api/middlewares/custom-profile.js
+++ b/lib/api/middlewares/custom-profile.js
@@ -1,11 +1,15 @@
 'use strict';
 
+const layergroupToken = require('../../models/layergroup-token');
+
 module.exports = function customProfile () {
     return function customProfileMiddleware (req, res, next) {
-        const __layergroup_id = res.get('X-Layergroup-Id') || res.locals._layergroupid;
-
-        if (__layergroup_id) {
-            req.profiler.add({ __layergroup_id });
+        if (res.locals.token && res.locals.cache_buster) {
+            const { token: layergroupid, cache_buster: cachebuster } = res.locals;
+            req.profiler.add({ layergroupid, cachebuster });
+        } else if (res.get('X-Layergroup-Id')) {
+            const { token: layergroupid, cacheBuster: cachebuster } = layergroupToken.parse(res.get('X-Layergroup-Id'));
+            req.profiler.add({ layergroupid, cachebuster });
         }
 
         next();

--- a/lib/api/middlewares/custom-profile.js
+++ b/lib/api/middlewares/custom-profile.js
@@ -2,7 +2,7 @@
 
 module.exports = function customProfile () {
     return function customProfileMiddleware (req, res, next) {
-        const layergroupid = res.get('X-Layergroup-Id') || req.params.token;
+        const layergroupid = res.get('X-Layergroup-Id') || res.locals._layergroupid;
 
         if (layergroupid) {
             req.profiler.add({ layergroupid });

--- a/lib/api/middlewares/layergroup-token.js
+++ b/lib/api/middlewares/layergroup-token.js
@@ -10,7 +10,6 @@ module.exports = function layergroupToken () {
         const user = res.locals.user;
         const layergroupToken = LayergroupToken.parse(req.params.token);
 
-        res.locals._layergroupid = req.params.token;
         res.locals.token = layergroupToken.token;
         res.locals.cache_buster = layergroupToken.cacheBuster;
 

--- a/lib/api/middlewares/layergroup-token.js
+++ b/lib/api/middlewares/layergroup-token.js
@@ -10,6 +10,7 @@ module.exports = function layergroupToken () {
         const user = res.locals.user;
         const layergroupToken = LayergroupToken.parse(req.params.token);
 
+        res.locals._layergroupid = req.params.token;
         res.locals.token = layergroupToken.token;
         res.locals.cache_buster = layergroupToken.cacheBuster;
 


### PR DESCRIPTION
Add `layergroupid` to tiler-stats  to be able to correlate different requests into the same workflow