### PR TITLE
Add pubsub metrics

### DIFF
--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -383,6 +383,12 @@ var config = {
             named_tiles: false
         }
     }
+    ,pubSubMetrics: {
+        enabled: false,
+        project_id: '',
+        credentials: '',
+        topic: ''
+    }
 };
 
 module.exports = config;

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -383,6 +383,12 @@ var config = {
             named_tiles: false
         }
     }
+    ,pubSubMetrics: {
+        enabled: true,
+        project_id: 'avid-wavelet-844',
+        credentials: '',
+        topic: 'raw-metric-events'
+    }
 };
 
 module.exports = config;

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -383,6 +383,12 @@ var config = {
             named_tiles: false
         }
     }
+    ,pubSubMetrics: {
+        enabled: true,
+        project_id: '',
+        credentials: '',
+        topic: 'raw-metric-events'
+    }
 };
 
 module.exports = config;

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -385,6 +385,12 @@ var config = {
             named_tiles: false
         }
     }
+    ,pubSubMetrics: {
+        enabled: false,
+        project_id: '',
+        credentials: '',
+        topic: ''
+    }
 };
 
 module.exports = config;

--- a/lib/api/api-router.js
+++ b/lib/api/api-router.js
@@ -200,6 +200,7 @@ module.exports = class ApiRouter {
 
         this.mapRouter = new MapRouter({ collaborators });
         this.templateRouter = new TemplateRouter({ collaborators });
+        this.metadataBackend = metadataBackend;
     }
 
     route (app, routes) {
@@ -224,7 +225,7 @@ module.exports = class ApiRouter {
             }));
             apiRouter.use(lzmaMiddleware());
             apiRouter.use(cors());
-            apiRouter.use(user());
+            apiRouter.use(user(this.metadataBackend));
 
             this.templateRouter.route(apiRouter, route.template);
             this.mapRouter.route(apiRouter, route.map);

--- a/lib/api/api-router.js
+++ b/lib/api/api-router.js
@@ -25,6 +25,8 @@ const TablesExtentBackend = require('../backends/tables-extent');
 
 const ClusterBackend = require('../backends/cluster');
 
+const PubSubMetricsBackend = require('../backends/pubsub-metrics');
+
 const LayergroupAffectedTablesCache = require('../cache/layergroup-affected-tables');
 const SurrogateKeysCache = require('../cache/surrogate-keys-cache');
 const VarnishHttpCacheBackend = require('../cache/backend/varnish-http');
@@ -59,6 +61,7 @@ const user = require('./middlewares/user');
 const sendResponse = require('./middlewares/send-response');
 const syntaxError = require('./middlewares/syntax-error');
 const errorMiddleware = require('./middlewares/error-middleware');
+const pubSubMetrics = require('./middlewares/pubsub-metrics');
 
 const MapRouter = require('./map/map-router');
 const TemplateRouter = require('./template/template-router');
@@ -201,6 +204,7 @@ module.exports = class ApiRouter {
         this.mapRouter = new MapRouter({ collaborators });
         this.templateRouter = new TemplateRouter({ collaborators });
         this.metadataBackend = metadataBackend;
+        this.pubSubMetricsBackend = PubSubMetricsBackend.build();
     }
 
     route (app, routes) {
@@ -233,6 +237,7 @@ module.exports = class ApiRouter {
             apiRouter.use(sendResponse());
             apiRouter.use(syntaxError());
             apiRouter.use(errorMiddleware());
+            apiRouter.use(pubSubMetrics(this.pubSubMetricsBackend));
 
             paths.forEach(path => app.use(path, apiRouter));
         });

--- a/lib/api/middlewares/cors.js
+++ b/lib/api/middlewares/cors.js
@@ -6,7 +6,10 @@ module.exports = function cors () {
             'X-Requested-With',
             'X-Prototype-Version',
             'X-CSRF-Token',
-            'Authorization'
+            'Authorization',
+            'Carto-Source-Lib',
+            'Carto-Source-Context',
+            'Carto-Source-Context-Id'
         ];
 
         if (req.method === 'OPTIONS') {

--- a/lib/api/middlewares/cors.js
+++ b/lib/api/middlewares/cors.js
@@ -7,9 +7,9 @@ module.exports = function cors () {
             'X-Prototype-Version',
             'X-CSRF-Token',
             'Authorization',
-            'Carto-Source-Lib',
-            'Carto-Source-Context',
-            'Carto-Source-Context-Id'
+            'Carto-Event',
+            'Carto-Event-Source',
+            'Carto-Event-Group-Id'
         ];
 
         if (req.method === 'OPTIONS') {

--- a/lib/api/middlewares/error-middleware.js
+++ b/lib/api/middlewares/error-middleware.js
@@ -38,7 +38,7 @@ module.exports = function errorMiddleware (/* options */) {
             res.json(errorResponseBody);
         }
 
-        next();
+        return next();
     };
 };
 

--- a/lib/api/middlewares/error-middleware.js
+++ b/lib/api/middlewares/error-middleware.js
@@ -37,6 +37,8 @@ module.exports = function errorMiddleware (/* options */) {
         } else {
             res.json(errorResponseBody);
         }
+
+        next();
     };
 };
 

--- a/lib/api/middlewares/pubsub-metrics.js
+++ b/lib/api/middlewares/pubsub-metrics.js
@@ -45,7 +45,7 @@ function getEventData (req, res) {
 }
 
 function normalizedField (field) {
-    return field.toString().substr(0, MAX_LENGTH);
+    return field.toString().trim().substr(0, MAX_LENGTH);
 }
 
 module.exports = pubSubMetrics;

--- a/lib/api/middlewares/pubsub-metrics.js
+++ b/lib/api/middlewares/pubsub-metrics.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EVENT_VERSION = '1';
+const MAX_LENGTH = 100;
 
 function pubSubMetrics (pubSubMetricsBackend) {
     if (!pubSubMetricsBackend.isEnabled()) {
@@ -19,9 +20,9 @@ function pubSubMetrics (pubSubMetricsBackend) {
 }
 
 function getEventData (req, res) {
-    const event = req.get('Carto-Event');
-    const eventSource = req.get('Carto-Event-Source');
-    const eventGroupId = req.get('Carto-Event-Group-Id');
+    const event = normalizedField(req.get('Carto-Event'));
+    const eventSource = normalizedField(req.get('Carto-Event-Source'));
+    const eventGroupId = normalizedField(req.get('Carto-Event-Group-Id'));
 
     if (!event || !eventSource) {
         return [undefined, undefined];
@@ -41,6 +42,10 @@ function getEventData (req, res) {
     }
 
     return { event, attributes };
+}
+
+function normalizedField (field) {
+    return field.toString().substr(0, MAX_LENGTH);
 }
 
 module.exports = pubSubMetrics;

--- a/lib/api/middlewares/pubsub-metrics.js
+++ b/lib/api/middlewares/pubsub-metrics.js
@@ -48,7 +48,7 @@ function normalizedField (field) {
     if (!field) {
         return undefined;
     }
-    
+
     return field.toString().trim().substr(0, MAX_LENGTH);
 }
 

--- a/lib/api/middlewares/pubsub-metrics.js
+++ b/lib/api/middlewares/pubsub-metrics.js
@@ -45,6 +45,10 @@ function getEventData (req, res) {
 }
 
 function normalizedField (field) {
+    if (!field) {
+        return undefined;
+    }
+    
     return field.toString().trim().substr(0, MAX_LENGTH);
 }
 

--- a/lib/api/middlewares/pubsub-metrics.js
+++ b/lib/api/middlewares/pubsub-metrics.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const EVENT_VERSION = '1';
+
+function pubSubMetrics (pubSubMetricsBackend) {
+    if (!pubSubMetricsBackend.isEnabled()) {
+        return function pubSubMetricsDisabledMiddleware (req, res, next) { next(); };
+    }
+
+    return function pubSubMetricsMiddleware (req, res, next) {
+        const data = getEventData(req, res);
+
+        if (data.event) {
+            pubSubMetricsBackend.sendEvent(data.event, data.attributes);
+        }
+
+        return next();
+    };
+}
+
+function getEventData (req, res) {
+    const event = req.get('Carto-Event');
+    const eventSource = req.get('Carto-Event-Source');
+    const eventGroupId = req.get('Carto-Event-Group-Id');
+
+    if (!event || !eventSource) {
+        return [undefined, undefined];
+    }
+
+    const attributes = {
+        event_source: eventSource,
+        user_id: res.locals.userId,
+        response_code: res.statusCode.toString(),
+        source_domain: req.hostname,
+        event_time: new Date().toISOString(),
+        event_version: EVENT_VERSION
+    };
+
+    if (eventGroupId) {
+        attributes.event_group_id = eventGroupId;
+    }
+
+    return { event, attributes };
+}
+
+module.exports = pubSubMetrics;

--- a/lib/api/middlewares/send-response.js
+++ b/lib/api/middlewares/send-response.js
@@ -1,19 +1,22 @@
 'use strict';
 
 module.exports = function sendResponse () {
-    return function sendResponseMiddleware (req, res) {
+    return function sendResponseMiddleware (req, res, next) {
         req.profiler.done('res');
 
         res.status(res.statusCode);
 
         if (Buffer.isBuffer(res.body)) {
-            return res.send(res.body);
+            res.send(res.body);
+            return next();
         }
 
         if (req.query.callback) {
-            return res.jsonp(res.body);
+            res.jsonp(res.body);
+            return next();
         }
 
         res.json(res.body);
+        return next();
     };
 };

--- a/lib/api/middlewares/user.js
+++ b/lib/api/middlewares/user.js
@@ -2,12 +2,30 @@
 
 const CdbRequest = require('../../models/cdb-request');
 
-module.exports = function user () {
+module.exports = function user (metadataBackend) {
     const cdbRequest = new CdbRequest();
 
     return function userMiddleware (req, res, next) {
-        res.locals.user = cdbRequest.userByReq(req);
+        res.locals.user = getUserNameFromRequest(req, cdbRequest);
 
-        next();
+        getUserId(metadataBackend, res.locals.user, function (userId) {
+            if (userId) {
+                res.locals.userId = userId;
+            }
+            return next();
+        });
     };
 };
+
+function getUserNameFromRequest (req, cdbRequest) {
+    return cdbRequest.userByReq(req);
+}
+
+function getUserId (metadataBackend, userName, callback) {
+    metadataBackend.getUserId(userName, function (err, userId) {
+        if (err) {
+            return callback();
+        }
+        return callback(userId);
+    });
+}

--- a/lib/backends/pubsub-metrics.js
+++ b/lib/backends/pubsub-metrics.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { PubSub } = require('@google-cloud/pubsub');
+
+/**
+ * PubSubMetricsBackend
+ */
+class PubSubMetricsBackend {
+    static build () {
+        if (!global.environment.pubSubMetrics || !global.environment.pubSubMetrics.enabled) {
+            return new PubSubMetricsBackend(undefined, false);
+        }
+
+        const pubsub = PubSubMetricsBackend.createPubSub();
+
+        return new PubSubMetricsBackend(pubsub, true);
+    }
+
+    static createPubSub () {
+        const projectId = global.environment.pubSubMetrics.project_id;
+        const credentials = global.environment.pubSubMetrics.credentials;
+        const config = {};
+
+        if (projectId) {
+            config.projectId = projectId;
+        }
+        if (credentials) {
+            config.keyFilename = credentials;
+        }
+        return new PubSub(config);
+    }
+
+    constructor (pubSub, enabled) {
+        this.pubsub = pubSub;
+        this.enabled = enabled;
+    }
+
+    isEnabled () {
+        return this.enabled;
+    }
+
+    _getTopic () {
+        const topicName = global.environment.pubSubMetrics.topic;
+
+        return this.pubsub.topic(topicName);
+    }
+
+    sendEvent (event, attributes) {
+        if (!this.enabled) {
+            return;
+        }
+
+        const data = Buffer.from(event);
+        const topic = this._getTopic();
+
+        topic.publish(data, attributes)
+            .then(() => {
+                console.log(`PubSubTracker: event '${event}' published to '${topic.name}'`);
+            })
+            .catch((error) => {
+                console.error(`ERROR: pubsub middleware failed to publish event '${event}': ${error.message}`);
+            });
+    }
+}
+
+module.exports = PubSubMetricsBackend;

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,9 +197,79 @@
       "resolved": "https://registry.npmjs.org/@carto/mapnik/-/mapnik-3.6.2-carto.16.tgz",
       "integrity": "sha512-RX8ov5EpEheToESVKiKnV5yMPLA2KxaX2ANAs9W4856oKFPdbGmB2buDz54mLhwBDfler9GVo0Bzr2ayRVLO2A==",
       "requires": {
-        "mapnik-vector-tile": "github:cartodb/mapnik-vector-tile#v1.6.1-carto.2",
+        "mapnik-vector-tile": "github:cartodb/mapnik-vector-tile#e7ca5471f9e5de81243e6035e70444321fc0a82f",
         "nan": "2.14.0",
         "node-pre-gyp": "0.13.0"
+      }
+    },
+    "@google-cloud/paginator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.3.tgz",
+      "integrity": "sha512-kp/pkb2p/p0d8/SKUu4mOq8+HGwF8NPzHWkj+VKrIPQPyMRw8deZtrO/OcSiy9C/7bpfU5Txah5ltUNfPkgEXg==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      }
+    },
+    "@google-cloud/precise-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-1.0.3.tgz",
+      "integrity": "sha512-wWnDGh9y3cJHLuVEY8t6un78vizzMWsS7oIWKeFtPj+Ndy+dXvHW0HTx29ZUhen+tswSlQYlwFubvuRP5kKdzQ=="
+    },
+    "@google-cloud/projectify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.4.tgz",
+      "integrity": "sha512-ZdzQUN02eRsmTKfBj9FDL0KNDIFNjBn/d6tHQmA/+FImH5DO6ZV8E7FzxMgAUiVAUq41RFAkb25p1oHOZ8psfg=="
+    },
+    "@google-cloud/promisify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.4.tgz",
+      "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
+    },
+    "@google-cloud/pubsub": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-1.5.0.tgz",
+      "integrity": "sha512-SCuNClo/xDGjYmciExxVjX78WPY1Ul6MK5Qn5eX2tsILqxXpf5Lan+XU/jnL53pirAIFgcxt8I2CWibSdSqRww==",
+      "requires": {
+        "@google-cloud/paginator": "^2.0.0",
+        "@google-cloud/precise-date": "^1.0.0",
+        "@google-cloud/projectify": "^1.0.0",
+        "@google-cloud/promisify": "^1.0.0",
+        "@types/duplexify": "^3.6.0",
+        "@types/long": "^4.0.0",
+        "arrify": "^2.0.0",
+        "async-each": "^1.0.1",
+        "extend": "^3.0.2",
+        "google-auth-library": "^5.5.0",
+        "google-gax": "^1.7.5",
+        "is-stream-ended": "^0.1.4",
+        "lodash.snakecase": "^4.1.1",
+        "p-defer": "^3.0.0",
+        "protobufjs": "^6.8.1"
+      }
+    },
+    "@grpc/grpc-js": {
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.16.tgz",
+      "integrity": "sha512-TckwrK2duWTeqE/fYQ5JaLMDwqLuun0B/yswf8Bb9Pb7vb5xGd3iulmcnnaA2RDVd/abQTHnkSAjfRibYU24eQ==",
+      "requires": {
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "@grpc/proto-loader": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.3.tgz",
+      "integrity": "sha512-8qvUtGg77G2ZT2HqdqYoM/OY97gQd/0crSG34xNmZ4ZOsv3aQT/FQV9QfZPazTGna6MIoyUd+u6AxsoZjJ/VMQ==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "protobufjs": "^6.8.6"
       }
     },
     "@mapbox/sphericalmercator": {
@@ -207,10 +277,156 @@
       "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz",
       "integrity": "sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA=="
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "@sinonjs/commons": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.0.tgz",
+      "integrity": "sha512-atR1J/jRXvQAb47gfzSK8zavXy7BcpnYq21ALon0U99etu99vsir0trzIO3wpeLtW+LLVY6X7EkfVTbjGSH8Ww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.0.tgz",
+      "integrity": "sha512-ejFRrFNMaTAmhg9u1lYKJQxDocowta6KQKFnBE7XtZb/AAPlLkWQQSaqwlGYnDWQ6paXzyM1vbMhLAujSFiVPw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^4.2.0"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.2.tgz",
+          "integrity": "sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.6.0",
+            "lodash.get": "^4.4.2",
+            "type-detect": "^4.0.8"
+          }
+        }
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.1.tgz",
+      "integrity": "sha512-iSZdE68szyFvV8ReYve6t4gAA1rLVwGyyhWBg9qrz8VAn1FH141gdg0NJcMrAJ069rD2XM2KQzY8ZNDgmTfBQA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "@types/duplexify": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-5zOA53RUlzN74bvrSGwjudssD9F3a797sDZQkiYpUOxW+WHaXTCPz4/d5Dgi6FKnOqZ2CpaTo0DhgIfsXAOE/A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
+    "@types/node": {
+      "version": "13.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
+      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -232,6 +448,29 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
       "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "ajv": {
       "version": "5.5.2",
@@ -341,6 +580,11 @@
         "es-abstract": "^1.7.0"
       }
     },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -371,6 +615,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -391,6 +640,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "basic-auth": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
@@ -406,6 +660,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -456,6 +715,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-writer": {
       "version": "1.0.1",
@@ -605,7 +869,7 @@
       "integrity": "sha512-myLV2xo3q9oTT8m8M+c+UTD/ziDN7hrYtZ9yY00KvMnu2NsVeRQsTe8Yxq1GVS8vF9iYfcelwjVEGObPUdLtHw==",
       "requires": {
         "debug": "^3.1.0",
-        "pg": "github:cartodb/node-postgres#6.4.2-cdb2",
+        "pg": "github:cartodb/node-postgres#5417d7b29b7272ca2e71bb396899ab3f177a9ae6",
         "underscore": "~1.6.0"
       }
     },
@@ -1001,6 +1265,46 @@
         "nan": "^2.0.8"
       }
     },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1008,6 +1312,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -1025,6 +1337,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1556,6 +1876,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -1730,6 +2055,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-text-encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
+      "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
     },
     "fastly-purge": {
       "version": "1.0.1",
@@ -1998,6 +2328,25 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
+      }
+    },
+    "gaxios": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.1.tgz",
+      "integrity": "sha512-DQOesWEx59/bm63lTX0uHDDXpGTW9oKqNsoigwCoRe2lOb5rFqxzHjLTa6aqEBecLcz69dHLw7rbS068z1fvIQ==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        }
       }
     },
     "gc-stats": {
@@ -2414,6 +2763,15 @@
           "version": "3.0.2",
           "bundled": true
         }
+      }
+    },
+    "gcp-metadata": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.3.1.tgz",
+      "integrity": "sha512-RrASg1HaVAxoB9Q/8sYfJ++v9PMiiqIgOrOxZeagMgS4osZtICT1lKBx2uvzYgwetxj8i6K99Z0iuKMg7WraTg==",
+      "requires": {
+        "gaxios": "^2.1.0",
+        "json-bigint": "^0.3.0"
       }
     },
     "gdal": {
@@ -2892,6 +3250,73 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "google-auth-library": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.9.2.tgz",
+      "integrity": "sha512-rBE1YTOZ3/Hu6Mojkr+UUmbdc/F28hyMGYEGxjyfVA9ZFmq12oqS3AeftX4h9XpdVIcxPooSo8hECYGT6B9XqQ==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^2.1.0",
+        "gcp-metadata": "^3.3.0",
+        "gtoken": "^4.1.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^5.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "google-gax": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.14.1.tgz",
+      "integrity": "sha512-lAvILUMnXL+BVSSlbzwpGzs3ZP2r+b1l44zeDTRWceejDgyZORKdPEEhtUw49x9CVwxpPx02+v0yktqnRhUD1A==",
+      "requires": {
+        "@grpc/grpc-js": "^0.6.12",
+        "@grpc/proto-loader": "^0.5.1",
+        "@types/fs-extra": "^8.0.1",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^3.6.0",
+        "google-auth-library": "^5.0.0",
+        "is-stream-ended": "^0.1.4",
+        "lodash.at": "^4.6.0",
+        "lodash.has": "^4.5.2",
+        "node-fetch": "^2.6.0",
+        "protobufjs": "^6.8.8",
+        "retry-request": "^4.0.0",
+        "semver": "^6.0.0",
+        "walkdir": "^0.4.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
+      "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
+      "requires": {
+        "node-forge": "^0.9.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -2905,7 +3330,7 @@
         "carto": "0.16.3",
         "debug": "~3.1.0",
         "generic-pool": "~2.2.0",
-        "millstone": "github:cartodb/millstone#v0.6.17-carto.3",
+        "millstone": "github:cartodb/millstone#eeeb308fba4586343bb848fbf8ae0d180192627d",
         "postcss": "~5.2.8",
         "postcss-scss": "0.4.0",
         "postcss-strip-inline-comments": "0.1.5",
@@ -2998,6 +3423,24 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "gtoken": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
+      "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+      "requires": {
+        "gaxios": "^2.1.0",
+        "google-p12-pem": "^2.0.0",
+        "jws": "^4.0.0",
+        "mime": "^2.2.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        }
+      }
     },
     "handlebars": {
       "version": "4.5.3",
@@ -3114,6 +3557,30 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "husl": {
@@ -3356,6 +3823,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-stream-ended": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
+    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -3560,6 +4032,14 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-bigint": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
+      "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+      "requires": {
+        "bignumber.js": "^7.0.0"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -3596,6 +4076,31 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "lcid": {
@@ -3654,11 +4159,37 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
+    "lodash.at": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.at/-/lodash.at-4.6.0.tgz",
+      "integrity": "sha1-k83OZk8KGZTqM9181A4jr9EbD/g="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
     },
     "log4js": {
       "version": "github:cartodb/log4js-node#145d5f91e35e7fb14a6278cbf7a711ced6603727",
@@ -3686,6 +4217,11 @@
           "integrity": "sha1-ZN8utZCJnelQeC83NRkLpC6/MR0="
         }
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -4013,6 +4549,52 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.1.tgz",
+      "integrity": "sha512-10PKL272rqg80o2RsWcTT6X9cDYqJ4kXqPTf8yCXPc9hbphZSDmbiG5FqUNeR5nouKCQMM24ld45kgYnBdx2rw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/formatio": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+          "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1",
+            "@sinonjs/samsam": "^4.2.0"
+          }
+        },
+        "@sinonjs/samsam": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.2.tgz",
+          "integrity": "sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.6.0",
+            "lodash.get": "^4.4.2",
+            "type-detect": "^4.0.8"
+          }
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
     "nock": {
       "version": "9.2.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-9.2.6.tgz",
@@ -4029,6 +4611,16 @@
         "qs": "^6.5.1",
         "semver": "^5.5.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-forge": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
     "node-pre-gyp": {
       "version": "0.13.0",
@@ -4483,6 +5075,11 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -4785,6 +5382,33 @@
       "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
     },
+    "protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.16.tgz",
+          "integrity": "sha512-A4283YSA1OmnIivcpy/4nN86YlnKRiQp8PYwI2KdPCONEBN093QTb0gCtERtkLyVNGKKIGazTZ2nAmVzQU51zA=="
+        }
+      }
+    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -4992,6 +5616,30 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "retry-request": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.1.tgz",
+      "integrity": "sha512-BINDzVtLI2BDukjWmjAIRZ0oglnCAkpP2vQjM3jdLhmT62h0xnQgciPwBRDAvHqpkPT2Wo1XuUyLyn6nbGrZQQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "rimraf": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
@@ -5153,6 +5801,44 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/simple-statistics/-/simple-statistics-0.9.2.tgz",
       "integrity": "sha1-PjXLEDCPx2ljqk7nJS5qbqENKOQ="
+    },
+    "sinon": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "@sinonjs/samsam": "^5.0.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -5318,6 +6004,11 @@
           }
         }
       }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strftime": {
       "version": "0.10.0",
@@ -5648,6 +6339,39 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "through2": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+      "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+      "requires": {
+        "readable-stream": "2 || 3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -5668,7 +6392,7 @@
       "resolved": "https://registry.npmjs.org/torque.js/-/torque.js-3.1.1.tgz",
       "integrity": "sha512-kfIrmI7TGqJT/J9DH8Mgvd9VEwcvAtnvyYyqymSN6WZ5L4BaVQEQ+zu5FgLChNAqCaRkqGc7bKp0Hj9A0rempA==",
       "requires": {
-        "carto": "github:cartodb/carto#master",
+        "carto": "github:cartodb/carto#85881d99dd7fcf2c4e16478b04db67108d27a50c",
         "d3": "3.5.17",
         "turbo-carto": "^0.21.1",
         "turf-jenks": "~1.0.1"
@@ -5838,6 +6562,11 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -5872,7 +6601,7 @@
         "@carto/cartonik": "^0.7.0",
         "@carto/mapnik": "3.6.2-carto.16",
         "canvas": "^2.4.1",
-        "carto": "github:cartodb/carto#0.15.1-cdb5",
+        "carto": "github:cartodb/carto#85881d99dd7fcf2c4e16478b04db67108d27a50c",
         "cartodb-psql": "^0.14.0",
         "cartodb-query-tables": "^0.6.1",
         "debug": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "main": "app.js",
   "dependencies": {
     "@carto/fqdn-sync": "0.2.2",
+    "@google-cloud/pubsub": "1.5.0",
     "basic-auth": "2.0.0",
     "body-parser": "1.18.3",
     "camshaft": "^0.65.1",
@@ -75,7 +76,8 @@
     "nyc": "^14.1.1",
     "redis": "2.8.0",
     "step": "1.0.0",
-    "strftime": "0.10.0"
+    "strftime": "0.10.0",
+    "sinon": "^9.0.0"
   },
   "scripts": {
     "lint:fix": "eslint --fix app.js \"lib/**/*.js\" \"test/**/*.js\"",

--- a/test/acceptance/ported/attributes-test.js
+++ b/test/acceptance/ported/attributes-test.js
@@ -43,7 +43,7 @@ describe('attributes', function () {
         assert.strictEqual(
             res.headers['access-control-allow-headers'],
             'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
-            'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id'
+            'Carto-Event, Carto-Event-Source, Carto-Event-Group-Id'
         );
         assert.strictEqual(res.headers['access-control-allow-origin'], '*');
     }

--- a/test/acceptance/ported/attributes-test.js
+++ b/test/acceptance/ported/attributes-test.js
@@ -42,7 +42,8 @@ describe('attributes', function () {
     function checkCORSHeaders (res) {
         assert.strictEqual(
             res.headers['access-control-allow-headers'],
-            'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization'
+            'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
+            'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id'
         );
         assert.strictEqual(res.headers['access-control-allow-origin'], '*');
     }

--- a/test/acceptance/ported/multilayer-test.js
+++ b/test/acceptance/ported/multilayer-test.js
@@ -28,7 +28,7 @@ describe('multilayer', function () {
         assert.strictEqual(
             res.headers['access-control-allow-headers'],
             'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
-            'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id'
+            'Carto-Event, Carto-Event-Source, Carto-Event-Group-Id'
         );
         assert.strictEqual(res.headers['access-control-allow-origin'], '*');
     }
@@ -1034,7 +1034,7 @@ describe('multilayer', function () {
 
     it('geting options on layergroup should return CORS headers', function (done) {
         const allowHeaders = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
-                                'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id, Content-Type';
+                                'Carto-Event, Carto-Event-Source, Carto-Event-Group-Id, Content-Type';
         assert.response(server, {
             url: '/api/v1/map',
             method: 'OPTIONS'

--- a/test/acceptance/ported/multilayer-test.js
+++ b/test/acceptance/ported/multilayer-test.js
@@ -27,7 +27,8 @@ describe('multilayer', function () {
     function checkCORSHeaders (res) {
         assert.strictEqual(
             res.headers['access-control-allow-headers'],
-            'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization'
+            'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
+            'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id'
         );
         assert.strictEqual(res.headers['access-control-allow-origin'], '*');
     }
@@ -1032,7 +1033,8 @@ describe('multilayer', function () {
     /// /////////////////////////////////////////////////////////////////
 
     it('geting options on layergroup should return CORS headers', function (done) {
-        const allowHeaders = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, Content-Type';
+        const allowHeaders = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
+                                'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id, Content-Type';
         assert.response(server, {
             url: '/api/v1/map',
             method: 'OPTIONS'

--- a/test/acceptance/ported/raster-test.js
+++ b/test/acceptance/ported/raster-test.js
@@ -20,7 +20,7 @@ describe('raster', function () {
         assert.strictEqual(
             res.headers['access-control-allow-headers'],
             'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
-            'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id'
+            'Carto-Event, Carto-Event-Source, Carto-Event-Group-Id'
         );
         assert.strictEqual(res.headers['access-control-allow-origin'], '*');
     }

--- a/test/acceptance/ported/raster-test.js
+++ b/test/acceptance/ported/raster-test.js
@@ -19,7 +19,8 @@ describe('raster', function () {
     function checkCORSHeaders (res) {
         assert.strictEqual(
             res.headers['access-control-allow-headers'],
-            'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization'
+            'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
+            'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id'
         );
         assert.strictEqual(res.headers['access-control-allow-origin'], '*');
     }

--- a/test/acceptance/ported/torque-test.js
+++ b/test/acceptance/ported/torque-test.js
@@ -31,7 +31,7 @@ describe('torque', function () {
         assert.strictEqual(
             res.headers['access-control-allow-headers'],
             'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
-            'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id'
+            'Carto-Event, Carto-Event-Source, Carto-Event-Group-Id'
         );
         assert.strictEqual(res.headers['access-control-allow-origin'], '*');
     }

--- a/test/acceptance/ported/torque-test.js
+++ b/test/acceptance/ported/torque-test.js
@@ -30,7 +30,8 @@ describe('torque', function () {
     function checkCORSHeaders (res) {
         assert.strictEqual(
             res.headers['access-control-allow-headers'],
-            'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization'
+            'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
+            'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id'
         );
         assert.strictEqual(res.headers['access-control-allow-origin'], '*');
     }

--- a/test/acceptance/templates-test.js
+++ b/test/acceptance/templates-test.js
@@ -304,7 +304,7 @@ describe('template_api', function () {
         },
         function testCORS () {
             const allowHeaders = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
-                                    'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id, Content-Type';
+                                    'Carto-Event, Carto-Event-Source, Carto-Event-Group-Id, Content-Type';
             assert.response(server, {
                 url: '/api/v1/map/named/acceptance1',
                 method: 'OPTIONS'

--- a/test/acceptance/templates-test.js
+++ b/test/acceptance/templates-test.js
@@ -303,7 +303,8 @@ describe('template_api', function () {
             assert.response(server, postRequest, {}, function (res) { next(null, res); });
         },
         function testCORS () {
-            const allowHeaders = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, Content-Type';
+            const allowHeaders = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, ' +
+                                    'Carto-Source-Lib, Carto-Source-Context, Carto-Source-Context-Id, Content-Type';
             assert.response(server, {
                 url: '/api/v1/map/named/acceptance1',
                 method: 'OPTIONS'

--- a/test/integration/pubsub-metrics-test.js
+++ b/test/integration/pubsub-metrics-test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const sinon = require('sinon');
+const assert = require('assert');
+const redis = require('redis');
+const TestClient = require('../support/test-client');
+const PubSubMetricsBackend = require('../../lib/backends/pubsub-metrics');
+
+const metricsHeaders = {
+    'Carto-Event': 'test-event',
+    'Carto-Event-Source': 'test',
+    'Carto-Event-Group-Id': '1'
+};
+
+const mapConfig = {
+    version: '1.7.0',
+    layers: [
+        {
+            options: {
+                sql: 'select * FROM test_table_localhost_regular1',
+                cartocss: TestClient.CARTOCSS.POINTS,
+                cartocss_version: '2.3.0'
+            }
+        }
+    ]
+};
+
+function buildEventAttributes (statusCode) {
+    return {
+        event_source: 'test',
+        user_id: '1',
+        event_group_id: '1',
+        response_code: statusCode.toString(),
+        source_domain: 'localhost',
+        event_time: new Date().toISOString(),
+        event_version: '1'
+    };
+}
+
+const fakeTopic = {
+    name: 'test-topic',
+    publish: sinon.stub().returns(Promise.resolve())
+};
+
+const fakePubSub = {
+    topic: () => fakeTopic
+};
+
+describe('pubsub metrics middleware', function () {
+    let redisClient;
+    let testClient;
+    let clock;
+
+    before(function () {
+        redisClient = redis.createClient(global.environment.redis.port);
+        clock = sinon.useFakeTimers();
+        sinon.stub(PubSubMetricsBackend, 'createPubSub').returns(fakePubSub);
+    });
+
+    after(function () {
+        clock.restore();
+        PubSubMetricsBackend.createPubSub.restore();
+        global.environment.pubSubMetrics.enabled = false;
+    });
+
+    afterEach(function (done) {
+        fakeTopic.publish.resetHistory();
+
+        redisClient.SELECT(0, () => {
+            redisClient.del('user:localhost:mapviews:global');
+
+            redisClient.SELECT(5, () => {
+                redisClient.del('user:localhost:mapviews:global');
+                done();
+            });
+        });
+    });
+
+    it('should not send event if not enabled', function (done) {
+        global.environment.pubSubMetrics.enabled = false;
+        testClient = new TestClient(mapConfig, 1234, metricsHeaders);
+
+        testClient.getLayergroup((err, body) => {
+            if (err) {
+                return done(err);
+            }
+
+            assert.strictEqual(typeof body.metadata, 'object');
+            assert(fakeTopic.publish.notCalled);
+            return done();
+        });
+    });
+
+    it('should not send event if headers not present', function (done) {
+        global.environment.pubSubMetrics.enabled = true;
+        testClient = new TestClient(mapConfig, 1234);
+
+        testClient.getLayergroup((err, body) => {
+            if (err) {
+                return done(err);
+            }
+
+            assert.strictEqual(typeof body.metadata, 'object');
+            assert(fakeTopic.publish.notCalled);
+            return done();
+        });
+    });
+
+    it('should send event for map requests', function (done) {
+        global.environment.pubSubMetrics.enabled = true;
+        const eventAttributes = buildEventAttributes(200);
+        testClient = new TestClient(mapConfig, 1234, metricsHeaders);
+
+        testClient.getLayergroup((err, body) => {
+            if (err) {
+                return done(err);
+            }
+
+            assert.strictEqual(typeof body.metadata, 'object');
+            assert(fakeTopic.publish.calledOnceWith(Buffer.from('test-event'), eventAttributes));
+            return done();
+        });
+    });
+
+    it('should send event when error', function (done) {
+        global.environment.pubSubMetrics.enabled = true;
+        const eventAttributes = buildEventAttributes(400);
+        eventAttributes.user_id = undefined;
+
+        testClient = new TestClient({}, 1234, metricsHeaders);
+
+        testClient.getLayergroup(() => {
+            assert(fakeTopic.publish.calledOnceWith(Buffer.from('test-event'), eventAttributes));
+            assert(fakeTopic.publish.calledOnce);
+            return done();
+        });
+    });
+});

--- a/test/integration/pubsub-metrics-test.js
+++ b/test/integration/pubsub-metrics-test.js
@@ -12,7 +12,7 @@ const metricsHeaders = {
     'Carto-Event-Group-Id': '1'
 };
 
-const tooLongField = 'If you are sending a text this long in a header you kind of deserve the worst, honestly. I mean ' +
+const tooLongField = '    If you are sending a text this long in a header you kind of deserve the worst, honestly. I mean ' +
     'this is not a header, it is almost a novel, and you do not see any Novel cookie here, right?';
 
 const badHeaders = {
@@ -119,7 +119,7 @@ describe('pubsub metrics middleware', function () {
         global.environment.pubSubMetrics.enabled = true;
         const eventAttributes = buildEventAttributes(200);
         const maxLength = 100;
-        const eventName = tooLongField.substr(0, maxLength);
+        const eventName = tooLongField.trim().substr(0, maxLength);
 
         testClient = new TestClient(mapConfig, 1234, badHeaders);
 

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -23,10 +23,11 @@ const MAPNIK_SUPPORTED_FORMATS = {
     mvt: true
 };
 
-function TestClient (config, apiKey) {
+function TestClient (config, apiKey, extraHeaders) {
     this.mapConfig = isMapConfig(config) ? config : null;
     this.template = isTemplate(config) ? config : null;
     this.apiKey = apiKey;
+    this.extraHeaders = extraHeaders || {};
     this.keysToDelete = {};
     this.server = new CartodbWindshaft(serverOptions);
 }
@@ -146,6 +147,8 @@ TestClient.prototype.getWidget = function (widgetName, params, callback) {
         url += '?' + qs.stringify({ filters: JSON.stringify(params.filters) });
     }
 
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
+
     step(
         function createLayergroup () {
             var next = this;
@@ -153,10 +156,7 @@ TestClient.prototype.getWidget = function (widgetName, params, callback) {
                 {
                     url: url,
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(self.mapConfig)
                 },
                 {
@@ -208,14 +208,13 @@ TestClient.prototype.getWidget = function (widgetName, params, callback) {
             });
 
             url = '/api/v1/map/' + layergroupId + '/0/widget/' + widgetName + '?' + qs.stringify(urlParams);
+            const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
 
             assert.response(self.server,
                 {
                     url: url,
                     method: 'GET',
-                    headers: {
-                        host: 'localhost'
-                    }
+                    headers
                 },
                 {
                     status: 200,
@@ -258,14 +257,13 @@ TestClient.prototype.widgetSearch = function (widgetName, userQuery, params, cal
     step(
         function createLayergroup () {
             var next = this;
+            const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
+
             assert.response(self.server,
                 {
                     url: url,
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(self.mapConfig)
                 },
                 {
@@ -315,14 +313,13 @@ TestClient.prototype.widgetSearch = function (widgetName, userQuery, params, cal
                 urlParams.bbox = params.bbox;
             }
             url = '/api/v1/map/' + layergroupId + '/0/widget/' + widgetName + '/search?' + qs.stringify(urlParams);
+            const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
 
             assert.response(self.server,
                 {
                     url: url,
                     method: 'GET',
-                    headers: {
-                        host: 'localhost'
-                    }
+                    headers
                 },
                 {
                     status: 200,
@@ -367,10 +364,11 @@ TestClient.prototype.getDataview = function (dataviewName, params, callback) {
 
     var url = '/api/v1/map';
     var urlNamed = url + '/named';
-
     if (Object.keys(extraParams).length > 0) {
         url += '?' + qs.stringify(extraParams);
     }
+
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
 
     var expectedResponse = params.response || {
         status: 200,
@@ -397,10 +395,7 @@ TestClient.prototype.getDataview = function (dataviewName, params, callback) {
                 {
                     url: urlNamed + '?' + qs.stringify({ api_key: self.apiKey }),
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(self.template)
                 },
                 {
@@ -437,15 +432,13 @@ TestClient.prototype.getDataview = function (dataviewName, params, callback) {
             var path = templateId
                 ? urlNamed + '/' + templateId + '?' + qs.stringify(queryParams)
                 : url;
+            const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
 
             assert.response(self.server,
                 {
                     url: path,
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(data)
                 },
                 {
@@ -495,14 +488,13 @@ TestClient.prototype.getDataview = function (dataviewName, params, callback) {
                 urlParams.api_key = self.apiKey;
             }
             url = '/api/v1/map/' + layergroupId + '/dataview/' + dataviewName + '?' + qs.stringify(urlParams);
+            const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
 
             assert.response(self.server,
                 {
                     url: url,
                     method: 'GET',
-                    headers: {
-                        host: 'localhost'
-                    }
+                    headers
                 },
                 expectedResponse,
                 function (res, err) {
@@ -543,6 +535,8 @@ TestClient.prototype.getFeatureAttributes = function (featureId, layerId, params
         url += '?' + qs.stringify(extraParams);
     }
 
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
+
     var expectedResponse = params.response || {
         status: 200,
         headers: {
@@ -557,10 +551,7 @@ TestClient.prototype.getFeatureAttributes = function (featureId, layerId, params
                 {
                     url: url,
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(self.mapConfig)
                 },
                 {
@@ -591,14 +582,13 @@ TestClient.prototype.getFeatureAttributes = function (featureId, layerId, params
             var next = this;
 
             url = '/api/v1/map/' + layergroupId + '/' + layerId + '/attributes/' + featureId;
+            const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
 
             assert.response(self.server,
                 {
                     url: url,
                     method: 'GET',
-                    headers: {
-                        host: 'localhost'
-                    }
+                    headers
                 },
                 expectedResponse,
                 function (res, err) {
@@ -643,6 +633,8 @@ TestClient.prototype.getClusterFeatures = function (zoom, clusterId, layerId, pa
         url += '?' + qs.stringify(extraParams);
     }
 
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
+
     var expectedResponse = params.response || {
         status: 200,
         headers: {
@@ -657,10 +649,7 @@ TestClient.prototype.getClusterFeatures = function (zoom, clusterId, layerId, pa
                 {
                     url: url,
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(self.mapConfig)
                 },
                 {
@@ -696,14 +685,13 @@ TestClient.prototype.getClusterFeatures = function (zoom, clusterId, layerId, pa
             }
 
             url = `/api/v1/map/${layergroupId}/${layerId}/${zoom}/cluster/${clusterId}?${queryParams}`;
+            const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
 
             assert.response(self.server,
                 {
                     url: url,
                     method: 'GET',
-                    headers: {
-                        host: 'localhost'
-                    }
+                    headers
                 },
                 expectedResponse,
                 function (res, err) {
@@ -735,6 +723,7 @@ TestClient.prototype.getTile = function (z, x, y, params, callback) {
 
     var url = '/api/v1/map';
     var urlNamed = url + '/named';
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
 
     if (this.apiKey) {
         url += '?' + qs.stringify({ api_key: this.apiKey });
@@ -764,10 +753,7 @@ TestClient.prototype.getTile = function (z, x, y, params, callback) {
                 {
                     url: urlNamed + '?' + qs.stringify({ api_key: self.apiKey }),
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(self.template)
                 },
                 {
@@ -811,14 +797,13 @@ TestClient.prototype.getTile = function (z, x, y, params, callback) {
                 ? urlNamed + '/' + templateId + '?' + qs.stringify(queryParams)
                 : url;
 
+            const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
+
             assert.response(self.server,
                 {
                     url: path,
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(data)
                 },
                 {
@@ -843,14 +828,12 @@ TestClient.prototype.getTile = function (z, x, y, params, callback) {
             self.keysToDelete['user:localhost:mapviews:global'] = 5;
 
             url = `/api/v1/map/${layergroupidTemplate(layergroupId, params)}/`;
-
             var layers = params.layers;
 
             if (layers !== undefined) {
                 layers = Array.isArray(layers) ? layers : [layers];
                 url += layers.join(',') + '/';
             }
-
             var format = params.format || 'png';
 
             if (layers === undefined && !MAPNIK_SUPPORTED_FORMATS[format]) {
@@ -859,6 +842,8 @@ TestClient.prototype.getTile = function (z, x, y, params, callback) {
 
             url += [z, x, y].join('/');
             url += '.' + format;
+
+            const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
 
             const queryParams = {};
 
@@ -873,9 +858,7 @@ TestClient.prototype.getTile = function (z, x, y, params, callback) {
             var request = {
                 url: url,
                 method: 'GET',
-                headers: {
-                    host: 'localhost'
-                }
+                headers
             };
 
             var expectedResponse = Object.assign({}, {
@@ -970,6 +953,7 @@ TestClient.prototype.getLayergroup = function (params, callback) {
     }
 
     var url = '/api/v1/map';
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
 
     const queryParams = {};
 
@@ -989,10 +973,7 @@ TestClient.prototype.getLayergroup = function (params, callback) {
         {
             url: url,
             method: 'POST',
-            headers: {
-                host: 'localhost',
-                'Content-Type': 'application/json'
-            },
+            headers,
             data: JSON.stringify(self.mapConfig)
         },
         params.response,
@@ -1022,10 +1003,11 @@ TestClient.prototype.getStaticCenter = function (params, callback) {
     const { layergroupid, zoom, lat, lng, width, height, format } = params;
 
     var url = '/api/v1/map/';
-
     if (this.apiKey) {
         url += '?' + qs.stringify({ api_key: this.apiKey });
     }
+
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, self.extraHeaders);
 
     step(
         function createLayergroup () {
@@ -1042,10 +1024,7 @@ TestClient.prototype.getStaticCenter = function (params, callback) {
                 {
                     url: path,
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(data)
                 },
                 {
@@ -1076,13 +1055,13 @@ TestClient.prototype.getStaticCenter = function (params, callback) {
                 url += '?' + qs.stringify({ api_key: self.apiKey });
             }
 
+            const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
+
             var request = {
                 url: url,
                 encoding: 'binary',
                 method: 'GET',
-                headers: {
-                    host: 'localhost'
-                }
+                headers
             };
 
             var expectedResponse = Object.assign({}, {
@@ -1126,6 +1105,8 @@ TestClient.prototype.getNodeStatus = function (nodeName, callback) {
         url += '?' + qs.stringify({ api_key: this.apiKey });
     }
 
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, this.extraHeaders);
+
     var nodes = {};
     step(
         function createLayergroup () {
@@ -1134,10 +1115,7 @@ TestClient.prototype.getNodeStatus = function (nodeName, callback) {
                 {
                     url: url,
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(self.mapConfig)
                 },
                 {
@@ -1176,12 +1154,12 @@ TestClient.prototype.getNodeStatus = function (nodeName, callback) {
                 url += '?' + qs.stringify({ api_key: self.apiKey });
             }
 
+            const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
+
             var request = {
                 url: url,
                 method: 'GET',
-                headers: {
-                    host: 'localhost'
-                }
+                headers
             };
 
             var expectedResponse = {
@@ -1219,6 +1197,8 @@ TestClient.prototype.getAttributes = function (params, callback) {
         url += '?' + qs.stringify({ api_key: this.apiKey });
     }
 
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, this.extraHeaders);
+
     var layergroupid;
 
     if (params.layergroupid) {
@@ -1237,10 +1217,7 @@ TestClient.prototype.getAttributes = function (params, callback) {
                 {
                     url: url,
                     method: 'POST',
-                    headers: {
-                        host: 'localhost',
-                        'Content-Type': 'application/json'
-                    },
+                    headers,
                     data: JSON.stringify(self.mapConfig)
                 },
                 {
@@ -1271,12 +1248,12 @@ TestClient.prototype.getAttributes = function (params, callback) {
                 url += '?' + qs.stringify({ api_key: self.apiKey });
             }
 
+            const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
+
             var request = {
                 url: url,
                 method: 'GET',
-                headers: {
-                    host: 'localhost'
-                }
+                headers
             };
 
             var expectedResponse = params.response || {
@@ -1318,12 +1295,12 @@ module.exports.getStaticMap = function getStaticMap (templateName, params, callb
         url += '?' + qs.stringify(params);
     }
 
+    const headers = Object.assign({ host: 'localhost' }, self.extraHeaders);
+
     var requestOptions = {
         url: url,
         method: 'GET',
-        headers: {
-            host: 'localhost'
-        },
+        headers,
         encoding: 'binary'
     };
 
@@ -1417,14 +1394,13 @@ TestClient.prototype.getAnalysesCatalog = function (params, callback) {
         url += '&' + qs.stringify({ callback: params.jsonp });
     }
 
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, this.extraHeaders);
+
     assert.response(this.server,
         {
             url: url,
             method: 'GET',
-            headers: {
-                host: 'localhost',
-                'Content-Type': 'application/json'
-            }
+            headers
         },
         {
             status: params.status || 200,
@@ -1447,13 +1423,12 @@ TestClient.prototype.getAnalysesCatalog = function (params, callback) {
 };
 
 TestClient.prototype.getNamedMapList = function (params, callback) {
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, this.extraHeaders);
+
     const request = {
         url: `/api/v1/map/named?${qs.stringify({ api_key: this.apiKey })}`,
         method: 'GET',
-        headers: {
-            host: 'localhost',
-            'Content-Type': 'application/json'
-        }
+        headers
     };
 
     let expectedResponse = {
@@ -1483,13 +1458,12 @@ TestClient.prototype.getNamedTile = function (name, z, x, y, format, options, ca
         return callback(new Error('apiKey param is mandatory to create a new template'));
     }
 
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, this.extraHeaders);
+
     const createTemplateRequest = {
         url: `/api/v1/map/named?${qs.stringify({ api_key: this.apiKey })}`,
         method: 'POST',
-        headers: {
-            host: 'localhost',
-            'Content-Type': 'application/json'
-        },
+        headers,
         data: JSON.stringify(this.template)
     };
 
@@ -1508,12 +1482,11 @@ TestClient.prototype.getNamedTile = function (name, z, x, y, format, options, ca
         const templateId = JSON.parse(res.body).template_id;
         const queryParams = params ? `?${qs.stringify(params)}` : '';
         const url = `/api/v1/map/named/${templateId}/all/${[z, x, y].join('/')}.${format}${queryParams}`;
+        const headers = Object.assign({ host: 'localhost' }, this.extraHeaders);
         const namedTileRequest = {
             url,
             method: 'GET',
-            headers: {
-                host: 'localhost'
-            },
+            headers,
             encoding: 'binary'
         };
 
@@ -1565,13 +1538,12 @@ TestClient.prototype.createTemplate = function (params, callback) {
         return callback(new Error('apiKey param is mandatory to create a new template'));
     }
 
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json' }, this.extraHeaders);
+
     const createTemplateRequest = {
         url: `/api/v1/map/named?${qs.stringify({ api_key: this.apiKey })}`,
         method: 'POST',
-        headers: {
-            host: 'localhost',
-            'Content-Type': 'application/json'
-        },
+        headers,
         data: JSON.stringify(this.template)
     };
 
@@ -1606,12 +1578,12 @@ TestClient.prototype.deleteTemplate = function (params, callback) {
         return callback(new Error('apiKey param is mandatory to create a new template'));
     }
 
+    const headers = Object.assign({ host: 'localhost' }, this.extraHeaders);
+
     const deleteTemplateRequest = {
         url: `/api/v1/map/named/${params.templateId}?${qs.stringify({ api_key: this.apiKey })}`,
         method: 'DELETE',
-        headers: {
-            host: 'localhost'
-        }
+        headers
     };
 
     let deleteTemplateResponse = {
@@ -1643,13 +1615,12 @@ TestClient.prototype.updateTemplate = function (params, callback) {
         return callback(new Error('apiKey param is mandatory to create a new template'));
     }
 
+    const headers = Object.assign({ host: 'localhost', 'Content-Type': 'application/json; charset=utf-8' }, this.extraHeaders);
+
     const updateTemplateRequest = {
         url: `/api/v1/map/named/${params.templateId}?${qs.stringify({ api_key: this.apiKey })}`,
         method: 'PUT',
-        headers: {
-            host: 'localhost',
-            'Content-Type': 'application/json; charset=utf-8'
-        },
+        headers,
         data: JSON.stringify(params.templateData)
     };
 
@@ -1684,12 +1655,12 @@ TestClient.prototype.getTemplate = function (params, callback) {
         return callback(new Error('apiKey param is mandatory to create a new template'));
     }
 
+    const headers = Object.assign({ host: 'localhost' }, this.extraHeaders);
+
     const getTemplateRequest = {
         url: `/api/v1/map/named/${params.templateId}?${qs.stringify({ api_key: this.apiKey })}`,
         method: 'GET',
-        headers: {
-            host: 'localhost'
-        }
+        headers
     };
 
     let getTemplateResponse = {

--- a/test/unit/backends/pubsub-metrics-test.js
+++ b/test/unit/backends/pubsub-metrics-test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const sinon = require('sinon');
+const assert = require('assert');
+const PubSubMetricsBackend = require('../../../lib/backends/pubsub-metrics');
+
+const fakeTopic = {
+    name: 'test-topic',
+    publish: sinon.stub().returns(Promise.resolve())
+};
+
+const fakePubSub = {
+    topic: () => fakeTopic
+};
+
+const eventAttributes = {
+    event_source: 'test',
+    user_id: '123',
+    event_group_id: '1',
+    response_code: '200',
+    source_domain: 'localhost',
+    event_time: new Date().toISOString(),
+    event_version: '1'
+};
+
+describe('pubsub metrics backend', function () {
+    it('should not send event if not enabled', function () {
+        const pubSubMetricsService = new PubSubMetricsBackend(fakePubSub, false);
+
+        pubSubMetricsService.sendEvent('test-event', eventAttributes);
+        assert(fakeTopic.publish.notCalled);
+    });
+
+    it('should send event if enabled', function () {
+        const pubSubMetricsService = new PubSubMetricsBackend(fakePubSub, true);
+
+        pubSubMetricsService.sendEvent('test-event', eventAttributes);
+        assert(fakeTopic.publish.calledOnceWith(Buffer.from('test-event'), eventAttributes));
+    });
+});

--- a/test/unit/error-middleware-test.js
+++ b/test/unit/error-middleware-test.js
@@ -62,13 +62,17 @@ describe('error-middleware', function () {
         };
 
         const errorFn = errorMiddleware();
-        errorFn(errors, req, res);
+        errorFn(errors, req, res, (err) => {
+            if (err) {
+                return done(err);
+            }
 
-        assert.deepStrictEqual(res.headers, {
-            'X-Tiler-Errors': JSON.stringify(errorHeader)
+            assert.deepStrictEqual(res.headers, {
+                'X-Tiler-Errors': JSON.stringify(errorHeader)
+            });
+
+            return done();
         });
-
-        done();
     });
 
     it('JSONP should return a header with error status code', function (done) {
@@ -114,13 +118,17 @@ describe('error-middleware', function () {
         };
 
         const errorFn = errorMiddleware();
-        errorFn(errors, req, res);
+        errorFn(errors, req, res, (err) => {
+            if (err) {
+                return done(err);
+            }
 
-        assert.deepStrictEqual(res.headers, {
-            'X-Tiler-Errors': JSON.stringify(errorHeader)
+            assert.deepStrictEqual(res.headers, {
+                'X-Tiler-Errors': JSON.stringify(errorHeader)
+            });
+
+            return done();
         });
-
-        done();
     });
 
     it('should escape chars that broke logs regex', function (done) {
@@ -167,12 +175,16 @@ describe('error-middleware', function () {
         };
 
         const errorFn = errorMiddleware();
-        errorFn(errors, req, res);
+        errorFn(errors, req, res, (err) => {
+            if (err) {
+                return done(err);
+            }
 
-        assert.deepStrictEqual(res.headers, {
-            'X-Tiler-Errors': JSON.stringify(errorHeader)
+            assert.deepStrictEqual(res.headers, {
+                'X-Tiler-Errors': JSON.stringify(errorHeader)
+            });
+
+            return done();
         });
-
-        done();
     });
 });


### PR DESCRIPTION
Closes [ch58706] https://app.clubhouse.io/cartoteam/story/58706/add-pubsub-middleware-to-maps-api

This PR adds a new middleware for sending metrics as pubsub events. This new middleware should be asynchronous and not wait for pubsub to finish.

**Acceptance:**

- Regular behavior should not be altered (navigate and perform some queries on staging to check everything goes well). No events should be generated since no request would add the headers now.
- Run some curl/postman requests with the new headers and check new events are created in the staging project in google cloud (ping me if you don't have access).
