### PR TITLE
fix: resolution divided twice

### DIFF
--- a/lib/backends/cluster.js
+++ b/lib/backends/cluster.js
@@ -161,7 +161,7 @@ const clusterFeaturesQuery = ctx => `
 
 const gridResolution = ctx => {
     const zoomResolution = webmercator.getResolution({ z: Math.min(38, ctx.zoom) });
-    return `${256 / ctx.res} * (${zoomResolution})::double precision`;
+    return `${ctx.res} * (${zoomResolution})::double precision`;
 };
 
 const aggregationQuery = ctx => `

--- a/lib/models/aggregation/aggregation-query.js
+++ b/lib/models/aggregation/aggregation-query.js
@@ -274,7 +274,7 @@ const havingClause = ctx => {
 // OGC's Styled Layer Descriptor Implementation Specification
 const gridResolution = ctx => {
     const minimumResolution = webmercator.getResolution({ z: 38 });
-    return `${256 / ctx.res} * GREATEST(!scale_denominator! * 0.00028, ${minimumResolution})::double precision`;
+    return `${ctx.res} * GREATEST(!scale_denominator! * 0.00028, ${minimumResolution})::double precision`;
 };
 
 // SQL query to extract the boundaries of the area to be aggregated and the grid resolution


### PR DESCRIPTION
It seems that these changes fix this:

https://app.clubhouse.io/cartoteam/story/79686/aquas-gencat-admin-cartoframes-map-resolution-rendering-issue#activity-87190
