### PR TITLE
Add notification when user is reaching named maps limit

### DIFF
--- a/lib/api/template/admin-template-controller.js
+++ b/lib/api/template/admin-template-controller.js
@@ -142,14 +142,14 @@ function createTemplate ({ templateMaps }) {
             res.statusCode = 200;
             res.body = { template_id: templateId };
 
-            if(limitMessage) {
-                res.body['limit_message'] = limitMessage;
+            if (limitMessage) {
+                res.body.limit_message = limitMessage;
             }
 
             next();
         });
     };
-} 
+}
 
 function updateTemplate ({ templateMaps }) {
     return function updateTemplateMiddleware (req, res, next) {

--- a/lib/api/template/admin-template-controller.js
+++ b/lib/api/template/admin-template-controller.js
@@ -134,7 +134,7 @@ function createTemplate ({ templateMaps }) {
         const { user } = res.locals;
         const template = req.body;
 
-        templateMaps.addTemplate(user, template, (err, templateId) => {
+        templateMaps.addTemplate(user, template, (err, templateId, _, limitMessage) => {
             if (err) {
                 return next(err);
             }
@@ -142,10 +142,14 @@ function createTemplate ({ templateMaps }) {
             res.statusCode = 200;
             res.body = { template_id: templateId };
 
+            if(limitMessage) {
+                res.body['limit_message'] = limitMessage;
+            }
+
             next();
         });
     };
-}
+} 
 
 function updateTemplate ({ templateMaps }) {
     return function updateTemplateMiddleware (req, res, next) {

--- a/lib/backends/template-maps.js
+++ b/lib/backends/template-maps.js
@@ -207,8 +207,7 @@ TemplateMaps.prototype._checkUserTemplatesLimit = function (userTemplatesKey, ow
  * @param callback returns error if the user reaches the limit
  */
 TemplateMaps.prototype._checkUserTemplatesNearLimit = function (userTemplatesKey, owner, callback) {
-    // const limit = this._userTemplateLimit();
-    const limit = 1;
+    const limit = this._userTemplateLimit();
 
     if (!limit) {
         return callback();

--- a/lib/backends/template-maps.js
+++ b/lib/backends/template-maps.js
@@ -117,18 +117,18 @@ TemplateMaps.prototype._checkInvalidTemplate = function (template) {
     var auth = template.auth || {};
 
     switch (auth.method) {
-        case 'open':
-            break;
-        case 'token':
-            if (!_.isArray(auth.valid_tokens)) {
-                return new Error("Invalid 'token' authentication: missing valid_tokens");
-            }
-            if (!auth.valid_tokens.length) {
-                return new Error("Invalid 'token' authentication: no valid_tokens");
-            }
-            break;
-        default:
-            return new Error('Unsupported authentication method: ' + auth.method);
+    case 'open':
+        break;
+    case 'token':
+        if (!_.isArray(auth.valid_tokens)) {
+            return new Error("Invalid 'token' authentication: missing valid_tokens");
+        }
+        if (!auth.valid_tokens.length) {
+            return new Error("Invalid 'token' authentication: no valid_tokens");
+        }
+        break;
+    default:
+        return new Error('Unsupported authentication method: ' + auth.method);
     }
 
     return false;
@@ -218,7 +218,7 @@ TemplateMaps.prototype._checkUserTemplatesNearLimit = function (userTemplatesKey
             return callback(err);
         }
 
-        if (numberOfTemplates >= limit - 20) {
+        if (numberOfTemplates >= limit - 100) {
             return callback(null, `User ${owner} reaching the named maps limit`);
         }
 
@@ -284,7 +284,7 @@ TemplateMaps.prototype.addTemplate = function (owner, template, callback) {
                 }
 
                 return callback(null, template.name, template);
-            })
+            });
         });
     });
 };

--- a/lib/backends/template-maps.js
+++ b/lib/backends/template-maps.js
@@ -208,6 +208,7 @@ TemplateMaps.prototype._checkUserTemplatesLimit = function (userTemplatesKey, ow
  */
 TemplateMaps.prototype._checkUserTemplatesNearLimit = function (userTemplatesKey, owner, callback) {
     const limit = this._userTemplateLimit();
+    const NAMED_MAPS_UNTIL_LIMIT = 100;
 
     if (!limit) {
         return callback();
@@ -218,7 +219,7 @@ TemplateMaps.prototype._checkUserTemplatesNearLimit = function (userTemplatesKey
             return callback(err);
         }
 
-        if (numberOfTemplates >= limit - 100) {
+        if (numberOfTemplates >= limit - NAMED_MAPS_UNTIL_LIMIT) {
             return callback(null, `User ${owner} reaching the named maps limit`);
         }
 

--- a/lib/backends/template-maps.js
+++ b/lib/backends/template-maps.js
@@ -117,18 +117,18 @@ TemplateMaps.prototype._checkInvalidTemplate = function (template) {
     var auth = template.auth || {};
 
     switch (auth.method) {
-    case 'open':
-        break;
-    case 'token':
-        if (!_.isArray(auth.valid_tokens)) {
-            return new Error("Invalid 'token' authentication: missing valid_tokens");
-        }
-        if (!auth.valid_tokens.length) {
-            return new Error("Invalid 'token' authentication: no valid_tokens");
-        }
-        break;
-    default:
-        return new Error('Unsupported authentication method: ' + auth.method);
+        case 'open':
+            break;
+        case 'token':
+            if (!_.isArray(auth.valid_tokens)) {
+                return new Error("Invalid 'token' authentication: missing valid_tokens");
+            }
+            if (!auth.valid_tokens.length) {
+                return new Error("Invalid 'token' authentication: no valid_tokens");
+            }
+            break;
+        default:
+            return new Error('Unsupported authentication method: ' + auth.method);
     }
 
     return false;
@@ -170,7 +170,7 @@ function templateDefaults (template) {
 }
 
 /**
- * Checks if the if the user reaches the templetes limit
+ * Checks if the if the user reaches the templates limit
  *
  * @param userTemplatesKey user templat key in Redis
  * @param owner cartodb username of the template owner
@@ -194,6 +194,33 @@ TemplateMaps.prototype._checkUserTemplatesLimit = function (userTemplatesKey, ow
             );
             limitReachedError.http_status = 409;
             return callback(limitReachedError);
+        }
+        return callback();
+    });
+};
+
+/**
+ * Checks if the if the user reaches the templetes limit
+ *
+ * @param userTemplatesKey user templat key in Redis
+ * @param owner cartodb username of the template owner
+ * @param callback returns error if the user reaches the limit
+ */
+TemplateMaps.prototype._checkUserTemplatesNearLimit = function (userTemplatesKey, owner, callback) {
+    // const limit = this._userTemplateLimit();
+    const limit = 1;
+
+    if (!limit) {
+        return callback();
+    }
+
+    this._redisCmd('HLEN', [userTemplatesKey], (err, numberOfTemplates) => {
+        if (err) {
+            return callback(err);
+        }
+
+        if (numberOfTemplates >= limit - 20) {
+            return callback(null, `User ${owner} reaching the named maps limit`);
         }
 
         return callback();
@@ -247,7 +274,18 @@ TemplateMaps.prototype.addTemplate = function (owner, template, callback) {
             }
 
             this.emit('add', owner, template.name, template);
-            return callback(null, template.name, template);
+
+            this._checkUserTemplatesNearLimit(userTemplatesKey, owner, (err, message) => {
+                if (err) {
+                    return callback(err);
+                }
+
+                if (message) {
+                    return callback(null, template.name, template, message);
+                }
+
+                return callback(null, template.name, template);
+            })
         });
     });
 };
@@ -485,7 +523,7 @@ TemplateMaps.prototype.instance = function (template, params) {
         var lyropt = layergroup.layers[i].options;
 
         if (params.styles && params.styles[i]) {
-        // dynamic styling for this layer
+            // dynamic styling for this layer
             lyropt.cartocss = params.styles[i];
         } else if (lyropt.cartocss) {
             lyropt.cartocss = _replaceVars(lyropt.cartocss, allParams);
@@ -493,7 +531,7 @@ TemplateMaps.prototype.instance = function (template, params) {
         if (lyropt.sql) {
             lyropt.sql = _replaceVars(lyropt.sql, allParams);
         }
-    // Anything else ?
+        // Anything else ?
     }
 
     // extra information about the template


### PR DESCRIPTION
There are several users that have reached their named map limits, and we haven't been notified about that. I've added a check when creating a new named map to ensure that the user is not reaching the named maps limit.

If the user is near the limit, the API will send a response with a notification message.