### PR TITLE
Fix logger error serializer when the exception stack is not set

### DIFF
--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -9,7 +9,7 @@ module.exports = class Logger {
         const { LOG_LEVEL, NODE_ENV } = process.env;
         const logLevelFromNodeEnv = NODE_ENV === 'test' ? 'fatal' : 'info';
         const errorSerializer = DEV_ENVS.includes(NODE_ENV) ? err : wrapErrorSerializer(err => {
-            if (err.hasOwnProperty('stack')) {
+            if (Object.prototype.hasOwnProperty.call(err, 'stack')) {
                 err.stack = err.stack.split('\n').slice(0, 3).join('\n');
             }
             return err;

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -9,7 +9,9 @@ module.exports = class Logger {
         const { LOG_LEVEL, NODE_ENV } = process.env;
         const logLevelFromNodeEnv = NODE_ENV === 'test' ? 'fatal' : 'info';
         const errorSerializer = DEV_ENVS.includes(NODE_ENV) ? err : wrapErrorSerializer(err => {
-            err.stack = err.stack.split('\n').slice(0, 3).join('\n');
+            if (err.hasOwnProperty('stack')) {
+                err.stack = err.stack.split('\n').slice(0, 3).join('\n');
+            }
             return err;
         });
         const options = {


### PR DESCRIPTION
Related RT story: https://app.clubhouse.io/cartoteam/story/101625/node-windshaft-exiting-because-of-typeerror-cannot-read-property-split-exception