### PR TITLE
Add response time to pubsub events

### DIFF
--- a/lib/api/middlewares/pubsub-metrics.js
+++ b/lib/api/middlewares/pubsub-metrics.js
@@ -41,6 +41,12 @@ function getEventData (req, res) {
         attributes.event_group_id = eventGroupId;
     }
 
+    const responseTime = getResponseTime(res);
+
+    if (responseTime) {
+        attributes.response_time = responseTime.toString();
+    }
+
     return { event, attributes };
 }
 
@@ -50,6 +56,19 @@ function normalizedField (field) {
     }
 
     return field.toString().trim().substr(0, MAX_LENGTH);
+}
+
+function getResponseTime (res) {
+    const profiler = res.get('X-SQLAPI-Profiler');
+    let stats;
+
+    try {
+        stats = JSON.parse(profiler);
+    } catch (e) {
+        return undefined;
+    }
+
+    return stats.total;
 }
 
 module.exports = pubSubMetrics;

--- a/lib/api/middlewares/pubsub-metrics.js
+++ b/lib/api/middlewares/pubsub-metrics.js
@@ -59,7 +59,7 @@ function normalizedField (field) {
 }
 
 function getResponseTime (res) {
-    const profiler = res.get('X-SQLAPI-Profiler');
+    const profiler = res.get('X-Tiler-Profiler');
     let stats;
 
     try {


### PR DESCRIPTION
Closes [ch61185] https://app.clubhouse.io/cartoteam/story/61185/add-response-time-to-apis-events