### PR TITLE
[ch89482] Update 'camshaft' to version 0.67.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ Released 2020-mm-dd
 Breaking changes:
 - Log system revamp:
   - Logs to stdout, disabled while testing
-  - Upgrade `camshaft` to version [`0.67.1`](https://github.com/CartoDB/camshaft/releases/tag/0.67.1)
+  - Upgrade `camshaft` to version [`0.67.2`](https://github.com/CartoDB/camshaft/releases/tag/0.67.2)
   - Use header `X-Request-Id`, or create a new `uuid` when no present, to identyfy log entries
   - Be able to set log level from env variable `LOG_LEVEL`, useful while testing: `LOG_LEVEL=info npm test`; even more human-readable: `LOG_LEVEL=info npm t | ./node_modules/.bin/pino-pretty`
   - Stop responding with `X-Tiler-Errors` header. Now errors are properly logged and will end up in ELK as usual.

--- a/package-lock.json
+++ b/package-lock.json
@@ -814,9 +814,9 @@
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
     },
     "camshaft": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/camshaft/-/camshaft-0.67.1.tgz",
-      "integrity": "sha512-2fDiAP3cztN+6xUeEei/nkq1jvwbXrPTIG5zzbMDcEtEpjMnQjfXtM+l90yj1aNpx8qfTXW5r5X4KSnvUqc/6w==",
+      "version": "0.67.2",
+      "resolved": "https://registry.npmjs.org/camshaft/-/camshaft-0.67.2.tgz",
+      "integrity": "sha512-egTmL1IYsDe0UeGMQ5VyJVo7SNbxpwnTgxzORSYEuRdZWJ1h1saV7ykSPOkxMLipj4GWKHxiBTBCqa26tkfMpg==",
       "requires": {
         "async": "^1.5.2",
         "cartodb-psql": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "assign-deep": "^1.0.1",
     "basic-auth": "2.0.0",
     "body-parser": "1.18.3",
-    "camshaft": "^0.67.1",
+    "camshaft": "^0.67.2",
     "cartodb-psql": "0.14.0",
     "cartodb-query-tables": "^0.7.0",
     "cartodb-redis": "^3.0.0",


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/89482/mr-jeff-if-a-column-name-has-an-uppercase-it-throws-an-error-when-run-add-column-from-second-dataset)
- ['camshaft' PR](https://github.com/CartoDB/camshaft/pull/409)

### Changes

- Update 'camshaft' to version 0.67.2