### PR TITLE
Avoid massive notifications about named maps limit

### DIFF
--- a/.cloudbuild/pr-tests-windshaft.yaml
+++ b/.cloudbuild/pr-tests-windshaft.yaml
@@ -271,7 +271,7 @@ steps:
           exit 1
         fi
 
-timeout: 1800s
+timeout: 2700s
 images:
     - ${_DOCKER_IMAGE_NAME}:${_BRANCH_TAG}--${SHORT_SHA} 
     - ${_DOCKER_IMAGE_NAME}:${_BRANCH_TAG} 

--- a/lib/backends/template-maps.js
+++ b/lib/backends/template-maps.js
@@ -231,7 +231,7 @@ TemplateMaps.prototype._checkUserTemplatesNearLimit = function (userTemplatesKey
 };
 
 TemplateMaps.prototype._handleUserNearTemplatesLimit = function (owner, callback) {
-    var userNearLimitNotificationKey = this.key_usr_near_limit_notification_tpl({owner})
+    var userNearLimitNotificationKey = this.key_usr_near_limit_notification_tpl({ owner });
 
     this._redisCmd('GET', [userNearLimitNotificationKey], (err, notification) => {
         if (err) {
@@ -245,31 +245,31 @@ TemplateMaps.prototype._handleUserNearTemplatesLimit = function (owner, callback
                 if (err) {
                     return callback(err);
                 }
-                return callback(null, `User ${owner} reaching the named maps limit`)
+                return callback(null, `User ${owner} reaching the named maps limit`);
             });
         }
 
         // Notification has already been sent in the past.
         // We check if it was sent more than one month ago to send it again
         if (notification) {
-            const lastNotificationSentDate = new Date(notification).getTime()
-            const lastMonthDate = new Date().getTime() - (30 * 24 * 60 * 60 * 1000) // actual date - 1 month in miliseconds
+            const lastNotificationSentDate = new Date(notification).getTime();
+            const lastMonthDate = new Date().getTime() - (30 * 24 * 60 * 60 * 1000); // actual date - 1 month in miliseconds
 
             if (lastMonthDate < lastNotificationSentDate) {
                 // Notification was sent recently, so we don't send it again
-                return callback()
+                return callback();
             } else {
                 // Send the notification again and update the last sent date
                 this._redisCmd('SET', [userNearLimitNotificationKey, new Date().toISOString()], (err) => {
                     if (err) {
                         return callback(err);
                     }
-                    return callback(null, `User ${owner} reaching the named maps limit`)
+                    return callback(null, `User ${owner} reaching the named maps limit`);
                 });
             }
         }
-    })
-}
+    });
+};
 
 // --------------- PUBLIC API -------------------------------------
 

--- a/lib/backends/template-maps.js
+++ b/lib/backends/template-maps.js
@@ -46,6 +46,9 @@ function TemplateMaps (redisPool, opts) {
 
     // User templates (HASH:tplId->tpl_val)
     this.key_usr_tpl = dot.template('map_tpl|{{=it.owner}}');
+
+    // User near limit last notification (HASH:username->last_notification)
+    this.key_usr_near_limit_notification_tpl = dot.template('map_tpl|last_near_limit_notification_sent|{{=it.owner}}');
 }
 
 util.inherits(TemplateMaps, EventEmitter);
@@ -220,12 +223,53 @@ TemplateMaps.prototype._checkUserTemplatesNearLimit = function (userTemplatesKey
         }
 
         if (numberOfTemplates >= limit - NAMED_MAPS_UNTIL_LIMIT) {
-            return callback(null, `User ${owner} reaching the named maps limit`);
+            return this._handleUserNearTemplatesLimit(owner, callback);
+        } else {
+            return callback();
         }
-
-        return callback();
     });
 };
+
+TemplateMaps.prototype._handleUserNearTemplatesLimit = function (owner, callback) {
+    var userNearLimitNotificationKey = this.key_usr_near_limit_notification_tpl({owner})
+
+    this._redisCmd('GET', [userNearLimitNotificationKey], (err, notification) => {
+        if (err) {
+            return callback(err);
+        }
+
+        // First time that notification is sent
+        // We store the actual date in Redis to check when we'll have to send it again
+        if (!notification) {
+            this._redisCmd('SET', [userNearLimitNotificationKey, new Date().toISOString()], (err) => {
+                if (err) {
+                    return callback(err);
+                }
+                return callback(null, `User ${owner} reaching the named maps limit`)
+            });
+        }
+
+        // Notification has already been sent in the past.
+        // We check if it was sent more than one month ago to send it again
+        if (notification) {
+            const lastNotificationSentDate = new Date(notification).getTime()
+            const lastMonthDate = new Date().getTime() - (30 * 24 * 60 * 60 * 1000) // actual date - 1 month in miliseconds
+
+            if (lastMonthDate < lastNotificationSentDate) {
+                // Notification was sent recently, so we don't send it again
+                return callback()
+            } else {
+                // Send the notification again and update the last sent date
+                this._redisCmd('SET', [userNearLimitNotificationKey, new Date().toISOString()], (err) => {
+                    if (err) {
+                        return callback(err);
+                    }
+                    return callback(null, `User ${owner} reaching the named maps limit`)
+                });
+            }
+        }
+    })
+}
 
 // --------------- PUBLIC API -------------------------------------
 


### PR DESCRIPTION
Last months we introduced a new notification when a user was reaching the named map limits.
With this change we're going to start saving in Redis the last date that we notified for a user about this limit to avoid sending massive notifications through email. If a notification has been sent in the last month, we'll omit the notification!