### PR TITLE
Fixes 1160: Prevent using cast column as part of __ctx_query

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@ Announcements:
 - Remove `bootstrapFonts` at process startup (now done in `windshaft@6.0.0`)
 - Stop checking the installed version of some dependencies while testing
 
+Bug Fixes:
+- Parsing date column in numeric histograms (#1160)
+
 ## 8.1.1
 Released 2020-02-17
 

--- a/lib/models/dataview/histograms/numeric-histogram.js
+++ b/lib/models/dataview/histograms/numeric-histogram.js
@@ -52,10 +52,18 @@ Numeric histogram:
 */
 module.exports = class NumericHistogram extends BaseHistogram {
     _buildQuery (psql, override, callback) {
+        let column = this.column;
+        let query = this.query;
+        // for date type we have to cast the column using an alias
+        // and using that alias to prevent multiple calls to the cast
+        if (this._columnType === 'date') {
+            query = `(SELECT *, ${utils.columnCastTpl({ column })} as __cdb_cast_date FROM (${this.query}) __cdb_original_query)`;
+            column = '__cdb_cast_date';
+        }
         const histogramSql = this._buildQueryTpl({
-            column: this._columnType === 'date' ? utils.columnCastTpl({ column: this.column }) : this.column,
+            column,
             isFloatColumn: this._columnType === 'float',
-            query: this.query,
+            query,
             start: this._getBinStart(override),
             end: this._getBinEnd(override),
             bins: this._getBinsCount(override),

--- a/test/acceptance/dataviews/histogram-test.js
+++ b/test/acceptance/dataviews/histogram-test.js
@@ -325,6 +325,15 @@ describe('histogram-dataview for date column type', function () {
                     column: 'd',
                     aggregation: 'minute'
                 }
+            },
+            date_histogram_no_agg: {
+                options: {
+                    column: 'd'
+                },
+                source: {
+                    id: 'minute-histogram-source-tz'
+                },
+                type: 'histogram'
             }
         },
         [
@@ -1229,6 +1238,21 @@ describe('histogram-dataview for date column type', function () {
             assert.ifError(err);
 
             assert.deepStrictEqual(dataview, dataviewWithDailyAggAndOffsetFixture);
+            done();
+        });
+    });
+
+    it('should work with dates without aggregation', function (done) {
+        var params = {
+            start: 1171583400,
+            end: 1171584600
+        };
+        this.testClient = new TestClient(mapConfig, 1234);
+        this.testClient.getDataview('date_histogram_no_agg', params, function (err, dataview) {
+            assert.ifError(err);
+            assert.strictEqual(dataview.type, 'histogram');
+            assert.strictEqual(dataview.bins.length, 6);
+            assert.strictEqual(dataview.bins_count, 6);
             done();
         });
     });


### PR DESCRIPTION
Prevent using cast column when it is date type as part of the alias `__ctx_query` for numeric histograms by keeping the original column.

Fixes #1160