### PR TITLE
[sc138209] Bump `camshaft` version to 0.67.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1015,8 +1015,9 @@
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
     },
     "camshaft": {
-      "version": "github:cartodb/camshaft#eefc37fcd8fe540a534ae60c370f32f94cd9d161",
-      "from": "github:cartodb/camshaft#feature/sc-138209/elmundodata-click-popup-not-showing-info",
+      "version": "0.67.4",
+      "resolved": "https://registry.npmjs.org/camshaft/-/camshaft-0.67.4.tgz",
+      "integrity": "sha512-zQjsasEOsbaq3Z8CN07AHbMp7R4rSETfsKv6Eomq3YXr6iruW1xRHmRoCzwh+bH0N5emIKRBr2wgtEMEcU7cvQ==",
       "requires": {
         "async": "^1.5.2",
         "cartodb-psql": "0.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1015,9 +1015,8 @@
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
     },
     "camshaft": {
-      "version": "0.67.3",
-      "resolved": "https://registry.npmjs.org/camshaft/-/camshaft-0.67.3.tgz",
-      "integrity": "sha512-RnciT+35jj/Ns+gZDK9ry2kxKE8FOQGd/R7M5u39+65n4w+ZOQy0mhG5r7LT6YCFBDxys2tzKTXCnYkZ0oP+UA==",
+      "version": "github:cartodb/camshaft#eefc37fcd8fe540a534ae60c370f32f94cd9d161",
+      "from": "github:cartodb/camshaft#feature/sc-138209/elmundodata-click-popup-not-showing-info",
       "requires": {
         "async": "^1.5.2",
         "cartodb-psql": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "assign-deep": "^1.0.1",
     "basic-auth": "2.0.0",
     "body-parser": "1.18.3",
-    "camshaft": "github:cartodb/camshaft#feature/sc-138209/elmundodata-click-popup-not-showing-info",
+    "camshaft": "^0.67.4",
     "cartodb-psql": "0.14.0",
     "cartodb-query-tables": "^0.7.0",
     "cartodb-redis": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "assign-deep": "^1.0.1",
     "basic-auth": "2.0.0",
     "body-parser": "1.18.3",
-    "camshaft": "^0.67.3",
+    "camshaft": "github:cartodb/camshaft#feature/sc-138209/elmundodata-click-popup-not-showing-info",
     "cartodb-psql": "0.14.0",
     "cartodb-query-tables": "^0.7.0",
     "cartodb-redis": "^3.0.0",


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/138209/elmundodata-click-popup-not-showing-info)
- ['camshaft' PR](https://github.com/CartoDB/camshaft/pull/416)

### Changes

- Update 'camshaft' to version 0.67.4