### PR TITLE
Unify env vars for docker-dev-env

### DIFF
--- a/test/acceptance/templates-test.js
+++ b/test/acceptance/templates-test.js
@@ -13,7 +13,7 @@ var redisStatsDb = 5;
 // configuration settings are always enforced
 // See https://github.com/CartoDB/Windshaft-cartodb/issues/174
 process.env.PGPORT = '666';
-process.env.PGHOST = 'fake';
+process.env.CARTO_POSTGRES_HOST = 'fake';
 
 var path = require('path');
 var fs = require('fs');


### PR DESCRIPTION
The ENV var `PGHOST` is renamed to `CARTO_POSTGRES_HOST` in order to follow the pattern 
 `CARO_{{PROJECT}}_{{VAR_NAME}}` as part of the proccess of unification ENV VARS. 

More info: https://app.clubhouse.io/cartoteam/story/123423/unify-env-vars