### PR TITLE
Layergroup Id should have cache buster defined always

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.0.1
+Released 2020-mm-dd
+
+Bug Fixes:
+- While instantiating a map, set the `cache buster` equal to `0` when there are no affected tables in the MapConfig. Thus `layergroupid` has the same structure always:
+  - `${map_id}:${cache_buster}` for anonymous map
+  - `${user}@${template_hash}@${map_id}:${cache_buster}` for named map
+
 ## 9.0.0
 Released 2020-06-05
 

--- a/lib/api/middlewares/last-updated-time-layergroup.js
+++ b/lib/api/middlewares/last-updated-time-layergroup.js
@@ -11,6 +11,10 @@ module.exports = function setLastUpdatedTimeToLayergroup () {
             }
 
             if (!affectedTables) {
+                res.locals.cache_buster = 0;
+                layergroup.layergroupid = `${layergroup.layergroupid}:${res.locals.cache_buster}`;
+                layergroup.last_updated = new Date(res.locals.cache_buster).toISOString();
+
                 return next();
             }
 

--- a/test/acceptance/layergroupid-test.js
+++ b/test/acceptance/layergroupid-test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+require('../support/test-helper');
+
+const assert = require('../support/assert');
+const TestClient = require('../support/test-client');
+const { parse: parseLayergroupToken } = require('../../lib/models/layergroup-token');
+
+describe('layergroup id', function () {
+    const suites = [
+        {
+            description: 'with empty layers should respond with cache buster equal to 0',
+            expectedCacheBuster: '0',
+            mapConfig: {
+                version: '1.8.0',
+                layers: []
+            }
+        },
+        {
+            description: 'with layer and dumb query (no affected tables) should respond with cache buster equal to 0',
+            expectedCacheBuster: '0',
+            mapConfig: {
+                version: '1.8.0',
+                layers: [{
+                    type: 'cartodb',
+                    options: {
+                        sql: TestClient.SQL.ONE_POINT
+                    }
+                }]
+            }
+        },
+        {
+            description: 'with layer and legit query should respond with cache buster',
+            expectedCacheBuster: '1234567890123',
+            mapConfig: {
+                version: '1.8.0',
+                layers: [{
+                    type: 'cartodb',
+                    options: {
+                        sql: 'SELECT * FROM test_table'
+                    }
+                }]
+            }
+        }
+    ];
+
+    suites.forEach(({ description, expectedCacheBuster, mapConfig }) => {
+        it(description, function (done) {
+            const testClient = new TestClient(mapConfig);
+
+            testClient.getLayergroup((err, body) => {
+                if (err) {
+                    return done(err);
+                }
+
+                const { layergroupid } = body;
+                assert.ok(typeof layergroupid === 'string');
+
+                const { cacheBuster } = parseLayergroupToken(layergroupid);
+                assert.strictEqual(cacheBuster, expectedCacheBuster);
+
+                testClient.drain(done);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Set a cache buster equal to `0` when there are no affected tables in the MapConfig. Thus `layergroupid` would have the same structure always:
  - `${map_id}:${cache_buster}` for anonymous map
  - `${user}@${template_hash}@${map_id}:${cache_buster}` for named map

Needed to facilitate parsings in other places in our platform (metrics, logs, etc..)

cc @ilbambino 