### PR TITLE
Replace analysis static config per ENV vars

### DIFF
--- a/config/environments/config.js
+++ b/config/environments/config.js
@@ -253,7 +253,7 @@ var config = {
             //  - running an standalone server without any dependency on external services
             inlineExecution: false,
             // where the SQL API is running, it will use a custom Host header to specify the username.
-            endpoint: 'http://127.0.0.1:8080/api/v2/sql/job',
+            endpoint: 'http://' + process.env.CARTO_WINDSHAFT_ANALYSIS_HOST + ':' + process.env.CARTO_WINDSHAFT_ANALYSIS_PORT + '/api/v2/sql/job',
             // the template to use for adding the host header in the batch api requests
             hostHeaderTemplate: '{{=it.username}}.localhost.lan'
         },


### PR DESCRIPTION
The analysis host now uses env vars instead of static config. This fixes both builder analysis and batch API requests in local environment