### PR TITLE
Overwrite layergroup TTL for cache-control header 

### DIFF
--- a/lib/api/map/anonymous-map-controller.js
+++ b/lib/api/map/anonymous-map-controller.js
@@ -114,7 +114,7 @@ module.exports = class AnonymousMapController {
             incrementMapViewCount(this.metadataBackend),
             augmentLayergroupData(),
             lastUpdatedTimeLayergroup(),
-            cacheControlHeader({ ttl: global.environment.varnish.layergroupTtl, revalidate: true }),
+            cacheControlHeader({ ttl: global.environment.varnish.layergroupTtl, revalidate: true, overwriteWithTTLAlways: true }),
             cacheChannelHeader(),
             surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
             lastModifiedHeader(),

--- a/lib/api/middlewares/cache-control-header.js
+++ b/lib/api/middlewares/cache-control-header.js
@@ -24,7 +24,8 @@ const validFallbackTTL = [
 module.exports = function setCacheControlHeader ({
     ttl = ONE_YEAR_IN_SECONDS,
     fallbackTtl = FALLBACK_TTL,
-    revalidate = false
+    revalidate = false,
+    overwriteWithTTLAlways = false
 } = {}) {
     if (!validFallbackTTL.includes(fallbackTtl)) {
         const message = [
@@ -50,7 +51,7 @@ module.exports = function setCacheControlHeader ({
 
             const directives = ['public'];
 
-            if (everyAffectedTableCanBeInvalidated(affectedTables)) {
+            if (everyAffectedTableCanBeInvalidated(affectedTables) || overwriteWithTTLAlways) {
                 directives.push(`max-age=${ttl}`);
             } else {
                 directives.push(`max-age=${computeNextTTL({ ttlInSeconds: fallbackTtl })}`);

--- a/lib/api/template/named-template-controller.js
+++ b/lib/api/template/named-template-controller.js
@@ -119,7 +119,7 @@ module.exports = class NamedMapController {
             incrementMapViewCount(this.metadataBackend),
             augmentLayergroupData(),
             lastUpdatedTimeLayergroup(),
-            cacheControlHeader({ ttl: global.environment.varnish.layergroupTtl, revalidate: true }),
+            cacheControlHeader({ ttl: global.environment.varnish.layergroupTtl, revalidate: true, overwriteWithTTLAlways: true }),
             cacheChannelHeader(),
             surrogateKeyHeader({ surrogateKeysCache: this.surrogateKeysCache }),
             lastModifiedHeader(),


### PR DESCRIPTION
- Overwrite layergroup TTL for the cache-control header even while using non-cartodbfied tables