### PR TITLE
Support Node.js 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       dist: bionic
 
 node_js:
-  - "10"
+  - "12"
 
 install:
  - npm ci

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,12 +5,15 @@ Released 2020-mm-dd
 
 Breaking changes:
 - Remove `/version` endpoint
+- Drop support for Node.js < 12
 
 Announcements:
-- Upgrade camshaft to [`0.65.3`](https://github.com/CartoDB/camshaft/blob/0.65.3/CHANGELOG.md#0653):
+- Support Node.js 12
+- Upgrade `windshaft` to version [`7.0.0`](https://github.com/CartoDB/Windshaft/releases/tag/7.0.0)
+- Upgrade `camshaft` to version [`0.65.3`](https://github.com/CartoDB/camshaft/blob/0.65.3/CHANGELOG.md#0653):
   - Fix noisy message logs while checking analyses' limits
   - Fix CI setup, explicit use of PGPORT while creating the PostgreSQL cluster
-- Upgrades major windshaft release version [`windshaft@6.0.0`](https://github.com/CartoDB/Windshaft/releases/tag/6.0.0)
+- Upgrade `cartodb-redis` to version [`3.0.0`](https://github.com/CartoDB/node-cartodb-redis/releases/tag/3.0.0)
 - Fix test where `http-fallback-image` renderer was failing quietly
 - Fix stat `named map providers` cache count
 - Use new signature for `onTileErrorStrategy`. Required by `windshaft@6.0.0`
@@ -24,6 +27,7 @@ Announcements:
 
 Bug Fixes:
 - Parsing date column in numeric histograms (#1160)
+- Use `Array.prototype.sort()`'s callback properly while testing. It should return a number not a boolean.
 
 ## 8.1.1
 Released 2020-02-17

--- a/lib/backends/template-maps.js
+++ b/lib/backends/template-maps.js
@@ -66,19 +66,15 @@ TemplateMaps.prototype._userTemplateLimit = function () {
  * @param callback - function to pass results too.
  */
 TemplateMaps.prototype._redisCmd = function (redisFunc, redisArgs, callback) {
-    this.redisPool.acquire(this.db_signatures, (err, redisClient) => {
-        if (err) {
-            return callback(err);
-        }
-
-        redisClient[redisFunc.toUpperCase()](...redisArgs, (err, data) => {
-            this.redisPool.release(this.db_signatures, redisClient);
-            if (err) {
-                return callback(err);
-            }
-            return callback(null, data);
-        });
-    });
+    this.redisPool.acquire(this.db_signatures)
+        .then((redisClient) => {
+            redisClient[redisFunc.toUpperCase()](...redisArgs, (err, data) => {
+                this.redisPool.release(this.db_signatures, redisClient)
+                    .then(() => err ? callback(err) : callback(null, data))
+                    .catch((err) => callback(err));
+            });
+        })
+        .catch((err) => callback(err));
 };
 
 var _reValidNameIdentifier = /^[a-z0-9][0-9a-z_-]*$/i;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2290,12 +2290,12 @@
       }
     },
     "gc-stats": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.2.1.tgz",
-      "integrity": "sha512-CPQfMBQPGkqG4upxCn4zHxYZo20woPClSeqnC/WK8pFqlfAtz6zpxbOfnmxOIDYiC26H/pYlWQfdoPVGoqxFUA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.4.0.tgz",
+      "integrity": "sha512-4FcCj9e8j8rCjvLkqRpGZBLgTC/xr9XEf5By3x77cDucWWB3pJK6FEwXZCTCbb4z8xdaOoi4owBNrvn3ciDdxA==",
       "requires": {
-        "nan": "^2.10.0",
-        "node-pre-gyp": "^0.11.0"
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.13.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2351,10 +2351,10 @@
           "bundled": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
@@ -2395,7 +2395,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2471,7 +2471,7 @@
           }
         },
         "minizlib": {
-          "version": "1.1.1",
+          "version": "1.2.1",
           "bundled": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2485,26 +2485,20 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true
         },
         "needle": {
-          "version": "2.2.4",
+          "version": "2.3.1",
           "bundled": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
-          },
-          "dependencies": {
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            }
           }
         },
         "node-pre-gyp": {
-          "version": "0.11.0",
+          "version": "0.13.0",
           "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -2528,11 +2522,11 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.1.12",
+          "version": "1.4.1",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -2618,10 +2612,10 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
@@ -2632,8 +2626,12 @@
           "version": "2.1.2",
           "bundled": true
         },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.0",
           "bundled": true
         },
         "set-blocking": {
@@ -2672,13 +2670,13 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.6",
+          "version": "4.4.8",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
@@ -2700,7 +2698,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,9 +165,9 @@
       }
     },
     "@carto/cartonik": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@carto/cartonik/-/cartonik-0.8.0.tgz",
-      "integrity": "sha512-avB1IyTxy04lN2lyyUdQPhCPRHTH4IcauhUOVFlhLOrQhxbkfrf/VXdE8dJsdlI4w6U1pTiHpiq++5+yZr2gyQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@carto/cartonik/-/cartonik-0.9.1.tgz",
+      "integrity": "sha512-AyAakGhDrOzBdViaEoGhJHc3/rCsTas6nG2i0qYZdDWaiAJb/P9ArkXTmAZmXwlushBEYXa7IdfA6yE+j9jx1Q==",
       "requires": {
         "@carto/mapnik": "3.6.2-carto.16",
         "@mapbox/sphericalmercator": "^1.1.0",
@@ -181,9 +181,9 @@
           "integrity": "sha512-ug6DAZoNgWm6q5KhPFA+hzXfBLFQu5sTXxPpv44DmE0A2g+CiHoq9LTVdkXpZMkYVMoGw83F6W+WT0h0MFMK/w=="
         },
         "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
+          "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w=="
         }
       }
     },
@@ -390,6 +390,11 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
       "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
+    },
+    "adm-zip": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
+      "integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
     },
     "agent-base": {
       "version": "6.0.0",
@@ -608,14 +613,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -824,12 +821,12 @@
       }
     },
     "cartodb-redis": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-2.1.0.tgz",
-      "integrity": "sha512-VT9SWWad5eyLkDZKO7W6jjPuboJB3mZSf29WTJqLVRVh9IYzwgGBfpXFBtXaRfVTaNMg/TplBL1+qffMsQtUfA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-3.0.0.tgz",
+      "integrity": "sha512-LVEfvGuBrMOmcDFNYRA0oKK+X9+bCrXW9ge2qtxjkli9TG/fCBI2KDxcgwSCdbACPjtQNKGf8C0lsgzYFSZvOQ==",
       "requires": {
         "dot": "~1.0.2",
-        "redis-mpool": "0.7.0",
+        "redis-mpool": "^0.8.0",
         "underscore": "~1.6.0"
       },
       "dependencies": {
@@ -1158,6 +1155,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1196,7 +1198,8 @@
     "double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
+      "dev": true
     },
     "dtrace-provider": {
       "version": "0.6.0",
@@ -2029,11 +2032,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -2716,425 +2714,6 @@
         "json-bigint": "^0.3.0"
       }
     },
-    "gdal": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/gdal/-/gdal-0.9.9.tgz",
-      "integrity": "sha512-YlFal25vTaN/tdLg8Irz0pxP+sTY69F0IIdD3fnkjcNaOnM04CoT2aMYUurdDByIVXnAWRHaFYcsxVQMVWptxg==",
-      "requires": {
-        "nan": "~2.10.0",
-        "node-pre-gyp": "^0.13.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "bundled": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "fs-minipass": {
-          "version": "1.2.6",
-          "bundled": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.4",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-        },
-        "needle": {
-          "version": "2.4.0",
-          "bundled": true,
-          "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.13.0",
-          "bundled": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "npm-packlist": {
-          "version": "1.4.4",
-          "bundled": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "bundled": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "tar": {
-          "version": "4.4.10",
-          "bundled": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.5",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true
-        }
-      }
-    },
     "generic-pool": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
@@ -3265,14 +2844,14 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "grainstore": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/grainstore/-/grainstore-2.0.1.tgz",
-      "integrity": "sha512-a7olYowSF+kSvh3Qqa7RXg5v7kpev8MrYtqVxpF9I0PftSBLVLL0SddEmN3ylRjkSlBLnuS7bZHFiYg5SGx95Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/grainstore/-/grainstore-3.0.0.tgz",
+      "integrity": "sha512-2PS+266ue5zuCxBxAMkZ76z2J0MYIqqMZfhS1630I4fuylbBAZGFScc583+2ufUc/nJhHaltiV058UiI0PiO4w==",
       "requires": {
         "carto": "0.16.3",
         "debug": "~3.1.0",
         "generic-pool": "~2.2.0",
-        "millstone": "github:cartodb/millstone#v0.6.17-carto.3",
+        "millstone": "github:cartodb/millstone#v0.6.17-carto.4",
         "postcss": "~5.2.8",
         "postcss-scss": "0.4.0",
         "postcss-strip-inline-comments": "0.1.5",
@@ -3465,15 +3044,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "hiredis": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.5.0.tgz",
-      "integrity": "sha1-2wOpi+zXAD0TwmAEOs7s+s31m4c=",
-      "requires": {
-        "bindings": "^1.2.1",
-        "nan": "^2.3.4"
-      }
     },
     "hosted-git-info": {
       "version": "2.8.5",
@@ -4241,18 +3811,17 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "millstone": {
-      "version": "github:cartodb/millstone#eeeb308fba4586343bb848fbf8ae0d180192627d",
-      "from": "github:cartodb/millstone#v0.6.17-carto.3",
+      "version": "github:cartodb/millstone#01b9f031afef48d380031c6783c7cb56d0d4a068",
+      "from": "github:cartodb/millstone#v0.6.17-carto.4",
       "requires": {
+        "adm-zip": "^0.4.14",
         "generic-pool": "~2.4.1",
         "mime": "~2.3.1",
         "mkdirp": "~0.5.0",
         "optimist": "0.6.1",
         "request": "2.x",
-        "srs": "^1.2.0",
         "step": "~1.0.0",
-        "underscore": "~1.9.1",
-        "zipfile": "~0.5.11"
+        "underscore": "~1.9.1"
       },
       "dependencies": {
         "mime": {
@@ -5399,6 +4968,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "dev": true,
       "requires": {
         "double-ended-queue": "^2.1.0-0",
         "redis-commands": "^1.2.0",
@@ -5410,28 +4980,51 @@
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
       "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
     },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
     "redis-mpool": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.7.0.tgz",
-      "integrity": "sha512-+Tk3LXK5YkmseZjsz6Bx6/uRHy0CBGVvl6GU5tlzugYRn1qArlxK9wSEhadIfWh96Qx9yngvtacb7g8GNi78rA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.8.0.tgz",
+      "integrity": "sha512-isydmGG506LarypB0sNn90ubG9asTpHdvTxSUVK6aj9BJlrqzCqNAclVpmObi3qh8Hd81f+wsHZQIsAqiD4R8g==",
       "requires": {
-        "generic-pool": "~2.1.1",
-        "hiredis": "~0.5.0",
-        "redis": "^2.8.0",
-        "underscore": "~1.6.0"
+        "generic-pool": "^3.7.1",
+        "redis": "^3.0.2"
       },
       "dependencies": {
         "generic-pool": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz",
-          "integrity": "sha1-rwTcLDJc/Ll1Aj+lK/zpYXp0Nf0="
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.7.1.tgz",
+          "integrity": "sha512-ug6DAZoNgWm6q5KhPFA+hzXfBLFQu5sTXxPpv44DmE0A2g+CiHoq9LTVdkXpZMkYVMoGw83F6W+WT0h0MFMK/w=="
+        },
+        "redis": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
+          "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
+          "requires": {
+            "denque": "^1.4.1",
+            "redis-commands": "^1.5.0",
+            "redis-errors": "^1.2.0",
+            "redis-parser": "^3.0.0"
+          }
+        },
+        "redis-parser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+          "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+          "requires": {
+            "redis-errors": "^1.0.0"
+          }
         }
       }
     },
     "redis-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
+      "dev": true
     },
     "regexpp": {
       "version": "2.0.1",
@@ -5807,14 +5400,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "srs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/srs/-/srs-1.2.0.tgz",
-      "integrity": "sha1-7LRHhU33bOsStFKQMr4j6eGO7Nw=",
-      "requires": {
-        "gdal": "~0.9.2"
-      }
     },
     "sshpk": {
       "version": "1.16.1",
@@ -6465,19 +6050,19 @@
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
     },
     "windshaft": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-6.0.0.tgz",
-      "integrity": "sha512-7GnPRZsJuHEnwC/Yp+QvMIyK/EhLqABs2RNz0iQsShqS5gdsxHCIp+koG2r31ujrl4T8JDFCT5Y2Q4yQC70EaA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-7.0.0.tgz",
+      "integrity": "sha512-YBjbnflMWPUcFOH0fPn6vmfhmeFnded3iqW+h5qsxUGgmn1tXjhLsh9tLBu1EkJspsdAbamP9PdEhbJJUB6iJw==",
       "requires": {
-        "@carto/cartonik": "^0.8.0",
+        "@carto/cartonik": "^0.9.1",
         "@carto/mapnik": "3.6.2-carto.16",
         "canvas": "^2.4.1",
         "carto": "github:cartodb/carto#0.15.1-cdb5",
         "cartodb-psql": "^0.14.0",
         "cartodb-query-tables": "^0.6.1",
         "debug": "3.1.0",
-        "grainstore": "^2.0.1",
-        "redis-mpool": "0.7.0",
+        "grainstore": "^3.0.0",
+        "redis-mpool": "^0.8.0",
         "request": "2.87.0",
         "semver": "5.5.0",
         "torque.js": "3.1.1"
@@ -6648,60 +6233,6 @@
       "requires": {
         "camelcase": "^3.0.0",
         "lodash.assign": "^4.0.6"
-      }
-    },
-    "zipfile": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/zipfile/-/zipfile-0.5.12.tgz",
-      "integrity": "sha512-zA60gW+XgQBu/Q4qV3BCXNIDRald6Xi5UOPj3jWGlnkjmBHaKDwIz7kyXWV3kq7VEsQN/2t/IWjdXdKeVNm6Eg==",
-      "requires": {
-        "nan": "~2.10.0",
-        "node-pre-gyp": "~0.10.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-        },
-        "node-pre-gyp": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
-          "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "camshaft": "^0.65.3",
     "cartodb-psql": "0.14.0",
     "cartodb-query-tables": "^0.7.0",
-    "cartodb-redis": "2.1.0",
+    "cartodb-redis": "^3.0.0",
     "debug": "3.1.0",
     "dot": "1.1.2",
     "express": "4.16.3",
@@ -54,13 +54,13 @@
     "node-statsd": "0.1.1",
     "on-headers": "1.0.1",
     "queue-async": "1.1.0",
-    "redis-mpool": "0.7.0",
+    "redis-mpool": "^0.8.0",
     "request": "2.87.0",
     "semver": "5.5.0",
     "step-profiler": "0.3.0",
     "turbo-carto": "0.21.2",
     "underscore": "1.6.0",
-    "windshaft": "^6.0.0",
+    "windshaft": "^7.0.0",
     "yargs": "11.1.0"
   },
   "devDependencies": {
@@ -94,7 +94,7 @@
     "docker:bash": "docker run -it -v `pwd`:/srv $DOCKER_IMAGE bash"
   },
   "engines": {
-    "node": "^10.15.1",
-    "npm": "^6.4.1"
+    "node": "^12.16.3",
+    "npm": "^6.14.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "dot": "1.1.2",
     "express": "4.16.3",
     "fastly-purge": "1.0.1",
-    "gc-stats": "1.2.1",
+    "gc-stats": "^1.4.0",
     "glob": "7.1.2",
     "log4js": "github:cartodb/log4js-node#cdb",
     "lru-cache": "4.1.3",

--- a/test/acceptance/cluster-test.js
+++ b/test/acceptance/cluster-test.js
@@ -16,6 +16,7 @@ const POINTS_SQL_1 = `
             ELSE 'odd'
         END AS type
     from generate_series(-3, 3) x
+    order by cartodb_id asc
 `;
 
 const defaultLayers = [{
@@ -62,14 +63,14 @@ describe('cluster', function () {
                 }
 
                 assert.deepStrictEqual(body, {
-                    errors: ['Map f697fb370c6479559ae2f66d684e8227 has no aggregation defined for layer 0'],
+                    errors: ['Map f105928729b4d3f67ae3578a163778c9 has no aggregation defined for layer 0'],
                     errors_with_context: [
                         {
                             layer: {
                                 index: '0',
                                 type: 'cartodb'
                             },
-                            message: 'Map f697fb370c6479559ae2f66d684e8227 has no aggregation defined for layer 0',
+                            message: 'Map f105928729b4d3f67ae3578a163778c9 has no aggregation defined for layer 0',
                             subtype: 'aggregation',
                             type: 'layer'
                         }
@@ -104,14 +105,14 @@ describe('cluster', function () {
                 }
 
                 assert.deepStrictEqual(body, {
-                    errors: ['Map 7521bcd1029c401289dd651ce91d5d9d has no aggregation defined for layer 0'],
+                    errors: ['Map 9d19316644f831332b44de7b3158aa77 has no aggregation defined for layer 0'],
                     errors_with_context: [
                         {
                             layer: {
                                 index: '0',
                                 type: 'cartodb'
                             },
-                            message: 'Map 7521bcd1029c401289dd651ce91d5d9d has no aggregation defined for layer 0',
+                            message: 'Map 9d19316644f831332b44de7b3158aa77 has no aggregation defined for layer 0',
                             subtype: 'aggregation',
                             type: 'layer'
                         }

--- a/test/acceptance/ported/torque-boundaries-test.js
+++ b/test/acceptance/ported/torque-boundaries-test.js
@@ -269,13 +269,7 @@ describe('torque boundary points', function () {
                     var parsed = JSON.parse(res.body);
                     /* Order the JSON first by descending x__uint8 and ascending
                      * y__uint8 */
-                    parsed.sort(function (a, b) {
-                        if (a.x__uint8 === b.x__uint8) {
-                            return (a.y__uint8 > b.y__uint8);
-                        }
-                        return (a.x__uint8 < b.x__uint8);
-                    });
-
+                    parsed.sort((a, b) => a.x__uint8 - b.x__uint8 === 0 ? a.y__uint8 - b.y__uint8 : b.x__uint8 - a.x__uint8);
                     var i = 0;
                     tileRequest.expects.forEach(function (expected) {
                         assert.strictEqual(
@@ -451,18 +445,18 @@ describe('torque boundary points', function () {
                 assert.ok(!err, 'Failed to request torque.json');
 
                 var parsed = JSON.parse(res.body);
-
-                assert.deepStrictEqual(parsed.sort(function (a, b) { return a.x__uint8 > b.x__uint8; }), [
-                    {
-                        x__uint8: 47,
-                        y__uint8: 127,
-                        vals__uint8: [2],
-                        dates__uint16: [0]
-                    },
+                parsed.sort((a, b) => a.x__uint8 - b.x__uint8 === 0 ? a.y__uint8 - b.y__uint8 : b.x__uint8 - a.x__uint8);
+                assert.deepStrictEqual(parsed, [
                     {
                         x__uint8: 48,
                         y__uint8: 127,
                         vals__uint8: [1],
+                        dates__uint16: [0]
+                    },
+                    {
+                        x__uint8: 47,
+                        y__uint8: 127,
+                        vals__uint8: [2],
                         dates__uint16: [0]
                     }
                 ]);

--- a/test/acceptance/ported/torque-test.js
+++ b/test/acceptance/ported/torque-test.js
@@ -69,7 +69,7 @@ describe('torque', function () {
                 assert.ok(parsed.errors, parsed);
                 var error = parsed.errors[0];
                 assert.strictEqual(error,
-                    "Missing required property '-torque-frame-count' in torque layer CartoCSS");
+                    "TorqueRenderer: Missing required property '-torque-frame-count' in torque layer CartoCSS");
                 return null;
             },
             function doPost2 (err) {
@@ -91,7 +91,7 @@ describe('torque', function () {
                 assert.ok(parsed.errors, parsed);
                 var error = parsed.errors[0];
                 assert.strictEqual(error,
-                    "Missing required property '-torque-resolution' in torque layer CartoCSS");
+                    "TorqueRenderer: Missing required property '-torque-resolution' in torque layer CartoCSS");
                 return null;
             },
             function doPost3 (err) {
@@ -113,7 +113,7 @@ describe('torque', function () {
                 assert.ok(parsed.errors, parsed);
                 var error = parsed.errors[0];
                 assert.strictEqual(error,
-                    "Missing required property '-torque-aggregation-function' in torque layer CartoCSS");
+                    "TorqueRenderer: Missing required property '-torque-aggregation-function' in torque layer CartoCSS");
                 return null;
             },
             function finish (err) {
@@ -447,7 +447,7 @@ describe('torque', function () {
                 assert.ok(parsed.errors, parsed);
                 var error = parsed.errors[0];
                 assert.strictEqual(error,
-                    "Unexpected type for property '-torque-aggregation-function', expected string");
+                    "TorqueRenderer: Unexpected type for property '-torque-aggregation-function', expected string");
                 done();
                 return null;
             }


### PR DESCRIPTION
- Drop support for Node.js < 12
- Support Node.js 12
- Upgrade `windshaft` to version `7.0.0`
- Upgrade `cartodb-redis` to version `3.0.0`